### PR TITLE
Fix ESM binary resolution in JavaScript client

### DIFF
--- a/clients/javascript/src/clicker/binary.ts
+++ b/clients/javascript/src/clicker/binary.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { getPlatform, getArch } from './platform';
 
 /**
@@ -24,6 +26,18 @@ export function getClickerPath(): string {
 
   // 2. Check platform-specific npm package
   try {
+    // Use createRequire to make this work in both CJS and ESM
+    // In ESM, use import.meta.url; in CJS, construct from __filename
+    let currentModulePath: string;
+    if (typeof __filename !== 'undefined') {
+      // CommonJS
+      currentModulePath = __filename;
+    } else {
+      // ESM - TypeScript won't compile this, but it works at runtime in ESM
+      // @ts-ignore - import.meta.url is available in ESM at runtime
+      currentModulePath = fileURLToPath(import.meta.url);
+    }
+    const require = createRequire(currentModulePath);
     const packagePath = require.resolve(`${packageName}/package.json`);
     const packageDir = path.dirname(packagePath);
     const binaryPath = path.join(packageDir, 'bin', binaryName);


### PR DESCRIPTION
## Summary

Fixes #62 - Vibium fails to locate the clicker binary when used as an ES Module. When using Vibium in an ESM project (with `"type": "module"` in package.json), the library failed to find the platform-specific clicker binary, even though it was correctly installed in `node_modules/@vibium/{platform}-{arch}/bin/clicker`.

In Vibium fashion, I leveraged Claude Code to identify and address this issue, then personally tested and verified the fixes on macOS 26.1.

## The Fix

The root cause was that `binary.ts` used `require.resolve()` to locate the platform package, which is a CommonJS function that doesn't work in ESM environments.

**Solution**: Implement dual CJS/ESM support using `createRequire()`:
1. Import `createRequire` from Node's built-in `module` package
2. Detect runtime environment by checking for `__filename` (CJS) vs `import.meta.url` (ESM)
3. Create a working `require` function using `createRequire()` that works in both environments
4. Use this to resolve the platform package path

**Key changes in `clients/javascript/src/clicker/binary.ts`**:
```typescript
import { fileURLToPath } from 'url';
import { createRequire } from 'module';

// Detect environment and create require function
let currentModulePath: string;
if (typeof __filename !== 'undefined') {
  currentModulePath = __filename;  // CommonJS
} else {
  currentModulePath = fileURLToPath(import.meta.url);  // ESM
}
const require = createRequire(currentModulePath);
const packagePath = require.resolve(`${packageName}/package.json`);
```

## Test plan

- [x] **ESM mode**: Created test project with `"type": "module"`, verified browser launches without CLICKER_PATH
- [x] **CommonJS mode**: Verified backwards compatibility maintained
- [x] **Existing test suite**: 21/23 tests pass (2 pre-existing failures in auto-wait tests tracked in #64)

### Testing with Claude Code

To reproduce the issue and verify the fix:

**Reproduce the issue (before fix)**:
```
Create a test ESM project with "type": "module" in package.json, install vibium, and try to launch a browser. You'll see: "Error: Could not find clicker binary"
```

**Verify the fix (after)**:
```
Test the fix in both ESM and CommonJS modes. Create two test projects - one with "type": "module" and one without. Both should successfully launch the browser without needing CLICKER_PATH.
```

**Claude Code prompts for testing**:
```
# ESM test
Create a test ESM project and verify Vibium can launch a browser without CLICKER_PATH

# CommonJS test  
Create a test CommonJS project and verify backwards compatibility is maintained
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)