### PR TITLE
Improve Connection closed troubleshooting and setup guidance

### DIFF
--- a/docs/tutorials/claude-code-mcp-setup.md
+++ b/docs/tutorials/claude-code-mcp-setup.md
@@ -196,6 +196,18 @@ Ensure Chrome for Testing is installed:
 ./clicker/bin/vibium install
 ```
 
+If you are setting up from npm, install `vibium` (not `clicker`):
+
+```bash
+npm install vibium@latest
+```
+
+The npm package named `clicker` is unrelated and will not install Vibium's browser binary.
+
+If you see `Error: Connection closed`, run again with debug logs enabled:
+- PowerShell: `$env:VIBIUM_DEBUG=1`
+- CMD: `set VIBIUM_DEBUG=1`
+
 ### View MCP server logs
 
 Run vibium directly to see any error output. You can test the full flow by sending JSON-RPC messages to stdin:

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -193,6 +193,27 @@ Try running with headless mode disabled (it's disabled by default, but just in c
 const vibe = browserSync.launch({ headless: false })
 ```
 
+### "Error: Connection closed" (especially on Windows)
+
+This usually means the browser process exited unexpectedly before the next command completed.
+
+Try this reset flow in a fresh folder:
+
+```bash
+mkdir vibium-test
+cd vibium-test
+npm init -y
+npm install vibium@latest
+```
+
+Important: install `vibium`, not `clicker`. The npm package `clicker` is unrelated.
+
+Then run your script again with debug logs enabled:
+- PowerShell: `$env:VIBIUM_DEBUG=1`
+- CMD: `set VIBIUM_DEBUG=1`
+
+If you use endpoint security/antivirus, add exclusions for `%LOCALAPPDATA%\vibium\`.
+
 ### Permission denied (Linux)
 
 You might need to install dependencies for Chrome:


### PR DESCRIPTION
## Summary

Fixes #14 by improving troubleshooting docs for `Error: Connection closed`, especially for Windows users who accidentally install the wrong npm package.

### What changed
- `docs/tutorials/getting-started.md`
  - Added a dedicated `Error: Connection closed` troubleshooting section
  - Added explicit reset flow in a fresh directory
  - Clarified to install `vibium` (not `clicker`)
  - Added debug-log commands and AV exclusion note
- `docs/tutorials/claude-code-mcp-setup.md`
  - Added the same package-name clarification (`vibium` vs unrelated `clicker`)
  - Added debug-log guidance for `Connection closed`

## Build/Test (GitHub Runner)

Ran on GitHub Actions runner:
- Build vibium binary
- Build JavaScript client
- Go tests (`cd clicker && go test ./...`)

Run: https://github.com/0xshitcode/vibium/actions/runs/22230289238
