### PR TITLE
Fix MCP server compatibility with Claude Desktop

### DIFF
--- a/clicker/internal/mcp/schema.go
+++ b/clicker/internal/mcp/schema.go
@@ -15,6 +15,7 @@ func GetToolSchemas() []Tool {
 						"default":     false,
 					},
 				},
+				"additionalProperties": false,
 			},
 		},
 		{
@@ -28,7 +29,8 @@ func GetToolSchemas() []Tool {
 						"description": "The URL to navigate to",
 					},
 				},
-				"required": []string{"url"},
+				"required":             []string{"url"},
+				"additionalProperties": false,
 			},
 		},
 		{
@@ -42,7 +44,8 @@ func GetToolSchemas() []Tool {
 						"description": "CSS selector for the element to click",
 					},
 				},
-				"required": []string{"selector"},
+				"required":             []string{"selector"},
+				"additionalProperties": false,
 			},
 		},
 		{
@@ -60,7 +63,8 @@ func GetToolSchemas() []Tool {
 						"description": "The text to type",
 					},
 				},
-				"required": []string{"selector", "text"},
+				"required":             []string{"selector", "text"},
+				"additionalProperties": false,
 			},
 		},
 		{
@@ -74,6 +78,7 @@ func GetToolSchemas() []Tool {
 						"description": "Optional filename to save the screenshot (e.g., screenshot.png)",
 					},
 				},
+				"additionalProperties": false,
 			},
 		},
 		{
@@ -87,15 +92,17 @@ func GetToolSchemas() []Tool {
 						"description": "CSS selector for the element to find",
 					},
 				},
-				"required": []string{"selector"},
+				"required":             []string{"selector"},
+				"additionalProperties": false,
 			},
 		},
 		{
 			Name:        "browser_quit",
 			Description: "Close the browser session",
 			InputSchema: map[string]interface{}{
-				"type":       "object",
-				"properties": map[string]interface{}{},
+				"type":                 "object",
+				"properties":           map[string]interface{}{},
+				"additionalProperties": false,
 			},
 		},
 	}

--- a/clicker/internal/mcp/server.go
+++ b/clicker/internal/mcp/server.go
@@ -191,17 +191,18 @@ func (s *Server) handleRequest(data []byte) *Response {
 
 	// Route to handler
 	result, err := s.route(req)
+
+	// Notifications (no ID) don't get a response (even on error)
+	if req.ID == nil {
+		return nil
+	}
+
 	if err != nil {
 		return &Response{
 			JSONRPC: "2.0",
 			ID:      req.ID,
 			Error:   err,
 		}
-	}
-
-	// Notifications (no ID) don't get a response
-	if req.ID == nil {
-		return nil
 	}
 
 	return &Response{
@@ -218,7 +219,7 @@ func (s *Server) route(req Request) (interface{}, *Error) {
 	switch req.Method {
 	case "initialize":
 		return s.handleInitialize(req.Params)
-	case "initialized":
+	case "initialized", "notifications/initialized":
 		// Notification, no response needed
 		return nil, nil
 	case "tools/list":


### PR DESCRIPTION
## Summary

Resolves JSON Schema validation errors and notification handling issues that prevented the MCP server from loading in Claude Desktop.

In Vibium fashion, I leveraged Claude Code to identify and address these compatibility issues, then personally tested and verified the fixes on macOS 25.1.0 with Claude Desktop (latest).

## Changes

### 1. Add `additionalProperties: false` to all tool schemas (`schema.go`)

- Added `"additionalProperties": false` to all 7 tool InputSchema definitions
- Required for strict JSON Schema compliance with Claude Desktop's Zod validator
- Without this property, schemas are ambiguous about whether extra properties are allowed, causing validation errors

**Example:**
```go
InputSchema: map[string]interface{}{
    "type": "object",
    "properties": map[string]interface{}{
        "headless": map[string]interface{}{...},
    },
    "additionalProperties": false,  // ← Added
},
```

### 2. Fix notification handling (`server.go`)

**Issue:** When Claude Desktop sent `notifications/initialized`, the server returned a "Method not found" error response, which violates JSON-RPC 2.0 spec (notifications must never receive responses).

**Changes:**
- Added `"notifications/initialized"` to the method switch case alongside `"initialized"`
- Moved notification check (line 195-198) to execute BEFORE error responses
- Ensures notifications never receive responses, even on error

**Before:**
```go
result, err := s.route(req)
if err != nil {
    return &Response{...}  // ❌ Would send error response to notifications
}
if req.ID == nil {
    return nil
}
```

**After:**
```go
result, err := s.route(req)

if req.ID == nil {  // ✅ Check notification first
    return nil
}

if err != nil {
    return &Response{...}
}
```

## Testing

Tested with full MCP protocol handshake including `notifications/initialized`:
```bash
printf '{"jsonrpc":"2.0","id":1,"method":"initialize",...}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n' | clicker mcp
```

**Results:**
- ✅ All schemas include `"additionalProperties": false`
- ✅ `notifications/initialized` receives no response (correct behavior)
- ✅ Only requests with IDs receive responses
- ✅ Claude Desktop loads vibium without errors

## Impact

- Makes MCP server compliant with JSON Schema and JSON-RPC 2.0 specifications
- Fixes compatibility with Claude Desktop's strict validation
- No breaking changes for valid clients (only rejects invalid tool calls with extra properties and fixes notification handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)