### PR TITLE
Serialize shared BiDi client commands

### DIFF
--- a/clicker/internal/bidi/session.go
+++ b/clicker/internal/bidi/session.go
@@ -3,12 +3,14 @@ package bidi
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 )
 
 // Client is a BiDi client that wraps a WebSocket connection.
 type Client struct {
 	conn    *Connection
+	cmdMu   sync.Mutex
 	verbose bool
 }
 
@@ -32,6 +34,9 @@ func (c *Client) SendCommand(method string, params interface{}) (*Message, error
 
 // SendCommandWithTimeout sends a BiDi command and waits for the response with a custom timeout.
 func (c *Client) SendCommandWithTimeout(method string, params interface{}, timeout time.Duration) (*Message, error) {
+	c.cmdMu.Lock()
+	defer c.cmdMu.Unlock()
+
 	cmd := NewCommand(method, params)
 
 	data, err := cmd.Marshal()


### PR DESCRIPTION
## Summary
- serialize `internal/bidi.Client` command execution so background screenshot recording cannot race foreground CLI commands on the same websocket
- keep the fix local to the shared BiDi client instead of changing the recording or daemon architecture
- address the daemon hangs seen when `vibium record start --screenshots` runs against a remote Kernel browser session

## Test plan
- [x] Build the Go CLI from source
- [x] Reproduce the previous failure shape with screenshots enabled: `start`, `record start --screenshots --snapshots`, `go https://var.parts/`, `title`, `screenshot`, `map`, `record stop`
- [x] Run the full `https://var.parts/` checkout flow with screenshots recording enabled against a remote Kernel browser session and confirm checkout completes plus recording zip is written

Made with [Cursor](https://cursor.com)