### PR TITLE
Add Windows 0x5 access-denied troubleshooting docs

### DIFF
--- a/docs/how-to-guides/debugging.md
+++ b/docs/how-to-guides/debugging.md
@@ -92,6 +92,19 @@ If Chrome fails to start:
 2. Reinstall if needed: `./clicker/bin/vibium install`
 3. On macOS, you may need to allow it in System Preferences → Security & Privacy
 
+### Windows: "Access is denied. (0x5)" for Chrome for Testing
+
+If Windows reports sandbox/access errors for `chrome.exe` under `%LOCALAPPDATA%\vibium\chrome-for-testing\...`:
+
+1. Delete `%LOCALAPPDATA%\vibium\chrome-for-testing\` and run `vibium install` again.
+2. Add antivirus/endpoint-security exclusions for `%LOCALAPPDATA%\vibium\`.
+3. Verify your user can execute files from that folder (no policy lock/block).
+4. Re-run with debug logs enabled:
+   - PowerShell: `$env:VIBIUM_DEBUG=1`
+   - CMD: `set VIBIUM_DEBUG=1`
+
+If this still fails, include the full debug output in your issue.
+
 ### Tests Hang
 
 If tests hang indefinitely:

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -193,6 +193,17 @@ Try running with headless mode disabled (it's disabled by default, but just in c
 const vibe = browserSync.launch({ headless: false })
 ```
 
+### Windows: "Access is denied. (0x5)" on Chrome launch
+
+If you see access/sandbox errors for a path under `%LOCALAPPDATA%\vibium\chrome-for-testing\...`:
+
+1. Delete `%LOCALAPPDATA%\vibium\chrome-for-testing\`.
+2. Re-run your script (Vibium will reinstall Chrome for Testing).
+3. Add antivirus exclusions for `%LOCALAPPDATA%\vibium\` if your endpoint security blocks unknown binaries.
+4. Enable debug logs and retry:
+   - PowerShell: `$env:VIBIUM_DEBUG=1`
+   - CMD: `set VIBIUM_DEBUG=1`
+
 ### Permission denied (Linux)
 
 You might need to install dependencies for Chrome:


### PR DESCRIPTION
## Summary

Fixes #16 by adding explicit troubleshooting guidance for Windows `Access is denied (0x5)` failures when Chrome for Testing is blocked.

### What changed
- Added a dedicated troubleshooting section in `docs/how-to-guides/debugging.md`:
  - clear cache path cleanup
  - reinstall step
  - antivirus/endpoint exclusion guidance
  - permission/policy check
  - debug log commands for PowerShell and CMD
- Added a matching quick troubleshooting section in `docs/tutorials/getting-started.md`

## Build/Test (GitHub Runner)

Ran on GitHub Actions runner:
- Build vibium binary
- Build JavaScript client
- Go tests (`cd clicker && go test ./...`)

Run: https://github.com/0xshitcode/vibium/actions/runs/22230214885
