### PR TITLE
fix(cli): forward binary exit status without dumping a Node stack trace

### DIFF
--- a/packages/vibium/bin/cli.js
+++ b/packages/vibium/bin/cli.js
@@ -23,4 +23,9 @@ function getVibiumBinPath() {
 const vibiumPath = getVibiumBinPath();
 const args = process.argv.slice(2);
 const binName = path.basename(process.argv[1] || 'vibium', path.extname(process.argv[1] || ''));
-execFileSync(vibiumPath, args, { stdio: 'inherit', argv0: binName });
+try {
+  execFileSync(vibiumPath, args, { stdio: 'inherit', argv0: binName });
+} catch (err) {
+  // Forward the binary's exit status without dumping a Node stack trace.
+  process.exit(typeof err.status === 'number' ? err.status : 1);
+}

--- a/tests/cli/wrapper-error-handling.test.js
+++ b/tests/cli/wrapper-error-handling.test.js
@@ -1,0 +1,75 @@
+/**
+ * CLI Wrapper Tests: error handling
+ *
+ * The JS wrapper at packages/vibium/bin/cli.js shells out to the platform
+ * binary via execFileSync. When the binary exits non-zero, the wrapper must
+ * forward the exit status without dumping a Node stack trace on the user.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execSync, execFileSync } = require('node:child_process');
+const { VIBIUM } = require('../helpers');
+
+function stopDaemon() {
+  try { execSync(`${VIBIUM} daemon stop`, { encoding: 'utf-8', timeout: 10000 }); } catch (e) {}
+}
+
+describe('CLI wrapper: forwards binary exit status without Node stack trace', () => {
+  before(() => {
+    stopDaemon();
+    execSync(`${VIBIUM} daemon start --headless`, { encoding: 'utf-8' });
+    execSync(`${VIBIUM} go https://example.com`, { encoding: 'utf-8' });
+  });
+
+  after(() => {
+    stopDaemon();
+  });
+
+  test('failing eval exits non-zero without Node trace', () => {
+    let err = null;
+    let stderr = '';
+    try {
+      execFileSync(VIBIUM, ['eval', 'throw new Error("boom")'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (e) {
+      err = e;
+      stderr = (e.stderr || '').toString();
+    }
+
+    assert.ok(err, 'eval that throws should cause non-zero exit');
+    assert.ok(typeof err.status === 'number' && err.status !== 0, `expected non-zero status, got ${err.status}`);
+    assert.ok(!stderr.includes('node:child_process'), `stderr should not contain a Node trace, got: ${stderr.slice(0, 400)}`);
+    assert.ok(!/Node\.js v\d+/.test(stderr), `stderr should not contain a Node version footer, got: ${stderr.slice(0, 400)}`);
+  });
+
+  test('failing eval --stdin exits non-zero without Node trace', () => {
+    let err = null;
+    let stderr = '';
+    try {
+      execFileSync(VIBIUM, ['eval', '--stdin'], {
+        input: 'throw new Error("boom")',
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (e) {
+      err = e;
+      stderr = (e.stderr || '').toString();
+    }
+
+    assert.ok(err, 'failing stdin eval should cause non-zero exit');
+    assert.ok(typeof err.status === 'number' && err.status !== 0, `expected non-zero status, got ${err.status}`);
+    assert.ok(!stderr.includes('node:child_process'), `stderr should not contain a Node trace, got: ${stderr.slice(0, 400)}`);
+    assert.ok(!/Node\.js v\d+/.test(stderr), `stderr should not contain a Node version footer, got: ${stderr.slice(0, 400)}`);
+  });
+
+  test('successful eval exits 0', () => {
+    const out = execFileSync(VIBIUM, ['eval', 'document.title'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    assert.ok(out.includes('Example Domain'), `expected Example Domain in output, got: ${out}`);
+  });
+});


### PR DESCRIPTION
## Why

`packages/vibium/bin/cli.js` shells out to the platform binary via `execFileSync`. When the binary exits non-zero (most commonly: an `eval` script that throws), Node treats the unhandled throw as a fatal error and prints its own stack trace plus a `Node.js v<X>` footer on top of the binary's already-inherited stderr. The user sees a confusing Node trace; the real cause is buried.

Reproducing on `main`:

```
$ vibium eval 'throw new Error("boom")'
Error: failed to evaluate: script exception:
node:child_process:964
    throw err;
    ^
Error: Command failed: vibium eval 'throw new Error("boom")'
    at genericNodeError (node:internal/errors:985:15)
    ...
Node.js v24.15.0
```

The first line is the real signal. Everything below is wrapper noise that shouldn't be there.

## What changed

`packages/vibium/bin/cli.js` — wrap the `execFileSync` call in try/catch and forward the binary's exit status. `stdio: 'inherit'` is unchanged so the binary's stderr still reaches the user; only the Node trace is suppressed.

```js
try {
  execFileSync(vibiumPath, args, { stdio: 'inherit', argv0: binName });
} catch (err) {
  process.exit(typeof err.status === 'number' ? err.status : 1);
}
```

After the fix:

```
$ vibium eval 'throw new Error("boom")'
Error: failed to evaluate: script exception:
$ echo $?
1
```

## How to test

`tests/cli/wrapper-error-handling.test.js` covers three cases against a real daemon:

- `eval` with a throwing script → non-zero exit, stderr free of `node:child_process` and `Node.js v<X>`
- `eval --stdin` with a throwing script → same
- `eval` with a passing script → exit 0, expected output

Run:

```bash
node --test tests/cli/wrapper-error-handling.test.js
```

All three pass locally on Linux x64 with the patched cli.js.

## Notes

- This wrapper ships in `packages/vibium/`. The published `vibium` npm package on this Linux box has the same untouched cli.js, so the fix applies to every install path.
- The same pattern exists at `packages/vibium/postinstall.js:31` (`execFileSync(vibiumPath, ['install'])` with no try/catch). The install failure surface is different and worth a separate change; not bundled here.