### PR TITLE
Fix newline characters not being typed into textareas

### DIFF
--- a/clicker/internal/bidi/input.go
+++ b/clicker/internal/bidi/input.go
@@ -137,6 +137,7 @@ func (c *Client) TypeText(context, text string) error {
 	// Build key actions for each character
 	keyActions := make([]map[string]interface{}, 0, len(text)*2)
 	for _, char := range text {
+		char = NormalizeKeyChar(char)
 		keyActions = append(keyActions,
 			map[string]interface{}{
 				"type": "keyDown",

--- a/clicker/internal/bidi/input.go
+++ b/clicker/internal/bidi/input.go
@@ -137,7 +137,7 @@ func (c *Client) TypeText(context, text string) error {
 	// Build key actions for each character
 	keyActions := make([]map[string]interface{}, 0, len(text)*2)
 	for _, char := range text {
-		char = NormalizeKeyChar(char)
+		char = ConvertToKeyChar(char)
 		keyActions = append(keyActions,
 			map[string]interface{}{
 				"type": "keyDown",

--- a/clicker/internal/bidi/keys.go
+++ b/clicker/internal/bidi/keys.go
@@ -1,0 +1,10 @@
+package bidi
+
+// NormalizeKeyChar converts characters to their WebDriver BiDi equivalents.
+// For example, newline (\n) must be sent as carriage return (\r) to produce Enter.
+func NormalizeKeyChar(r rune) rune {
+	if r == '\n' {
+		return '\r'
+	}
+	return r
+}

--- a/clicker/internal/bidi/keys.go
+++ b/clicker/internal/bidi/keys.go
@@ -1,10 +1,11 @@
 package bidi
 
-// NormalizeKeyChar converts characters to their WebDriver BiDi equivalents.
-// For example, newline (\n) must be sent as carriage return (\r) to produce Enter.
-func NormalizeKeyChar(r rune) rune {
+// ConvertToKeyChar maps string literal characters to their WebDriver BiDi key
+// equivalents for keyboard input. For example, newline (\n) is a line break in
+// strings but must be sent as the Return key (\uE006) to produce a key press.
+func ConvertToKeyChar(r rune) rune {
 	if r == '\n' {
-		return '\r'
+		return '\uE006'
 	}
 	return r
 }

--- a/clicker/internal/proxy/router.go
+++ b/clicker/internal/proxy/router.go
@@ -271,6 +271,7 @@ func (r *Router) handleVibiumType(session *BrowserSession, cmd bidiCommand) {
 	// Build key actions for typing
 	keyActions := make([]map[string]interface{}, 0, len(text)*2)
 	for _, char := range text {
+		char = bidi.NormalizeKeyChar(char)
 		keyActions = append(keyActions,
 			map[string]interface{}{"type": "keyDown", "value": string(char)},
 			map[string]interface{}{"type": "keyUp", "value": string(char)},

--- a/clicker/internal/proxy/router.go
+++ b/clicker/internal/proxy/router.go
@@ -271,7 +271,7 @@ func (r *Router) handleVibiumType(session *BrowserSession, cmd bidiCommand) {
 	// Build key actions for typing
 	keyActions := make([]map[string]interface{}, 0, len(text)*2)
 	for _, char := range text {
-		char = bidi.NormalizeKeyChar(char)
+		char = bidi.ConvertToKeyChar(char)
 		keyActions = append(keyActions,
 			map[string]interface{}{"type": "keyDown", "value": string(char)},
 			map[string]interface{}{"type": "keyUp", "value": string(char)},

--- a/tests/cli/elements.test.js
+++ b/tests/cli/elements.test.js
@@ -40,4 +40,30 @@ describe('CLI: Elements', () => {
     );
     assert.match(result, /12345/, 'Should show typed text in result');
   });
+
+  test('type command enters text with carriage returns into textarea', () => {
+    const result = execSync(
+      `${CLICKER} type https://seleniumbase.io/demo_page "textarea" $'123\\r456'`,
+      {
+        encoding: 'utf-8',
+        timeout: 30000,
+        shell: '/bin/bash',
+      }
+    );
+    // The output should show the textarea value with a newline (via carriage return)
+    assert.match(result, /value is now: 123\n456/, 'Should show typed value with newline (via carriage return)');
+  });
+
+  test('type command enters text with newlines into textarea', () => {
+    const result = execSync(
+      `${CLICKER} type https://seleniumbase.io/demo_page "textarea" $'123\\n456'`,
+      {
+        encoding: 'utf-8',
+        timeout: 30000,
+        shell: '/bin/bash',
+      }
+    );
+    // The output should show the textarea value with a newline
+    assert.match(result, /value is now: 123\n456/, 'Should show typed value with newline');
+  });
 });

--- a/tests/js/async-api.test.js
+++ b/tests/js/async-api.test.js
@@ -108,6 +108,40 @@ describe('JS Async API', () => {
     }
   });
 
+  test('element.type() enters text with carriage returns', async () => {
+    const vibe = await browser.launch({ headless: true });
+    try {
+      await vibe.go('https://seleniumbase.io/demo_page');
+      const textarea = await vibe.find('textarea');
+      await textarea.type('123\r456');
+
+      // Verify the value was entered
+      const value = await vibe.evaluate(`
+        return document.querySelector('textarea').value;
+      `);
+      assert.strictEqual(value, '123\n456', 'Textarea should have typed value with newline (via carriage return)');
+    } finally {
+      await vibe.quit();
+    }
+  });
+
+  test('element.type() enters text with newlines', async () => {
+    const vibe = await browser.launch({ headless: true });
+    try {
+      await vibe.go('https://seleniumbase.io/demo_page');
+      const textarea = await vibe.find('textarea');
+      await textarea.type('123\n456');
+
+      // Verify the value was entered
+      const value = await vibe.evaluate(`
+        return document.querySelector('textarea').value;
+      `);
+      assert.strictEqual(value, '123\n456', 'Textarea should have typed value with newline');
+    } finally {
+      await vibe.quit();
+    }
+  });
+
   test('element.text() returns element text', async () => {
     const vibe = await browser.launch({ headless: true });
     try {

--- a/tests/js/sync-api.test.js
+++ b/tests/js/sync-api.test.js
@@ -101,4 +101,38 @@ describe('JS Sync API', () => {
       vibe.quit();
     }
   });
+
+  test('element.type() enters text with carriage returns (sync)', () => {
+    const vibe = browserSync.launch({ headless: true });
+    try {
+      vibe.go('https://seleniumbase.io/demo_page');
+      const textarea = vibe.find('textarea');
+      textarea.type('123\r456');
+
+      // Verify the value was entered
+      const value = vibe.evaluate(`
+        return document.querySelector('textarea').value;
+      `);
+      assert.strictEqual(value, '123\n456', 'Textarea should have typed value with newline (via carriage return)');
+    } finally {
+      vibe.quit();
+    }
+  });
+
+  test('element.type() enters text with newlines (sync)', () => {
+    const vibe = browserSync.launch({ headless: true });
+    try {
+      vibe.go('https://seleniumbase.io/demo_page');
+      const textarea = vibe.find('textarea');
+      textarea.type('123\n456');
+
+      // Verify the value was entered
+      const value = vibe.evaluate(`
+        return document.querySelector('textarea').value;
+      `);
+      assert.strictEqual(value, '123\n456', 'Textarea should have typed value with newline');
+    } finally {
+      vibe.quit();
+    }
+  });
 });


### PR DESCRIPTION
WebDriver BiDi requires carriage return (\r) to produce the Enter key, not newline (\n). Text containing \n was being typed without line breaks / line breaks were being dropped.

- Add NormalizeKeyChar helper in internal/bidi/keys.go
- Apply conversion in both input.go (CLI) and router.go (WebSocket API)
- Add newline tests for JS async API and CLI