### PR TITLE
Fix #64: Improve timeout error messages in find()

### DIFF
--- a/clients/javascript/src/bidi/client.ts
+++ b/clients/javascript/src/bidi/client.ts
@@ -39,7 +39,13 @@ export class BiDiClient {
     this.pendingCommands.delete(response.id);
 
     if (response.type === 'error' && response.error) {
-      pending.reject(new Error(`${response.error}: ${response.message}`));
+      const errorStr = typeof response.error === 'string'
+        ? response.error
+        : JSON.stringify(response.error);
+      const messageStr = typeof response.message === 'string'
+        ? response.message
+        : (response.message !== undefined ? JSON.stringify(response.message) : 'unknown error');
+      pending.reject(new Error(`${errorStr}: ${messageStr}`));
     } else {
       pending.resolve(response.result);
     }

--- a/clients/javascript/src/vibe.ts
+++ b/clients/javascript/src/vibe.ts
@@ -2,6 +2,7 @@ import { BiDiClient, BrowsingContextTree, NavigationResult, ScreenshotResult } f
 import { ClickerProcess } from './clicker';
 import { Element, ElementInfo } from './element';
 import { debug } from './utils/debug';
+import { TimeoutError } from './utils/errors';
 
 export interface FindOptions {
   /** Timeout in milliseconds to wait for element. Default: 30000 */
@@ -89,11 +90,21 @@ export class Vibe {
     debug('finding element', { selector, timeout: options?.timeout });
     const context = await this.getContext();
 
-    const result = await this.client.send<VibiumFindResult>('vibium:find', {
-      context,
-      selector,
-      timeout: options?.timeout,
-    });
+    const timeoutMs = options?.timeout ?? 30000;
+    let result: VibiumFindResult;
+    try {
+      result = await this.client.send<VibiumFindResult>('vibium:find', {
+        context,
+        selector,
+        timeout: timeoutMs,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.toLowerCase().includes('timeout') || message.includes('no node')) {
+        throw new TimeoutError(selector, timeoutMs, message);
+      }
+      throw err;
+    }
 
     const info: ElementInfo = {
       tag: result.tag,


### PR DESCRIPTION
## Summary

Fixes #64 — timeout errors from `find()` were showing as `[object Object]: undefined` instead of helpful messages.

## Changes

### 1. `clients/javascript/src/bidi/client.ts`
- **`handleResponse()`**: Safely stringify `response.error` and `response.message` fields that may not be strings, preventing the `[object Object]: undefined` output.

### 2. `clients/javascript/src/vibe.ts`
- **`find()`**: Catch BiDi errors and re-throw as `TimeoutError` (from `utils/errors.ts`) when the error indicates a timeout or missing element. This produces clear messages like:
  ```
  TimeoutError: Timeout after 1000ms waiting for '#does-not-exist': ...
  ```

## Testing

- TypeScript compiles cleanly (`tsc --noEmit`)
- Build succeeds (`npm run build`)
- The two failing tests (`find() times out for non-existent element` and `timeout error message is clear`) should now pass since:
  - Error messages include "timeout" (matching the `/timeout/i` regex)
  - Error messages include the selector (matching the `includes('#nonexistent-element-xyz')` check)