### PR TITLE
Fix #62: Resolve clicker binary path in ES Module context

### DIFF
--- a/clients/javascript/src/clicker/binary.ts
+++ b/clients/javascript/src/clicker/binary.ts
@@ -1,6 +1,34 @@
 import fs from 'fs';
 import path from 'path';
+import { createRequire } from 'module';
 import { getPlatform, getArch } from './platform';
+
+/**
+ * Resolve a package's location using either require.resolve (CJS)
+ * or createRequire (ESM-compatible fallback).
+ */
+function resolvePackageJson(packageName: string): string | null {
+  const specifier = `${packageName}/package.json`;
+
+  // Try native require.resolve first (works in CJS context)
+  try {
+    if (typeof require !== 'undefined' && typeof require.resolve === 'function') {
+      return require.resolve(specifier);
+    }
+  } catch {
+    // Not found via native require
+  }
+
+  // Fallback: createRequire from cwd (works in ESM context)
+  try {
+    const esmRequire = createRequire(path.join(process.cwd(), 'package.json'));
+    return esmRequire.resolve(specifier);
+  } catch {
+    // Not found via createRequire either
+  }
+
+  return null;
+}
 
 /**
  * Resolve the path to the clicker binary.
@@ -23,16 +51,14 @@ export function getClickerPath(): string {
   const binaryName = platform === 'win32' ? 'clicker.exe' : 'clicker';
 
   // 2. Check platform-specific npm package
-  try {
-    const packagePath = require.resolve(`${packageName}/package.json`);
-    const packageDir = path.dirname(packagePath);
+  const packageJsonPath = resolvePackageJson(packageName);
+  if (packageJsonPath) {
+    const packageDir = path.dirname(packageJsonPath);
     const binaryPath = path.join(packageDir, 'bin', binaryName);
 
     if (fs.existsSync(binaryPath)) {
       return binaryPath;
     }
-  } catch {
-    // Package not installed, continue to fallback
   }
 
   // 3. Check local development paths (relative to cwd)


### PR DESCRIPTION
## Summary

Fixes #62 — Vibium fails to locate the clicker binary when used in ESM projects (`"type": "module"` in package.json).

## Problem

The `getClickerPath()` function used `require.resolve()` to find the platform-specific binary package. In ESM context, `require` is not available, causing the resolution to fail with:

```
Error: Could not find clicker binary. Set CLICKER_PATH environment variable or install @vibium/darwin-x64
```

## Solution

Added a `resolvePackageJson()` helper that:
1. Tries native `require.resolve()` first (works in CJS)
2. Falls back to `createRequire()` from the `module` builtin (works in ESM)

The `createRequire` approach creates a require function anchored to `process.cwd()`, which correctly resolves packages from the project's `node_modules`.

## Verification

- `tsup` build succeeds for both CJS and ESM formats
- ESM bundle correctly uses `createRequire` fallback (tsup transforms `require` → `__require` in ESM, so the CJS branch naturally skips)
- No changes to CJS behavior — existing `require.resolve` path still works

## Files Changed

- `clients/javascript/src/clicker/binary.ts` — Added ESM-compatible package resolution