### PR TITLE
Add Safari explicitly to V2 browser support roadmap

### DIFF
--- a/V2-ROADMAP.md
+++ b/V2-ROADMAP.md
@@ -199,15 +199,15 @@ const el = await vibe.find("the blue submit button");
 
 ---
 
-## Firefox & Edge Support
+## Firefox, Edge, and Safari Support
 
-**What:** Support browsers beyond Chrome.
+**What:** Support browsers beyond Chrome (Firefox, Edge, and Safari).
 
 **Why deferred:** Chrome covers 90%+ of use cases. BiDi implementations vary across browsers.
 
-**When to build:** When users explicitly need Firefox (privacy testing) or Edge (enterprise).
+**When to build:** When users explicitly need Firefox (privacy testing), Edge (enterprise), or Safari (macOS/WebKit coverage).
 
-**Estimated effort:** 1 week per browser
+**Estimated effort:** 1-2 weeks per browser (Safari likely needs additional WebKit-specific validation)
 
 ---
 
@@ -241,7 +241,7 @@ Based on likely user demand:
 6. **AI locators** — High value but high uncertainty
 7. **Java client** — Enterprise demand
 8. **Cortex UI** — Nice to have
-9. **Firefox/Edge** — Edge cases
+9. **Firefox/Edge/Safari** — Non-Chrome coverage on demand
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #74 by explicitly adding Safari to the V2 browser-support roadmap section.

### What changed
- Renamed section from `Firefox & Edge Support` to `Firefox, Edge, and Safari Support`
- Updated scope text to include Safari
- Updated "when to build" criteria to include Safari/macOS/WebKit coverage
- Updated priority list item to `Firefox/Edge/Safari`

## Build/Test (GitHub Runner)

Ran on GitHub Actions runner:
- Build vibium binary
- Build JavaScript client
- Go tests (`cd clicker && go test ./...`)

Run: https://github.com/0xshitcode/vibium/actions/runs/22230144179
