### PR TITLE
Fix #108 - Semantic element interactions

### DIFF
--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -1007,87 +1007,72 @@ func ScrollWheel(s Session, context string, x, y, deltaX, deltaY int) error {
 }
 
 // --- Script builders for JS-based interactions ---
+//
+// CSS vs semantic resolution matches buildActionableScript in actionability.go:
+// use querySelector(selector) only when !hasSemantic(ep) && ep.Selector != "".
+// Otherwise use collectMatches + pickBest (same as handlers_state helpers), so
+// we never call querySelector("") when the client sent only xpath/role/text/…
+// or when selector is empty.
+//
+// Shared JS fragments keep CSS vs semantic paths in sync per operation.
 
-// buildIsCheckedScript builds a JS function to check if an element is checked.
-func buildIsCheckedScript(ep ElementParams) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
+// scriptConfig describes one interaction JS builder for both CSS and semantic paths.
+type scriptConfig struct {
+	cssSignature      string
+	semanticSignature string
+	body              string
+	rootNotFound      string
+	elNotFound        string
+	extraArgs         []map[string]interface{}
+}
+
+const (
+	jsReturnFalse     = "'false'"
+	jsReturnNotFound  = "'not found'"
+	jsReturnElementNF = "'element not found'"
+)
+
+// buildScript assembles a script.callFunction declaration and argument list
+// using either the CSS or semantic element-resolution prelude.
+func buildScript(ep ElementParams, cfg scriptConfig) (string, []map[string]interface{}) {
+	var (
+		args   []map[string]interface{}
+		sig    string
+		openFn string
+	)
+
+	if useCSSInteractionScript(ep) {
+		args = buildElBaseArgs(ep)
+		sig = cfg.cssSignature
+		openFn = interactionScriptOpenCSS(cfg.rootNotFound, cfg.elNotFound)
+	} else {
+		args = buildElSemanticArgs(ep)
+		sig = cfg.semanticSignature
+		openFn = interactionScriptOpenSemantic(cfg.rootNotFound, cfg.elNotFound)
 	}
 
+	args = append(args, cfg.extraArgs...)
 	script := `
-		(scope, selector, index, hasIndex) => {
-			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'false';
-			let el;
-			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
-			} else {
-				el = root.querySelector(selector);
-			}
-			if (!el) return 'false';
-			return el.checked ? 'true' : 'false';
+		` + sig + `
+	` + openFn + cfg.body + `
 		}
 	`
 	return script, args
 }
 
-// buildSelectOptionScript builds a JS function to set a select element's value.
-func buildSelectOptionScript(ep ElementParams, value string) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-		{"type": "string", "value": value},
-	}
-
-	script := `
-		(scope, selector, index, hasIndex, value) => {
-			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'element not found';
-			let el;
-			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
-			} else {
-				el = root.querySelector(selector);
-			}
-			if (!el) return 'element not found';
-			if (el.tagName !== 'SELECT') return 'not a <select> element';
-			// Match by option value, then fall back to the visible label/text so
-			// passing "California" (for <option value="CA">California</option>)
-			// works. Without this, an unmatched value silently no-ops (issue #140).
-			const opts = Array.from(el.options || []);
-			const match = opts.find(o => o.value === value)
-				|| opts.find(o => ((o.label || o.text || '').trim() === value));
-			if (!match) return 'no <option> matches "' + value + '"';
-			el.value = match.value;
-			el.dispatchEvent(new Event('input', { bubbles: true }));
-			el.dispatchEvent(new Event('change', { bubbles: true }));
-			return 'ok';
-		}
-	`
-	return script, args
+// useCSSInteractionScript returns true when the strict CSS-only script path is valid.
+// Mirrors actionability.buildActionableScript branching.
+func useCSSInteractionScript(ep ElementParams) bool {
+	return !hasSemantic(ep) && ep.Selector != ""
 }
 
-// buildSetValueScript builds a JS function to set an element's value and dispatch events.
-func buildSetValueScript(ep ElementParams, value string) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-		{"type": "string", "value": value},
-	}
-
-	script := `
-		(scope, selector, index, hasIndex, value) => {
+// interactionScriptOpenCSS returns JS from `const root` through assigning `el`
+// or returning elNotFound. rootNotFound and elNotFound are full JS return
+// expressions, e.g. `'not found'` or `'false'`.
+func interactionScriptOpenCSS(rootNotFound, elNotFound string) string {
+	return `
 			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'element not found';
+			if (!root) return ` + rootNotFound + `;
 			let el;
 			if (hasIndex) {
 				const all = root.querySelectorAll(selector);
@@ -1095,7 +1080,30 @@ func buildSetValueScript(ep ElementParams, value string) (string, []map[string]i
 			} else {
 				el = root.querySelector(selector);
 			}
-			if (!el) return 'element not found';
+			if (!el) return ` + elNotFound + `;
+	`
+}
+
+// interactionScriptOpenSemantic resolves `el` like GetAttribute / buildElStateScript.
+func interactionScriptOpenSemantic(rootNotFound, elNotFound string) string {
+	return `
+			const root = scope ? document.querySelector(scope) : document;
+			if (!root) return ` + rootNotFound + `;
+	` + semanticMatchesHelper() + `
+			const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
+			let el;
+			if (hasIndex) {
+				el = found[index];
+			} else {
+				el = pickBest(found, text);
+			}
+			if (!el) return ` + elNotFound + `;
+	`
+}
+
+// setValueBody writes `value` into `el` and dispatches input/change. Assumes `el` and `value` in scope.
+func setValueBody() string {
+	return `
 			el.focus();
 			// Pick the native value setter for the element's ACTUAL type. Calling
 			// the HTMLInputElement setter on a <textarea> throws "Illegal
@@ -1116,67 +1124,113 @@ func buildSetValueScript(ep ElementParams, value string) (string, []map[string]i
 			el.dispatchEvent(new Event('input', { bubbles: true }));
 			el.dispatchEvent(new Event('change', { bubbles: true }));
 			return 'ok';
-		}
 	`
-	return script, args
+}
+
+// selectOptionValueBody sets value on <select> and dispatches standard change events.
+func selectOptionValueBody() string {
+	return `
+			if (el.tagName !== 'SELECT') return 'not a <select> element';
+			// Match by option value, then fall back to the visible label/text so
+			// passing "California" (for <option value="CA">California</option>)
+			// works. Without this, an unmatched value silently no-ops (issue #140).
+			const opts = Array.from(el.options || []);
+			const match = opts.find(o => o.value === value)
+				|| opts.find(o => ((o.label || o.text || '').trim() === value));
+			if (!match) return 'no <option> matches "' + value + '"';
+			el.value = match.value;
+			el.dispatchEvent(new Event('input', { bubbles: true }));
+			el.dispatchEvent(new Event('change', { bubbles: true }));
+			return 'ok';
+	`
+}
+
+// checkedStateBody returns the checked state encoded as 'true'/'false'.
+func checkedStateBody() string {
+	return `
+			return el.checked ? 'true' : 'false';
+	`
+}
+
+// focusBody focuses the resolved element and returns 'ok'.
+func focusBody() string {
+	return `
+			el.focus();
+			return 'ok';
+	`
+}
+
+// dispatchEventBody parses init JSON and dispatches the requested DOM event.
+func dispatchEventBody() string {
+	return `
+			const init = JSON.parse(initJSON);
+			el.dispatchEvent(new Event(eventType, init));
+			return 'ok';
+	`
+}
+
+// buildIsCheckedScript builds a JS function to check if an element is checked.
+func buildIsCheckedScript(ep ElementParams) (string, []map[string]interface{}) {
+	return buildScript(ep, scriptConfig{
+		cssSignature:      "(scope, selector, index, hasIndex) => {",
+		semanticSignature: "(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex) => {",
+		body:              checkedStateBody(),
+		rootNotFound:      jsReturnFalse,
+		elNotFound:        jsReturnFalse,
+	})
+}
+
+// buildSelectOptionScript builds a JS function to set a select element's value.
+func buildSelectOptionScript(ep ElementParams, value string) (string, []map[string]interface{}) {
+	return buildScript(ep, scriptConfig{
+		cssSignature:      "(scope, selector, index, hasIndex, value) => {",
+		semanticSignature: "(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex, value) => {",
+		body:              selectOptionValueBody(),
+		rootNotFound:      jsReturnElementNF,
+		elNotFound:        jsReturnElementNF,
+		extraArgs: []map[string]interface{}{
+			{"type": "string", "value": value},
+		},
+	})
+}
+
+// buildSetValueScript builds a JS function to set an element's value and dispatch events.
+// CSS path only when useCSSInteractionScript(ep); else semantic (see package comment above).
+func buildSetValueScript(ep ElementParams, value string) (string, []map[string]interface{}) {
+	return buildScript(ep, scriptConfig{
+		cssSignature:      "(scope, selector, index, hasIndex, value) => {",
+		semanticSignature: "(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex, value) => {",
+		body:              setValueBody(),
+		rootNotFound:      jsReturnElementNF,
+		elNotFound:        jsReturnElementNF,
+		extraArgs: []map[string]interface{}{
+			{"type": "string", "value": value},
+		},
+	})
 }
 
 // buildFocusScript builds a JS function to focus an element.
 func buildFocusScript(ep ElementParams) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-	}
-
-	script := `
-		(scope, selector, index, hasIndex) => {
-			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'not found';
-			let el;
-			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
-			} else {
-				el = root.querySelector(selector);
-			}
-			if (!el) return 'not found';
-			el.focus();
-			return 'ok';
-		}
-	`
-	return script, args
+	return buildScript(ep, scriptConfig{
+		cssSignature:      "(scope, selector, index, hasIndex) => {",
+		semanticSignature: "(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex) => {",
+		body:              focusBody(),
+		rootNotFound:      jsReturnNotFound,
+		elNotFound:        jsReturnNotFound,
+	})
 }
 
 // buildDispatchEventScript builds a JS function to dispatch an event on an element.
 func buildDispatchEventScript(ep ElementParams, eventType, initJSON string) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-		{"type": "string", "value": eventType},
-		{"type": "string", "value": initJSON},
-	}
-
-	script := `
-		(scope, selector, index, hasIndex, eventType, initJSON) => {
-			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'not found';
-			let el;
-			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
-			} else {
-				el = root.querySelector(selector);
-			}
-			if (!el) return 'not found';
-			const init = JSON.parse(initJSON);
-			el.dispatchEvent(new Event(eventType, init));
-			return 'ok';
-		}
-	`
-	return script, args
+	return buildScript(ep, scriptConfig{
+		cssSignature:      "(scope, selector, index, hasIndex, eventType, initJSON) => {",
+		semanticSignature: "(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex, eventType, initJSON) => {",
+		body:              dispatchEventBody(),
+		rootNotFound:      jsReturnNotFound,
+		elNotFound:        jsReturnNotFound,
+		extraArgs: []map[string]interface{}{
+			{"type": "string", "value": eventType},
+			{"type": "string", "value": initJSON},
+		},
+	})
 }
-

--- a/tests/js/async/interaction.test.js
+++ b/tests/js/async/interaction.test.js
@@ -58,6 +58,44 @@ describe('Interaction: Checkpoint', () => {
     assert.strictEqual(await first.isChecked(), false, 'First checkbox should be unchecked');
   });
 
+  test('checkbox: check and uncheck with xpath-only locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/checkboxes');
+
+    const first = await vibe.find({ xpath: "(//input[@type='checkbox'])[1]" });
+    await first.check();
+
+    let checked = await vibe.evaluate(`
+      document.querySelectorAll('input[type="checkbox"]')[0].checked;
+    `);
+    assert.strictEqual(checked, true, 'First checkbox should be checked via xpath');
+
+    await first.uncheck();
+    checked = await vibe.evaluate(`
+      document.querySelectorAll('input[type="checkbox"]')[0].checked;
+    `);
+    assert.strictEqual(checked, false, 'First checkbox should be unchecked via xpath');
+  });
+
+  test('checkbox: check and uncheck with semantic role locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/checkboxes');
+
+    const first = await vibe.find({ role: 'checkbox' });
+    await first.check();
+
+    let checked = await vibe.evaluate(`
+      document.querySelectorAll('input[type="checkbox"]')[0].checked;
+    `);
+    assert.strictEqual(checked, true, 'First checkbox should be checked via role');
+
+    await first.uncheck();
+    checked = await vibe.evaluate(`
+      document.querySelectorAll('input[type="checkbox"]')[0].checked;
+    `);
+    assert.strictEqual(checked, false, 'First checkbox should be unchecked via role');
+  });
+
   test('hover reveals hidden content', async () => {
     const vibe = await bro.page();
     await vibe.go(baseURL + '/hovers');
@@ -157,6 +195,44 @@ describe('Interaction: Input methods', () => {
     assert.strictEqual(value, '', 'clear() should empty the input');
   });
 
+  test('fill and clear work with xpath-only locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/login');
+
+    const username = await vibe.find({ xpath: "//input[@id='username']" });
+    await username.fill('xpath-value');
+
+    let value = await vibe.evaluate(`
+      document.getElementById('username').value;
+    `);
+    assert.strictEqual(value, 'xpath-value', 'fill() should work with xpath locator');
+
+    await username.clear();
+    value = await vibe.evaluate(`
+      document.getElementById('username').value;
+    `);
+    assert.strictEqual(value, '', 'clear() should work with xpath locator');
+  });
+
+  test('fill and clear work with role+label locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/login');
+
+    const username = await vibe.find({ role: 'textbox', label: 'Username' });
+    await username.fill('semantic-value');
+
+    let value = await vibe.evaluate(`
+      document.getElementById('username').value;
+    `);
+    assert.strictEqual(value, 'semantic-value', 'fill() should work with role+label locator');
+
+    await username.clear();
+    value = await vibe.evaluate(`
+      document.getElementById('username').value;
+    `);
+    assert.strictEqual(value, '', 'clear() should work with role+label locator');
+  });
+
   test('press sends key events', async () => {
     const vibe = await bro.page();
     await vibe.go(baseURL + '/login');
@@ -189,6 +265,32 @@ describe('Interaction: Select', () => {
     `);
     assert.strictEqual(value, '2', 'selectOption should set dropdown value');
   });
+
+  test('selectOption works with xpath-only locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/dropdown');
+
+    const dropdown = await vibe.find({ xpath: "//select[@id='dropdown']" });
+    await dropdown.selectOption('1');
+
+    const value = await vibe.evaluate(`
+      document.getElementById('dropdown').value;
+    `);
+    assert.strictEqual(value, '1', 'selectOption should work with xpath locator');
+  });
+
+  test('selectOption works with semantic role locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/dropdown');
+
+    const dropdown = await vibe.find({ role: 'combobox' });
+    await dropdown.selectOption('2');
+
+    const value = await vibe.evaluate(`
+      document.getElementById('dropdown').value;
+    `);
+    assert.strictEqual(value, '2', 'selectOption should work with role locator');
+  });
 });
 
 describe('Interaction: Focus', () => {
@@ -203,6 +305,32 @@ describe('Interaction: Focus', () => {
       document.activeElement ? document.activeElement.id : '';
     `);
     assert.strictEqual(activeId, 'username', 'focus() should set active element');
+  });
+
+  test('focus works with xpath-only locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/login');
+
+    const username = await vibe.find({ xpath: "//input[@id='username']" });
+    await username.focus();
+
+    const activeId = await vibe.evaluate(`
+      document.activeElement ? document.activeElement.id : '';
+    `);
+    assert.strictEqual(activeId, 'username', 'focus() should work with xpath locator');
+  });
+
+  test('focus works with role+label locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/login');
+
+    const username = await vibe.find({ role: 'textbox', label: 'Username' });
+    await username.focus();
+
+    const activeId = await vibe.evaluate(`
+      document.activeElement ? document.activeElement.id : '';
+    `);
+    assert.strictEqual(activeId, 'username', 'focus() should work with role+label locator');
   });
 });
 
@@ -275,6 +403,46 @@ describe('Interaction: dispatchEvent', () => {
       window.__eventFired;
     `);
     assert.strictEqual(fired, true, 'dispatchEvent should fire the event');
+  });
+
+  test('dispatchEvent works with xpath-only locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/login');
+
+    await vibe.evaluate(`
+      window.__userClicks = 0;
+      document.getElementById('username').addEventListener('click', () => {
+        window.__userClicks += 1;
+      });
+    `);
+
+    const username = await vibe.find({ xpath: "//input[@id='username']" });
+    await username.dispatchEvent('click', { bubbles: true });
+
+    const clicks = await vibe.evaluate(`
+      window.__userClicks;
+    `);
+    assert.strictEqual(clicks, 1, 'dispatchEvent should work with xpath locator');
+  });
+
+  test('dispatchEvent works with role+label locator', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/login');
+
+    await vibe.evaluate(`
+      window.__userClicks = 0;
+      document.getElementById('username').addEventListener('click', () => {
+        window.__userClicks += 1;
+      });
+    `);
+
+    const username = await vibe.find({ role: 'textbox', label: 'Username' });
+    await username.dispatchEvent('click', { bubbles: true });
+
+    const clicks = await vibe.evaluate(`
+      window.__userClicks;
+    `);
+    assert.strictEqual(clicks, 1, 'dispatchEvent should work with role+label locator');
   });
 });
 


### PR DESCRIPTION
## Summary

This PR Fixes #108  a selector-resolution mismatch in interaction script builders for non-CSS element locators.

Vibium already supports semantic element discovery (`role`, `text`, `label`, etc. include `xpath`) and actionability checks follow that model.  
However, several JS-backed interaction scripts re-resolved elements using CSS-only `querySelector(selector)`, which fails when semantic/xpath locators are used and `selector` is empty.

## Root Cause

`actionability.go` uses this branching philosophy:

- CSS path only when `!hasSemantic(ep) && ep.Selector != ""`
- semantic path otherwise

Some interaction builders in `handlers_interaction.go` did not mirror that rule and used CSS-only lookup in follow-up JS operations.

## Changes

### `clicker/internal/api/handlers_interaction.go`
- Aligned interaction script path selection with actionability philosophy:
  - CSS path only for strict CSS selector cases
  - semantic path otherwise
- Added shared script builder abstractions to avoid drift between CSS and semantic variants:
  - `scriptConfig`
  - `buildScript(...)`
  - `useCSSInteractionScript(...)`
  - shared JS body/open helpers

This keeps behavior consistent while reducing duplicated script assembly code.

### `tests/js/async/interaction.test.js`
Added coverage for non-CSS locators:

- **Input methods**
  - fill/clear with xpath-only locator
  - fill/clear with role+label locator

- **Select**
  - selectOption with xpath-only locator
  - selectOption with semantic role locator

- **Focus**
  - focus with xpath-only locator
  - focus with role+label locator

- **dispatchEvent**
  - dispatchEvent with xpath-only locator
  - dispatchEvent with role+label locator

- **Checkbox**
  - check/uncheck with xpath-only locator
  - check/uncheck with semantic role locator

## Why this matters

This closes a real gap between element discovery and action execution, making semantic workflows reliable across interaction APIs and preventing regressions with explicit tests.

## Validation

Executed:

```bash
node --test tests/js/async/interaction.test.js
```
<img width="545" height="690" alt="image" src="https://github.com/user-attachments/assets/e07a9659-fe3a-49b6-b15d-56e4dc4babf7" />
