### PR TITLE
Selenium Grid Support:  Allow Vibium to connect to an existing BiDi websocket session

### DIFF
--- a/clicker/internal/bidi/connect.go
+++ b/clicker/internal/bidi/connect.go
@@ -1,17 +1,31 @@
 package bidi
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
 
 // ConnectRemote connects to a remote BiDi endpoint, creates a client,
-// and establishes a session. Returns the connection, client, and session ID.
-func ConnectRemote(url string, headers http.Header) (*Connection, *Client, string, error) {
-	conn, err := ConnectWithHeaders(url, headers)
+// and either establishes a new session or attaches to an existing one
+// if the URL already contains /session/<sessionId>/.
+func ConnectRemote(rawURL string, headers http.Header) (*Connection, *Client, string, error) {
+	conn, err := ConnectWithHeaders(rawURL, headers)
 	if err != nil {
 		return nil, nil, "", err
 	}
 
 	client := NewClient(conn)
 
+	// If this is an existing-session BiDi URL like:
+	// ws://127.0.0.1:4444/session/<sessionId>/se/bidi
+	// then reuse that session ID instead of creating a new session.
+	if sessionID, ok := sessionIDFromBiDiURL(rawURL); ok {
+		return conn, client, sessionID, nil
+	}
+
+	// Otherwise create a new session.
 	result, err := client.SessionNew(map[string]interface{}{})
 	if err != nil {
 		conn.Close()
@@ -19,4 +33,20 @@ func ConnectRemote(url string, headers http.Header) (*Connection, *Client, strin
 	}
 
 	return conn, client, result.SessionID, nil
+}
+
+func sessionIDFromBiDiURL(rawURL string) (string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for i := 0; i < len(parts)-1; i++ {
+		if parts[i] == "session" && parts[i+1] != "" {
+			return parts[i+1], true
+		}
+	}
+
+	return "", false
 }

--- a/clicker/internal/bidi/connect.go
+++ b/clicker/internal/bidi/connect.go
@@ -1,7 +1,6 @@
 package bidi
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"


### PR DESCRIPTION
Not sure if a Vibium Grid is in the works, but given that Selenium Grid is an established open source BiDi enabled solution and Playwright has support for connecting to Selenium Grid, it seems that Vibium should support BiDi connections to Selenium Grid as well.  This would allow existing Selenium shops using Selenium Grid to more aggressively explore using Vibium.

Currently, Vibium attempts to create a new session when provided a websocket URL.  This does not work with Selenium Grid since a new session is already created on the Grid Node (normally handled by RemoteWebDriver and subsequent calls though Selenium's stack).

`@dev:~/Projects/vibiummain$ clicker/bin/vibium pipe --connect ws://localhost:4444/session/a2747d3ac11bd126fb4b8a8f85df2d69/se/bidi
[router] Connecting to remote browser for client 1: ws://localhost:4444/session/a2747d3ac11bd126fb4b8a8f85df2d69/se/bidi
[router] Failed to connect to remote browser for client 1: BiDi error: session not created - session not created
[pipe] Failed to send ready signal: pipe closed
`

connect.go does not support connecting to an existing session, only creation of new sessions.  This PR is targeted specifically at taking a Selenium Grid websocket URL, parsing for the sessionid, then allowing connect.go to connect to that existing session.

`@dev:~/Projects/vibium$ clicker/bin/vibium pipe --connect ws://localhost:4444/session/a2747d3ac11bd126fb4b8a8f85df2d69/se/bidi
[router] Connecting to remote browser for client 1: ws://localhost:4444/session/a2747d3ac11bd126fb4b8a8f85df2d69/se/bidi
[router] Remote BiDi connection established for client 1
{"method":"browsingContext.contextCreated","params":{"children":null,"clientWindow":"1675517167","context":"0755B6BC54FF61371797C4C456F549E6","originalOpener":null,"parent":null,"url":"about:blank","userContext":"default"},"type":"event"}
{"method":"vibium:lifecycle.ready","params":{"version":"26.3.18"}}`

Selenium Grid recognizes the connection:
`14:25:19.277 INFO [ProxyNodeWebsockets.createWsEndPoint] - Establishing connection to ws://localhost:6980/session/a2747d3ac11bd126fb4b8a8f85df2d69
`