### PR TITLE
Fix dropped reason field in actionability check results

### DIFF
--- a/clicker/internal/features/actionability.go
+++ b/clicker/internal/features/actionability.go
@@ -52,6 +52,7 @@ func CheckVisible(client *bidi.Client, context, selector string) (bool, error) {
 
 	var data struct {
 		Visible bool   `json:"visible"`
+		Reason  string `json:"reason,omitempty"`
 		Error   string `json:"error,omitempty"`
 	}
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
@@ -60,6 +61,10 @@ func CheckVisible(client *bidi.Client, context, selector string) (bool, error) {
 
 	if data.Error != "" {
 		return false, fmt.Errorf("element %s", data.Error)
+	}
+
+	if !data.Visible && data.Reason != "" {
+		return false, fmt.Errorf("element not visible: %s", data.Reason)
 	}
 
 	return data.Visible, nil
@@ -130,6 +135,7 @@ func CheckReceivesEvents(client *bidi.Client, context, selector string) (bool, e
 
 	var data struct {
 		ReceivesEvents bool   `json:"receivesEvents"`
+		Reason         string `json:"reason,omitempty"`
 		Error          string `json:"error,omitempty"`
 	}
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
@@ -138,6 +144,10 @@ func CheckReceivesEvents(client *bidi.Client, context, selector string) (bool, e
 
 	if data.Error != "" {
 		return false, fmt.Errorf("element %s", data.Error)
+	}
+
+	if !data.ReceivesEvents && data.Reason != "" {
+		return false, fmt.Errorf("element does not receive events: %s", data.Reason)
 	}
 
 	return data.ReceivesEvents, nil
@@ -185,6 +195,7 @@ func CheckEnabled(client *bidi.Client, context, selector string) (bool, error) {
 
 	var data struct {
 		Enabled bool   `json:"enabled"`
+		Reason  string `json:"reason,omitempty"`
 		Error   string `json:"error,omitempty"`
 	}
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
@@ -193,6 +204,10 @@ func CheckEnabled(client *bidi.Client, context, selector string) (bool, error) {
 
 	if data.Error != "" {
 		return false, fmt.Errorf("element %s", data.Error)
+	}
+
+	if !data.Enabled && data.Reason != "" {
+		return false, fmt.Errorf("element not enabled: %s", data.Reason)
 	}
 
 	return data.Enabled, nil
@@ -261,6 +276,7 @@ func CheckEditable(client *bidi.Client, context, selector string) (bool, error) 
 
 	var data struct {
 		Editable bool   `json:"editable"`
+		Reason   string `json:"reason,omitempty"`
 		Error    string `json:"error,omitempty"`
 	}
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
@@ -269,6 +285,10 @@ func CheckEditable(client *bidi.Client, context, selector string) (bool, error) 
 
 	if data.Error != "" {
 		return false, fmt.Errorf("element %s", data.Error)
+	}
+
+	if !data.Editable && data.Reason != "" {
+		return false, fmt.Errorf("element not editable: %s", data.Reason)
 	}
 
 	return data.Editable, nil


### PR DESCRIPTION
## Summary

Fixes #2 - The `reason` field returned by JavaScript actionability checks (visible, receivesEvents, enabled, editable) was silently dropped during JSON unmarshalling because the Go structs did not include a `Reason` field. This meant callers only knew *that* a check failed, but not *why*.

In Vibium fashion, I leveraged Claude Code to identify and address this issue, then personally tested and verified the fixes on macOS 26.1.

## The Fix

The JavaScript check functions return JSON with a `reason` field when a check fails (e.g., `{"visible": false, "reason": "zero size"}`), but the Go structs used to unmarshal these results only had the boolean and error fields — `reason` was never captured.

**Solution**: Add a `Reason` field to each check function's unmarshal struct and include it in the returned error message when a check fails.

All four affected functions in `clicker/internal/features/actionability.go`:
- `CheckVisible` — now returns `"element not visible: zero size"` instead of just `false, nil`
- `CheckReceivesEvents` — now returns `"element does not receive events: obscured by div"` 
- `CheckEnabled` — now returns `"element not enabled: disabled attribute"`
- `CheckEditable` — now returns `"element not editable: readonly attribute"`

This reason info propagates through `WaitForActionable` into timeout error messages, so users now see:
```
timeout: Timeout after 30000ms waiting for '#my-button': check 'Visible' failed: element not visible: display none
```

Instead of:
```
timeout: Timeout after 30000ms waiting for '#my-button': check 'Visible' failed
```

## Test Plan

- [x] Verified all four check functions now preserve the `reason` field from JS responses
- [x] Confirmed error messages include the reason string for all failure cases (zero size, visibility hidden, display none, obscured by element, disabled attribute, aria-disabled, inside disabled fieldset, readonly attribute, aria-readonly, non-editable input type, non-form element)
- [x] Go tests pass: `go test ./...`

### Testing with Claude Code

```
# Verify reason field is preserved in actionability checks
Read the actionability.go file and confirm each check function's unmarshal struct includes a Reason field and returns it in the error message when the check fails
```

## Files Changed

- `clicker/internal/features/actionability.go` - Added `Reason` field to all four check function unmarshal structs and included reason in error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)