### PR TITLE
feat(skills): add 5-skill suite (recon, inventory, explore, screenshot-all, diff)

### DIFF
--- a/skills/vibe-diff/SKILL.md
+++ b/skills/vibe-diff/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: vibe-diff
+description: Compare two `vibe-inventory` snapshots and surface what changed — new routes, removed routes, new API endpoints, version bumps, permission tokens added or dropped. Use when periodically re-inventorying an app to catch drift, especially during a rebuild where you want to mirror upstream changes.
+---
+
+# Vibium Diff — what changed between two inventory snapshots
+
+`vibe-diff` takes two `skills/vibe-inventory` run directories and produces a one-page diff: routes added, routes removed, API endpoints added, API endpoints removed, version-string change, permission-token delta.
+
+The deliverable answers: **"what changed in this app since the last time I looked?"**
+
+## When to use this skill
+
+- Rebuilding a tool — re-run weekly during the rebuild to catch new functionality the original team ships in the meantime.
+- Audit cadence — monthly snapshot to track what a vendor is shipping.
+- Pre-deploy verification — diff a staging snapshot against production to confirm the change set.
+
+## How to run
+
+```bash
+skills/vibe-diff/diff.sh <old-run-dir> <new-run-dir> [--out DIFF.md]
+```
+
+Example:
+
+```bash
+skills/vibe-inventory/inventory.sh ./run-2026-04-15 https://example.com/
+# … two weeks pass …
+skills/vibe-inventory/inventory.sh ./run-2026-04-30 https://example.com/
+skills/vibe-diff/diff.sh ./run-2026-04-15 ./run-2026-04-30
+```
+
+## Pipeline
+
+1. **Read both run dirs**: each must have at minimum `api-endpoints.txt` and `frontend-route-patterns.txt` produced by `skills/vibe-inventory`.
+2. **Compute deltas** with `comm` / `diff`:
+   - frontend routes added / removed
+   - api endpoints added / removed (grouped by top-level path segment)
+   - permissions added / removed (from `permissions.txt`)
+3. **Detect version bump** — grep both `app.bundle.js` snapshots for `"v\d+\.\d+\.\d+"` and report any change.
+4. **Bundle size delta** — bytes diff between `app.bundle.js` files.
+5. **Write `DIFF.md`** in the new run dir (or to `--out`).
+
+## Deliverable: `DIFF.md`
+
+Required sections:
+
+1. **Summary line** — `+12 endpoints, -2 routes, version 1.1.334 → 1.2.0, bundle +120 KB`.
+2. **New endpoints** — table by API domain.
+3. **Removed endpoints** — table by API domain.
+4. **New routes** — list.
+5. **Removed routes** — list.
+6. **Permission tokens added / removed**.
+7. **Version + bundle-size delta**.
+8. **Triage notes** — operator-actionable notes ("the new `/api/Order/Cancel` suggests a feature shipped — check if it's user-facing").
+
+## Files in this skill
+
+| File | Purpose |
+|---|---|
+| `SKILL.md` | This file. |
+| `diff.sh` | Bash runner — pure file-based diff, no browser, no daemon. |
+
+## See also
+
+- `skills/vibe-inventory/SKILL.md` — produces the inputs `vibe-diff` consumes.
+- `skills/vibe-recon/SKILL.md` — for the auth-wall + edge map.

--- a/skills/vibe-diff/diff.sh
+++ b/skills/vibe-diff/diff.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# vibe-diff — diff two vibe-inventory snapshots. No browser, no daemon.
+# Usage: diff.sh <old-run-dir> <new-run-dir> [--out DIFF.md]
+
+set -uo pipefail
+
+OLD="${1:?old-run-dir required}"
+NEW="${2:?new-run-dir required}"
+OUT="$NEW/DIFF.md"
+
+shift 2
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out) OUT="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+for f in api-endpoints.txt frontend-route-patterns.txt; do
+  [ -f "$OLD/$f" ] || { echo "ERROR: $OLD/$f not found (run vibe-inventory first)" >&2; exit 1; }
+  [ -f "$NEW/$f" ] || { echo "ERROR: $NEW/$f not found (run vibe-inventory first)" >&2; exit 1; }
+done
+
+mktmp() { mktemp /tmp/vibe-diff.XXXXXX; }
+
+API_NEW=$(mktmp); API_REM=$(mktmp)
+ROUTE_NEW=$(mktmp); ROUTE_REM=$(mktmp)
+PERM_NEW=$(mktmp); PERM_REM=$(mktmp)
+
+comm -13 <(sort -u "$OLD/api-endpoints.txt") <(sort -u "$NEW/api-endpoints.txt") > "$API_NEW"
+comm -23 <(sort -u "$OLD/api-endpoints.txt") <(sort -u "$NEW/api-endpoints.txt") > "$API_REM"
+comm -13 <(sort -u "$OLD/frontend-route-patterns.txt") <(sort -u "$NEW/frontend-route-patterns.txt") > "$ROUTE_NEW"
+comm -23 <(sort -u "$OLD/frontend-route-patterns.txt") <(sort -u "$NEW/frontend-route-patterns.txt") > "$ROUTE_REM"
+
+if [ -f "$OLD/permissions.txt" ] && [ -f "$NEW/permissions.txt" ]; then
+  comm -13 <(sort -u "$OLD/permissions.txt") <(sort -u "$NEW/permissions.txt") > "$PERM_NEW"
+  comm -23 <(sort -u "$OLD/permissions.txt") <(sort -u "$NEW/permissions.txt") > "$PERM_REM"
+fi
+
+OLD_VER=$(grep -oE '"v[0-9]+\.[0-9]+\.[0-9]+"' "$OLD/app.bundle.js" 2>/dev/null | sort -u | head -1 | tr -d '"')
+NEW_VER=$(grep -oE '"v[0-9]+\.[0-9]+\.[0-9]+"' "$NEW/app.bundle.js" 2>/dev/null | sort -u | head -1 | tr -d '"')
+OLD_SIZE=$(wc -c < "$OLD/app.bundle.js" 2>/dev/null || echo 0)
+NEW_SIZE=$(wc -c < "$NEW/app.bundle.js" 2>/dev/null || echo 0)
+SIZE_DELTA=$((NEW_SIZE - OLD_SIZE))
+
+NEW_API_COUNT=$(wc -l < "$API_NEW")
+REM_API_COUNT=$(wc -l < "$API_REM")
+NEW_ROUTE_COUNT=$(wc -l < "$ROUTE_NEW")
+REM_ROUTE_COUNT=$(wc -l < "$ROUTE_REM")
+
+{
+  echo "# DIFF — $OLD → $NEW"
+  echo ""
+  echo "**Summary**: +${NEW_API_COUNT} endpoints / -${REM_API_COUNT} endpoints, +${NEW_ROUTE_COUNT} routes / -${REM_ROUTE_COUNT} routes, version ${OLD_VER:-?} → ${NEW_VER:-?}, bundle delta ${SIZE_DELTA} bytes"
+  echo ""
+
+  if [ "$NEW_API_COUNT" -gt 0 ]; then
+    echo "## New API endpoints (${NEW_API_COUNT})"
+    echo ""
+    awk -F'/' '{print "/" $3}' "$API_NEW" | sort | uniq -c | sort -rn | while read -r count domain; do
+      echo "### $domain ($count new)"
+      grep "^$domain" "$API_NEW" | sed 's/^/- `/;s/$/`/'
+      echo ""
+    done
+  fi
+
+  if [ "$REM_API_COUNT" -gt 0 ]; then
+    echo "## Removed API endpoints (${REM_API_COUNT})"
+    echo ""
+    awk -F'/' '{print "/" $3}' "$API_REM" | sort | uniq -c | sort -rn | while read -r count domain; do
+      echo "### $domain ($count removed)"
+      grep "^$domain" "$API_REM" | sed 's/^/- `/;s/$/`/'
+      echo ""
+    done
+  fi
+
+  if [ "$NEW_ROUTE_COUNT" -gt 0 ]; then
+    echo "## New frontend routes"
+    echo ""
+    sed 's/^/- `/;s/$/`/' "$ROUTE_NEW"
+    echo ""
+  fi
+  if [ "$REM_ROUTE_COUNT" -gt 0 ]; then
+    echo "## Removed frontend routes"
+    echo ""
+    sed 's/^/- `/;s/$/`/' "$ROUTE_REM"
+    echo ""
+  fi
+
+  if [ -s "$PERM_NEW" ]; then
+    echo "## New permission tokens"
+    echo ""
+    sed 's/^/- /' "$PERM_NEW"
+    echo ""
+  fi
+  if [ -s "$PERM_REM" ]; then
+    echo "## Removed permission tokens"
+    echo ""
+    sed 's/^/- /' "$PERM_REM"
+    echo ""
+  fi
+
+  echo "## Version + bundle"
+  echo ""
+  echo "| Metric | Old | New | Delta |"
+  echo "|---|---|---|---|"
+  echo "| Version | ${OLD_VER:-?} | ${NEW_VER:-?} | $([ "$OLD_VER" != "$NEW_VER" ] && echo CHANGED || echo same) |"
+  echo "| Bundle size | $OLD_SIZE | $NEW_SIZE | $SIZE_DELTA bytes |"
+  echo ""
+} > "$OUT"
+
+rm -f "$API_NEW" "$API_REM" "$ROUTE_NEW" "$ROUTE_REM" "$PERM_NEW" "$PERM_REM"
+
+echo "Wrote $OUT"

--- a/skills/vibe-explore/SKILL.md
+++ b/skills/vibe-explore/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: vibe-explore
+description: Browser exploration mode — clicks every safe interactive element on a page, classifies what each does, and produces a ranked "what you can do here" report. Use when the user lands on an unfamiliar tool, dashboard, or app and wants to know its capabilities without reading docs. Skips destructive actions (delete/submit/pay/sign-out/send) by default.
+---
+
+# Vibium Explore — "What can I do on this site?"
+
+`vibe-explore` is the mode for landing on an unfamiliar UI and asking *what does this thing do*. It clicks every safe interactive element on the page in turn, screenshots before and after, classifies the outcome, then produces a ranked capability map.
+
+This is the inverse of `vibe-check`: instead of executing a known plan against a known UI, you let the page tell you what it offers.
+
+## When to use this skill
+
+- An unfamiliar internal tool or SaaS dashboard — "what can I do here?"
+- Onboarding to a new app — capture the surface before reading docs.
+- Pre-test exploration — find clickable surface before writing test cases.
+- UX audit of a competitor or partner.
+
+## Hard safety rules (always applied unless `--include-destructive`)
+
+The mode skips any element whose visible text or `aria-label` matches a destructive pattern:
+
+- destructive: `delete`, `remove`, `drop`, `destroy`, `clear (all|cache|history)`, `reset`, `wipe`, `purge`, `archive`
+- auth: `sign out`, `log out`, `disconnect account`, `revoke`
+- payments: `submit`, `send`, `pay`, `charge`, `subscribe`, `confirm purchase`, `place order`, `checkout`, `buy`
+- comms: `send (email|message|notification|invite)`, `post`, `publish`, `tweet`, `reply (all)?`
+- DB: `truncate`, `migrate`, `seed`
+
+Always skipped:
+
+- form submit buttons (`type=submit` or any `<button>` inside a `<form>`)
+- `<a target="_blank">` links (would open new tabs)
+- external-origin `<a href>` links (would leave the site)
+- duplicate clickables (deduped by visible-text + selector)
+
+## How to run
+
+The skill ships a self-contained bash runner. From the repo root:
+
+```bash
+skills/vibe-explore/explore.sh <run-dir> <url> [--max N] [--include-destructive] [--auth-required]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--max N` | 30 | Cap on clicks. Hard limit so runs stay bounded. |
+| `--include-destructive` | off | Lift the destructive-action filter. **Off by default — safety first.** |
+| `--auth-required` | off | Pause for manual login in the headed Chrome window before clicking. |
+
+Example:
+
+```bash
+skills/vibe-explore/explore.sh ./run https://example.com/dashboard --max 20
+```
+
+## Pipeline
+
+1. **Resolve binary**: try `vibium` on PATH, fall back to `./clicker/bin/vibium`, fall back to `./node_modules/.bin/vibium`.
+2. **Daemon start** (idempotent — `vibium daemon start`).
+3. **Navigate** to the URL.
+4. **Auth pause** if `--auth-required` (operator signs in manually, hits Enter to resume).
+5. **Dismiss consent banner** — Usercentrics / OneTrust / Cookiebot / generic "Accept all" / shadow-DOM walk / force-hide as last resort.
+6. **Capture baseline** state (URL, title, modal count, body-text hash) + `before.png`.
+7. **Enumerate** all `button`, `[role=button]`, `[role=tab]`, `[role=menuitem]`, `[role=link]`, `a[href]` (same-origin), `[onclick]`, `.MuiButtonBase-root`. Apply the safety filter.
+8. **Click loop** — for each safe element, capture before-state, click, sleep 1.5s, capture after-state, classify outcome, screenshot, reset to baseline.
+9. **Write `EXPLORE.md`** in the run dir.
+
+## Outcome taxonomy
+
+| Outcome | Detected by |
+|---|---|
+| `navigation` | URL changed (same origin) |
+| `external` | URL changed (different origin); reset to baseline |
+| `modal` | new visible `[role=dialog]` / `.modal` count > before |
+| `inline-disclosure` | URL same, body-text-hash changed (accordion/menu opened) |
+| `route-error` | URL ends in `/error` or `/404`, or page contains "page not found" / "something went wrong" / "forbidden" / "unauthorized" |
+| `noop` | URL same, body-text-hash same — button does nothing observable |
+| `click_failed` | element couldn't be clicked (off-screen / detached / obscured) |
+
+## Reset between clicks
+
+| Outcome | Reset |
+|---|---|
+| `navigation` / `external` / `route-error` / `click_failed` | `vibium go <baseline>` + 2s sleep |
+| `modal` | `vibium keys Escape`; if still up, navigate baseline |
+| `inline-disclosure` | click the same element again to collapse; if that fails, navigate baseline |
+| `noop` | no reset needed |
+
+## Deliverable: `EXPLORE.md`
+
+Required sections:
+
+1. **Header** — URL, time, total clickables found / safe / clicked / skipped.
+2. **Capability map** — table of every clicked element with ordinal, label, outcome, leads-to URL, screenshot links.
+3. **Skipped (and why)** — table of every filtered element so the operator can decide if any deserve manual review.
+4. **What you can do here** — the deliverable section. Ranked, grouped by intent (not by DOM order).
+5. **Coverage gaps** — what the page hints at but the explorer couldn't reach without different auth or input.
+6. **State pollution** — what side effects this run created (audit logs, GA pageviews, last-viewed lists). The operator should know.
+
+## What this skill does NOT do
+
+- **No form filling.** If a button reveals an input, the report notes "form revealed: <field labels>" and moves on.
+- **No drags, scroll-jacking, or hover-only interactions.** Clicks only.
+- **No new tabs.** Single-tab discipline; if a click opens a new tab despite the filter, close it and continue from the baseline tab.
+- **No automatic re-login** if a session expires mid-run. Bails with a clear message instead.
+
+## Files in this skill
+
+| File | Purpose |
+|---|---|
+| `SKILL.md` | This file. |
+| `explore.sh` | Bash runner — orchestrates the pipeline. |
+| `enumerate-clickables.js` | Finds + safety-filters all clickables on the page. Returns JSON. |
+| `probe-state.js` | Captures `{ url, title, modal_count, body_text_hash, error_visible }` before/after each click. |
+| `dismiss-consent.js` | 4-strategy consent-banner dismissal: visible-button text-match → vendor-specific (Usercentrics / OneTrust / Cookiebot) → shadow-DOM walk → force-hide-CSS as last resort. |
+
+The JS helpers are pure browser scripts — `vibium eval --stdin` runs them. Only `explore.sh` is platform-dependent (bash + jq).
+
+## Safe-by-default examples
+
+```bash
+# Public marketing site, no auth, default cap of 30 clicks
+skills/vibe-explore/explore.sh ./run https://example.com
+
+# Internal SaaS — pause for manual login
+skills/vibe-explore/explore.sh ./run https://app.example.com --auth-required
+
+# Tighter exploration of a specific section
+skills/vibe-explore/explore.sh ./run https://example.com/products --max 15
+
+# Lift the safety filter (use with care — can submit forms, send messages, etc.)
+skills/vibe-explore/explore.sh ./run https://staging.example.com --include-destructive
+```
+
+## See also
+
+- `skills/vibe-check/SKILL.md` — full Vibium CLI reference for executing known plans.
+- `docs/tutorials/getting-started-mcp.md` — for AI-agent integration via MCP.

--- a/skills/vibe-explore/dismiss-consent.js
+++ b/skills/vibe-explore/dismiss-consent.js
@@ -1,0 +1,115 @@
+// Dismiss the most common cookie/consent banners so a click loop can run.
+// Strategy ladder: prefer clicking the visible button (works on most vendors).
+// Fall through to vendor-specific APIs only when nothing visible matches.
+// Force-hide CSS as last resort if a banner persists.
+// Returns JSON: { dismissed: bool, vendor: string|null, attempts: [...] }
+
+(() => {
+  const attempts = [];
+
+  const isVisible = (el) => {
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) return false;
+    const s = getComputedStyle(el);
+    if (s.visibility === 'hidden' || s.display === 'none' || parseFloat(s.opacity) === 0) return false;
+    return true;
+  };
+
+  const bannerStillUp = () => {
+    const re = /\b(cookie|consent|privacy|tracking|gdpr)\b/i;
+    return [...document.querySelectorAll('*')].some(el => {
+      if (!isVisible(el)) return false;
+      const s = getComputedStyle(el);
+      const z = parseInt(s.zIndex, 10);
+      if (!(s.position === 'fixed' || s.position === 'sticky') || isNaN(z) || z < 100) return false;
+      if (el.offsetHeight < 100 || el.offsetWidth < 200) return false;
+      const txt = (el.innerText || '').slice(0, 1000);
+      return re.test(txt);
+    });
+  };
+
+  // Strategy A: visible button text-match (most reliable across vendors)
+  const TEXT_RE = /^(accept(\s| )+all(\s| )*(cookies?)?|accept(\s| )+cookies?|allow(\s| )+all|i(\s| )+agree|got(\s| )+it|consent|i(\s| )+understand|continue|ok(ay)?)$/i;
+  const allClickable = [...document.querySelectorAll('button, a[role=button], [role=button], [data-testid*=accept i], [aria-label*=accept i]')];
+  const visibleAccept = allClickable.find(el => {
+    if (!isVisible(el)) return false;
+    const t = (el.innerText || el.getAttribute('aria-label') || '').replace(/\s+/g, ' ').trim();
+    return TEXT_RE.test(t);
+  });
+  if (visibleAccept) {
+    visibleAccept.click();
+    attempts.push({ strategy: 'visible-text', text: visibleAccept.innerText.slice(0, 60), clicked: true });
+    return JSON.stringify({ dismissed: true, vendor: 'visible-text', attempts });
+  }
+  attempts.push({ strategy: 'visible-text', clicked: false });
+
+  // Strategy B: vendor-specific selectors
+  const ot = document.querySelector('#onetrust-accept-btn-handler');
+  if (ot && isVisible(ot)) {
+    ot.click();
+    attempts.push({ strategy: 'onetrust-button', clicked: true });
+    return JSON.stringify({ dismissed: true, vendor: 'onetrust', attempts });
+  }
+  const cb = document.querySelector('#CybotCookiebotDialogBodyButtonAccept, #CybotCookiebotDialogBodyLevelButtonAccept');
+  if (cb && isVisible(cb)) {
+    cb.click();
+    attempts.push({ strategy: 'cookiebot-button', clicked: true });
+    return JSON.stringify({ dismissed: true, vendor: 'cookiebot', attempts });
+  }
+  const ucHost = document.querySelector('uc-consent-banner, uc-consent-modal, #usercentrics-root, [id*=usercentrics i]');
+  if (ucHost && ucHost.shadowRoot) {
+    const ucBtn = ucHost.shadowRoot.querySelector('[data-testid*=accept-all i], button[aria-label*=accept i]');
+    if (ucBtn) {
+      ucBtn.click();
+      attempts.push({ strategy: 'usercentrics-shadow', clicked: true });
+      return JSON.stringify({ dismissed: true, vendor: 'usercentrics-shadow', attempts });
+    }
+  }
+  try {
+    if (window.UC_UI && typeof window.UC_UI.acceptAllConsents === 'function') {
+      window.UC_UI.acceptAllConsents();
+      attempts.push({ strategy: 'usercentrics-api', called: true });
+      if (!bannerStillUp()) {
+        return JSON.stringify({ dismissed: true, vendor: 'usercentrics-api', attempts });
+      }
+      attempts.push({ strategy: 'usercentrics-api', note: 'API set consent but banner still visible' });
+    }
+  } catch (e) {
+    attempts.push({ strategy: 'usercentrics-api', error: String(e).slice(0, 80) });
+  }
+
+  // Strategy C: walk every shadow root looking for an accept-button
+  const allElements = document.querySelectorAll('*');
+  for (const el of allElements) {
+    if (!el.shadowRoot) continue;
+    const btn = el.shadowRoot.querySelector('button[aria-label*=accept i], button[id*=accept i], [data-testid*=accept i]');
+    if (btn && isVisible(btn)) {
+      btn.click();
+      attempts.push({ strategy: 'shadow-walk', host: el.tagName, clicked: true });
+      return JSON.stringify({ dismissed: true, vendor: 'shadow-walk', attempts });
+    }
+  }
+  attempts.push({ strategy: 'shadow-walk', clicked: false });
+
+  // Strategy D: force-hide CSS as last resort. Does not record consent;
+  // just unblocks the UI so the click loop can proceed.
+  if (bannerStillUp()) {
+    const overlays = [...document.querySelectorAll('*')].filter(el => {
+      if (!isVisible(el)) return false;
+      const s = getComputedStyle(el);
+      const z = parseInt(s.zIndex, 10);
+      if (!(s.position === 'fixed' || s.position === 'sticky') || isNaN(z) || z < 100) return false;
+      if (el.offsetHeight < 100 || el.offsetWidth < 200) return false;
+      const txt = (el.innerText || '').slice(0, 1000);
+      return /\b(cookie|consent|privacy|tracking|gdpr)\b/i.test(txt);
+    });
+    overlays.forEach(el => { el.style.setProperty('display', 'none', 'important'); });
+    if (overlays.length > 0) {
+      attempts.push({ strategy: 'force-hide-css', count: overlays.length });
+      return JSON.stringify({ dismissed: true, vendor: 'force-hide-css', attempts });
+    }
+  }
+
+  return JSON.stringify({ dismissed: false, vendor: null, attempts });
+})()

--- a/skills/vibe-explore/enumerate-clickables.js
+++ b/skills/vibe-explore/enumerate-clickables.js
@@ -1,0 +1,129 @@
+// Enumerate every interactive element on the current page, classified by safety.
+// Usage: cat enumerate-clickables.js | vibium eval --stdin
+// Returns JSON: { clickables: [{ ord, label, selector, tag, href, safe, skip_reason }], summary }
+//
+// To lift the destructive-action filter, replace `INCLUDE_DESTRUCTIVE = false` with
+// `INCLUDE_DESTRUCTIVE = true` before piping (the runner does this for `--include-destructive`).
+
+(() => {
+  const INCLUDE_DESTRUCTIVE = false;
+
+  const DESTRUCTIVE_RE = /\b(delete|remove|drop|destroy|clear (all|cache|history)|reset|wipe|purge|archive|sign\s*out|log\s*out|disconnect account|revoke|submit|send|pay|charge|subscribe|confirm purchase|place order|checkout|buy|post|publish|tweet|reply( all)?|truncate|migrate|seed)\b/i;
+
+  const cssEscape = (s) => (window.CSS && CSS.escape) ? CSS.escape(s) : String(s).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+
+  const buildSelector = (el) => {
+    if (el.id) return `#${cssEscape(el.id)}`;
+    const path = [];
+    let cur = el;
+    while (cur && cur.nodeType === 1 && cur.tagName !== 'HTML' && path.length < 6) {
+      let part = cur.tagName.toLowerCase();
+      if (cur.className && typeof cur.className === 'string') {
+        const cls = cur.className.split(/\s+/).filter(Boolean).slice(0, 2).map(cssEscape).join('.');
+        if (cls) part += '.' + cls;
+      }
+      const parent = cur.parentNode;
+      if (parent) {
+        const sibs = [...parent.children].filter(c => c.tagName === cur.tagName);
+        if (sibs.length > 1) part += `:nth-of-type(${sibs.indexOf(cur) + 1})`;
+      }
+      path.unshift(part);
+      cur = cur.parentNode;
+    }
+    return path.join(' > ');
+  };
+
+  const isVisible = (el) => {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) return false;
+    const style = getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.display === 'none' || parseFloat(style.opacity) === 0) return false;
+    return true;
+  };
+
+  const labelOf = (el) => {
+    const aria = el.getAttribute('aria-label');
+    if (aria && aria.trim()) return aria.trim();
+    const txt = (el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
+    if (txt) return txt.slice(0, 80);
+    const title = el.getAttribute('title');
+    if (title) return title.trim();
+    const placeholder = el.getAttribute('placeholder');
+    if (placeholder) return placeholder.trim();
+    return '(unlabeled)';
+  };
+
+  const candidates = new Set();
+  const sel = [
+    'button',
+    '[role="button"]',
+    '[role="tab"]',
+    '[role="menuitem"]',
+    '[role="link"]',
+    'a[href]',
+    '[onclick]',
+    '.MuiButtonBase-root',
+  ].join(', ');
+  document.querySelectorAll(sel).forEach(el => candidates.add(el));
+
+  const seen = new Set();
+  const result = [];
+  let ord = 0;
+
+  for (const el of candidates) {
+    if (!isVisible(el)) continue;
+
+    const label = labelOf(el);
+    const selector = buildSelector(el);
+    const tag = el.tagName.toLowerCase();
+    const href = el.getAttribute('href');
+    const target = el.getAttribute('target');
+    const dedupKey = label.toLowerCase() + '|' + selector;
+
+    if (seen.has(dedupKey)) continue;
+    seen.add(dedupKey);
+
+    let safe = true;
+    let skip_reason = null;
+
+    if (tag === 'a' && target === '_blank') {
+      safe = false;
+      skip_reason = 'opens new tab';
+    }
+    if (safe && tag === 'a' && href && /^https?:\/\//i.test(href)) {
+      try {
+        const u = new URL(href, location.href);
+        if (u.origin !== location.origin) {
+          safe = false;
+          skip_reason = `external origin (${u.origin})`;
+        }
+      } catch (e) {}
+    }
+    if (safe && (el.getAttribute('type') === 'submit' || (tag === 'button' && el.closest('form')))) {
+      safe = false;
+      skip_reason = 'form submit';
+    }
+    if (safe && !INCLUDE_DESTRUCTIVE && DESTRUCTIVE_RE.test(label)) {
+      safe = false;
+      skip_reason = 'destructive: matches banned-words';
+    }
+    if (safe && label === '(unlabeled)') {
+      safe = false;
+      skip_reason = 'unlabeled — needs human review';
+    }
+
+    ord += 1;
+    result.push({ ord, label, selector, tag, href: href || null, safe, skip_reason });
+  }
+
+  const summary = {
+    total: result.length,
+    safe: result.filter(r => r.safe).length,
+    skipped_destructive: result.filter(r => r.skip_reason && r.skip_reason.startsWith('destructive')).length,
+    skipped_external: result.filter(r => r.skip_reason && (r.skip_reason.includes('new tab') || r.skip_reason.includes('external'))).length,
+    skipped_form: result.filter(r => r.skip_reason === 'form submit').length,
+    skipped_unlabeled: result.filter(r => r.skip_reason && r.skip_reason.startsWith('unlabeled')).length,
+  };
+
+  return JSON.stringify({ clickables: result, summary });
+})()

--- a/skills/vibe-explore/explore.sh
+++ b/skills/vibe-explore/explore.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# vibe-explore — clicks every safe interactive element on a page, classifies what each does,
+# and produces a ranked "what you can do here" report.
+#
+# Usage: explore.sh <run-dir> <url> [--max N] [--include-destructive] [--auth-required]
+
+set -uo pipefail
+
+RUN_DIR="${1:?run-dir required}"
+BASE_URL="${2:?url required}"
+shift 2
+
+MAX_CLICKS=30
+INCLUDE_DESTRUCTIVE=false
+AUTH_REQUIRED=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --max) MAX_CLICKS="$2"; shift 2 ;;
+    --include-destructive) INCLUDE_DESTRUCTIVE=true; shift ;;
+    --auth-required) AUTH_REQUIRED=true; shift ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Locate the vibium binary (mirrors vibe-check resolution)
+if command -v vibium >/dev/null 2>&1; then
+  VIBIUM=vibium
+elif [ -x ./clicker/bin/vibium ]; then
+  VIBIUM=./clicker/bin/vibium
+elif [ -x ./node_modules/.bin/vibium ]; then
+  VIBIUM=./node_modules/.bin/vibium
+else
+  echo "ERROR: cannot find vibium binary on PATH or in repo dev locations" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required (sudo apt install jq / brew install jq)" >&2
+  exit 1
+fi
+
+mkdir -p "$RUN_DIR/routes"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOG="$RUN_DIR/explore.log"
+RESULTS="$RUN_DIR/results.jsonl"
+: > "$LOG"
+: > "$RESULTS"
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" | tee -a "$LOG"; }
+
+log "vibe-explore starting"
+log "  base_url=$BASE_URL"
+log "  max_clicks=$MAX_CLICKS"
+log "  include_destructive=$INCLUDE_DESTRUCTIVE"
+log "  auth_required=$AUTH_REQUIRED"
+
+# 1. Daemon (idempotent)
+$VIBIUM daemon start >/dev/null 2>&1 || true
+
+# 2. Navigate
+log "navigating to $BASE_URL"
+$VIBIUM go "$BASE_URL" >/dev/null 2>&1 || { log "ERROR: navigate failed"; exit 1; }
+sleep 3
+
+# 3. Auth gate
+if [ "$AUTH_REQUIRED" = true ]; then
+  log "auth_required=true; pausing for operator login"
+  echo ""
+  echo "==> Sign in via the headed Chrome window. Press Enter when you're past the wall."
+  read -r _
+  log "operator confirmed login"
+  $VIBIUM go "$BASE_URL" >/dev/null 2>&1
+  sleep 2
+fi
+
+# 4. Dismiss consent banner
+log "attempting to dismiss consent banner"
+$VIBIUM eval --stdin < "$HERE/dismiss-consent.js" > "$RUN_DIR/consent.json" 2>/dev/null
+DISMISSED=$(jq -r '.dismissed' "$RUN_DIR/consent.json" 2>/dev/null)
+VENDOR=$(jq -r '.vendor // "none"' "$RUN_DIR/consent.json" 2>/dev/null)
+log "  consent dismissed=$DISMISSED  vendor=$VENDOR"
+sleep 1
+
+# 5. Capture baseline
+log "capturing baseline"
+$VIBIUM eval --stdin < "$HERE/probe-state.js" > "$RUN_DIR/baseline.json" 2>/dev/null
+$VIBIUM screenshot -o before.png >/dev/null 2>&1 || true
+[ -f "$HOME/Pictures/Vibium/before.png" ] && mv "$HOME/Pictures/Vibium/before.png" "$RUN_DIR/before.png"
+BASELINE_URL=$(jq -r '.url // empty' "$RUN_DIR/baseline.json")
+log "  baseline_url=$BASELINE_URL"
+
+# 6. Enumerate clickables
+log "enumerating clickables"
+ENUM_SCRIPT="$RUN_DIR/enumerate.js"
+cp "$HERE/enumerate-clickables.js" "$ENUM_SCRIPT"
+[ "$INCLUDE_DESTRUCTIVE" = true ] && sed -i.bak 's/INCLUDE_DESTRUCTIVE = false/INCLUDE_DESTRUCTIVE = true/' "$ENUM_SCRIPT" && rm -f "$ENUM_SCRIPT.bak"
+
+$VIBIUM eval --stdin < "$ENUM_SCRIPT" > "$RUN_DIR/clickables.json" 2>/dev/null
+TOTAL=$(jq -r '.summary.total' "$RUN_DIR/clickables.json")
+SAFE=$(jq -r '.summary.safe' "$RUN_DIR/clickables.json")
+log "  found total=$TOTAL safe=$SAFE"
+
+# 7. Click loop
+log "click loop starting (cap=$MAX_CLICKS)"
+CLICKED=0
+jq -c '.clickables[] | select(.safe == true)' "$RUN_DIR/clickables.json" | while read -r row; do
+  if [ "$CLICKED" -ge "$MAX_CLICKS" ]; then
+    log "reached --max=$MAX_CLICKS, stopping"
+    break
+  fi
+  ORD=$(echo "$row" | jq -r '.ord')
+  LABEL=$(echo "$row" | jq -r '.label')
+  SELECTOR=$(echo "$row" | jq -r '.selector')
+
+  SLUG=$(printf '%s' "$LABEL" | tr 'A-Z' 'a-z' | sed 's/[^a-z0-9]\+/-/g; s/^-//; s/-$//' | cut -c1-40)
+  [ -z "$SLUG" ] && SLUG="ord$ORD"
+  PREFIX=$(printf '%03d-%s' "$ORD" "$SLUG")
+
+  log "[$ORD] click \"$LABEL\""
+
+  $VIBIUM screenshot -o "${PREFIX}-before.png" >/dev/null 2>&1
+  [ -f "$HOME/Pictures/Vibium/${PREFIX}-before.png" ] && mv "$HOME/Pictures/Vibium/${PREFIX}-before.png" "$RUN_DIR/routes/${PREFIX}-before.png"
+  $VIBIUM eval --stdin < "$HERE/probe-state.js" > "$RUN_DIR/routes/${PREFIX}-before.json" 2>/dev/null
+
+  CLICK_OUT=$($VIBIUM click "$SELECTOR" 2>&1)
+  CLICK_OK=$?
+  if [ $CLICK_OK -ne 0 ]; then
+    log "  click failed: $CLICK_OUT"
+    echo "{\"ord\":$ORD,\"label\":$(jq -Rs <<<"$LABEL"),\"outcome\":\"click_failed\",\"detail\":$(jq -Rs <<<"$CLICK_OUT")}" >> "$RESULTS"
+    CLICKED=$((CLICKED + 1))
+    continue
+  fi
+  sleep 1.5
+
+  $VIBIUM eval --stdin < "$HERE/probe-state.js" > "$RUN_DIR/routes/${PREFIX}-after.json" 2>/dev/null
+  $VIBIUM screenshot -o "${PREFIX}-after.png" >/dev/null 2>&1
+  [ -f "$HOME/Pictures/Vibium/${PREFIX}-after.png" ] && mv "$HOME/Pictures/Vibium/${PREFIX}-after.png" "$RUN_DIR/routes/${PREFIX}-after.png"
+
+  BEFORE_URL=$(jq -r '.url' "$RUN_DIR/routes/${PREFIX}-before.json")
+  AFTER_URL=$(jq -r '.url' "$RUN_DIR/routes/${PREFIX}-after.json")
+  BEFORE_HASH=$(jq -r '.body_text_hash' "$RUN_DIR/routes/${PREFIX}-before.json")
+  AFTER_HASH=$(jq -r '.body_text_hash' "$RUN_DIR/routes/${PREFIX}-after.json")
+  BEFORE_MOD=$(jq -r '.modal_count' "$RUN_DIR/routes/${PREFIX}-before.json")
+  AFTER_MOD=$(jq -r '.modal_count' "$RUN_DIR/routes/${PREFIX}-after.json")
+  AFTER_ERR=$(jq -r '.error_visible' "$RUN_DIR/routes/${PREFIX}-after.json")
+
+  OUTCOME=unknown
+  if [ "$AFTER_ERR" = "true" ]; then
+    OUTCOME=route-error
+  elif [ "$AFTER_URL" != "$BEFORE_URL" ]; then
+    BEFORE_ORIGIN=$(printf '%s' "$BEFORE_URL" | awk -F/ '{print $1"//"$3}')
+    AFTER_ORIGIN=$(printf '%s' "$AFTER_URL"  | awk -F/ '{print $1"//"$3}')
+    [ "$BEFORE_ORIGIN" != "$AFTER_ORIGIN" ] && OUTCOME=external || OUTCOME=navigation
+  elif [ "$AFTER_MOD" -gt "$BEFORE_MOD" ]; then
+    OUTCOME=modal
+  elif [ "$AFTER_HASH" != "$BEFORE_HASH" ]; then
+    OUTCOME=inline-disclosure
+  else
+    OUTCOME=noop
+  fi
+
+  log "  outcome=$OUTCOME"
+  echo "{\"ord\":$ORD,\"label\":$(jq -Rs <<<"$LABEL"),\"selector\":$(jq -Rs <<<"$SELECTOR"),\"outcome\":\"$OUTCOME\",\"before_url\":$(jq -Rs <<<"$BEFORE_URL"),\"after_url\":$(jq -Rs <<<"$AFTER_URL"),\"before_screenshot\":\"routes/${PREFIX}-before.png\",\"after_screenshot\":\"routes/${PREFIX}-after.png\"}" >> "$RESULTS"
+
+  case "$OUTCOME" in
+    navigation|route-error|external|click_failed)
+      $VIBIUM go "$BASELINE_URL" >/dev/null 2>&1
+      sleep 2
+      ;;
+    modal)
+      $VIBIUM keys Escape >/dev/null 2>&1
+      sleep 1
+      AFTER_MOD2=$($VIBIUM eval --stdin < "$HERE/probe-state.js" 2>/dev/null | jq -r '.modal_count // 0')
+      if [ "${AFTER_MOD2:-0}" -gt "$BEFORE_MOD" ]; then
+        $VIBIUM go "$BASELINE_URL" >/dev/null 2>&1
+        sleep 2
+      fi
+      ;;
+    inline-disclosure)
+      $VIBIUM click "$SELECTOR" >/dev/null 2>&1 || $VIBIUM go "$BASELINE_URL" >/dev/null 2>&1
+      sleep 1
+      ;;
+    *)
+      :
+      ;;
+  esac
+
+  CLICKED=$((CLICKED + 1))
+done
+
+log "click loop done. clicked=$CLICKED  results in $RESULTS"
+log "next step: read $RESULTS + screenshots and write EXPLORE.md"

--- a/skills/vibe-explore/probe-state.js
+++ b/skills/vibe-explore/probe-state.js
@@ -1,0 +1,19 @@
+// Capture page state for before/after comparison in explore mode.
+// Usage: cat probe-state.js | vibium eval --stdin
+// Returns JSON: { url, title, modal_count, body_text_hash, body_text_sample, error_visible }
+
+(() => {
+  const url = location.href;
+  const title = document.title;
+  const modal_count = document.querySelectorAll('[role="dialog"], .modal, [class*="modal" i]:not([class*="modalcontent"])').length;
+  const body_text = (document.body.innerText || '').replace(/\s+/g, ' ').trim();
+  let h = 5381;
+  for (let i = 0; i < body_text.length; i++) {
+    h = ((h << 5) + h) ^ body_text.charCodeAt(i);
+  }
+  const body_text_hash = (h >>> 0).toString(16);
+  const body_text_sample = body_text.slice(0, 200);
+  const err_re = /sorry,?\s*it.s not you|page not found|something went wrong|forbidden|unauthori[sz]ed|access denied/i;
+  const error_visible = err_re.test(body_text) || /\/(error|404)(\?|$|\/)/.test(url);
+  return JSON.stringify({ url, title, modal_count, body_text_hash, body_text_sample, error_visible });
+})()

--- a/skills/vibe-inventory/SKILL.md
+++ b/skills/vibe-inventory/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: vibe-inventory
+description: Walk every visible route of a SPA, capture per-route status (200 / /error / 404), screenshot each, and grep the JS bundle for backend API endpoints + role/permission strings. Produces an INVENTORY.md feature map. Use when handed a tool you need to understand structurally — what routes exist, what each does, what the backend API surface looks like, what the role model is.
+---
+
+# Vibium Inventory — full feature map of a SPA
+
+`vibe-inventory` produces the structural map of a single-page app: every route declared by the bundle, walked end-to-end, classified by per-route status, screenshotted, with a backend API surface extracted from the bundle by grep.
+
+The deliverable answers: **"what does this app do, how is it organized, and what's the backend it talks to?"**
+
+## When to use this skill
+
+- New tool or dashboard — capture routes + API surface in one shot.
+- Pre-rebuild scoping — produce an inventory the new app's team can work from.
+- Permission audit — surface every role / capability string declared in the bundle.
+- Drift detection — periodic snapshots compared via `skills/vibe-diff` to catch new routes/endpoints.
+
+## How to run
+
+```bash
+skills/vibe-inventory/inventory.sh <run-dir> <url> [--max-routes N] [--auth-required]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--max-routes N` | 30 | Cap on routes walked. Hard limit so runs stay bounded. |
+| `--auth-required` | off | Pause for manual login in the headed Chrome window before walking. |
+
+## Pipeline
+
+1. **Resolve binary**.
+2. **Daemon start** (idempotent).
+3. **Navigate** to the URL.
+4. **Auth pause** if `--auth-required` (operator signs in, hits Enter).
+5. **Bundle grep**: pull the SPA's main JS bundle, extract React Router `path:"…"` patterns and `/api/*` endpoint references. Also extract permission tokens (`Word:Word:Word` patterns like `Portal:View:Order`) and role names.
+6. **Build route candidate list** from bundle paths + sidebar/nav links visible in the DOM.
+7. **Walk each route** (capped at `--max-routes`), capturing per-route: landed URL, page title, headings, tables, MUI DataGrids, inputs, buttons, error state, body-text excerpt, screenshot.
+8. **Classify**: `accessible` / `gated` (URL ends in `/error`) / `dev-leak` (Page not found from a bundle-declared path).
+9. **Write `INVENTORY.md`** in the run dir.
+
+## Bulk-extraction guardrail
+
+For routes that show data tables, capture **first page only** (≤10 rows). Bulk pagination is not in scope; use the app's own export flow for full data dumps.
+
+## Deliverable: `INVENTORY.md`
+
+Required sections:
+
+1. **Header** — URL, time, role/identity if visible.
+2. **Stack & external dependencies** — auth, hosting, embedded SDKs (PowerBI, OpenCV, Auth0, etc.) inferred from CSP + bundle.
+3. **Auth flow** — provider chain.
+4. **Role & permission model** — every `Word:Word:Word` pattern + every role name found in the bundle.
+5. **Sidebar / navigation tree** — top-level sections + children.
+6. **Backend API surface** — `/api/*` endpoints, grouped by top-level path segment.
+7. **Feature modules** — each module with route + key endpoints.
+8. **Known issues / gaps** — `/error` redirects, 404s on bundle-declared paths, permission boundaries hit.
+9. **Data-model hints** — entity relationships inferred from endpoint names.
+10. **Concrete artifacts on disk** — file inventory of the run dir.
+
+## Reference run shape
+
+```
+run/
+├── INVENTORY.md
+├── app.bundle.js                # snapshotted JS bundle for grep
+├── api-endpoints.txt            # one /api/* path per line, sorted unique
+├── frontend-route-patterns.txt  # one React Router path per line
+├── api-domains.txt              # api endpoints grouped by top-level segment with counts
+├── walk.log                     # per-route landing URL + status
+├── routes/
+│   ├── home.json                # JSON probe of the home route
+│   ├── home.png                 # screenshot of the home route
+│   └── …                        # per-route, slug-named
+└── inventory.log
+```
+
+## Files in this skill
+
+| File | Purpose |
+|---|---|
+| `SKILL.md` | This file. |
+| `inventory.sh` | Bash runner — orchestrates pipeline. |
+| `bundle-grep.sh` | Pulls bundle + extracts routes, endpoints, permission strings. |
+| `walk.sh` | Walks a list of routes, JSON probe + screenshot per route. |
+| `probe.js` | Standard DOM probe (URL, title, headings, tables, MuiDataGrid, inputs, buttons, body text). |
+
+## See also
+
+- `skills/vibe-recon/SKILL.md` — for the auth-wall + edge map without login.
+- `skills/vibe-explore/SKILL.md` — for what-the-page-actually-lets-you-do (clicks elements rather than walking declared routes).
+- `skills/vibe-diff/SKILL.md` — for periodic re-inventories to catch drift.

--- a/skills/vibe-inventory/bundle-grep.sh
+++ b/skills/vibe-inventory/bundle-grep.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Pull the SPA's main JS bundle, grep React Router paths + /api/* endpoints +
+# permission tokens (Word:Word:Word) + role names.
+# Usage: bundle-grep.sh <run-dir> <base-url>
+
+set -uo pipefail
+RUN_DIR="${1:?run dir}"
+BASE="${2:?base url}"
+BASE="${BASE%/}"
+
+INDEX=$(curl -sS -L --max-time 15 "${BASE}/" || true)
+# Match /assets/<name>.js but require a non-word boundary after .js so we don't
+# accidentally truncate /assets/manifest.json into /assets/manifest.js.
+BUNDLE_PATH=$(echo "$INDEX" | grep -oE '/assets/[a-zA-Z0-9._-]+\.js("|[^a-zA-Z])' | grep -v '\.json' | head -1 | sed 's/.$//')
+if [ -z "$BUNDLE_PATH" ]; then
+  BUNDLE_PATH=$(echo "$INDEX" | grep -oE 'src="[^"]+\.js"' | head -1 | sed 's/src="//;s/"$//')
+fi
+[ -z "$BUNDLE_PATH" ] && { echo "no JS bundle found"; exit 0; }
+
+BUNDLE_URL="${BASE}${BUNDLE_PATH}"
+[[ "$BUNDLE_PATH" =~ ^https?:// ]] && BUNDLE_URL="$BUNDLE_PATH"
+
+curl -sS --max-time 30 "$BUNDLE_URL" -o "$RUN_DIR/app.bundle.js"
+echo "Bundle: $BUNDLE_URL ($(wc -c < "$RUN_DIR/app.bundle.js") bytes)"
+
+grep -oE 'path:"[^"]{1,120}"' "$RUN_DIR/app.bundle.js" | sort -u | sed 's/^path:"//;s/"$//' | grep '^/api' > "$RUN_DIR/api-endpoints.txt" 2>/dev/null || true
+grep -oE 'path:"[^"]{1,120}"' "$RUN_DIR/app.bundle.js" | sort -u | sed 's/^path:"//;s/"$//' | grep -v '^/api' > "$RUN_DIR/frontend-route-patterns.txt" 2>/dev/null || true
+
+# Permission tokens (Capitalized:Capitalized:Capitalized)
+grep -oE '"[A-Z][a-zA-Z]+:[A-Z][a-zA-Z]+(:[A-Z][a-zA-Z]+)?"' "$RUN_DIR/app.bundle.js" | sort -u > "$RUN_DIR/permissions.txt" 2>/dev/null || true
+
+# Role names — heuristic: capitalized words ending in Admin, User, Representative, Operator, Manager, Driver, Group
+grep -oE '"[A-Z][a-zA-Z]*(Admin|User|Representative|Operator|Manager|Driver|Group|Owner|Member)[a-zA-Z]*"' "$RUN_DIR/app.bundle.js" | sort -u > "$RUN_DIR/roles.txt" 2>/dev/null || true
+
+awk -F'/' '{print $3}' "$RUN_DIR/api-endpoints.txt" | sort | uniq -c | sort -rn > "$RUN_DIR/api-domains.txt"
+
+echo "API endpoints: $(wc -l < "$RUN_DIR/api-endpoints.txt")"
+echo "Frontend route patterns: $(wc -l < "$RUN_DIR/frontend-route-patterns.txt")"
+echo "Permission tokens: $(wc -l < "$RUN_DIR/permissions.txt")"
+echo "Role names: $(wc -l < "$RUN_DIR/roles.txt")"
+echo "Distinct API domains: $(wc -l < "$RUN_DIR/api-domains.txt")"

--- a/skills/vibe-inventory/inventory.sh
+++ b/skills/vibe-inventory/inventory.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# vibe-inventory — full feature map of a SPA. Walks declared routes, grep bundle.
+# Usage: inventory.sh <run-dir> <url> [--max-routes N] [--auth-required]
+
+set -uo pipefail
+
+RUN_DIR="${1:?run-dir required}"
+BASE_URL="${2:?url required}"
+shift 2
+
+MAX_ROUTES=30
+AUTH_REQUIRED=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --max-routes) MAX_ROUTES="$2"; shift 2 ;;
+    --auth-required) AUTH_REQUIRED=true; shift ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if command -v vibium >/dev/null 2>&1; then VIBIUM=vibium
+elif [ -x ./clicker/bin/vibium ]; then VIBIUM=./clicker/bin/vibium
+elif [ -x ./node_modules/.bin/vibium ]; then VIBIUM=./node_modules/.bin/vibium
+else echo "ERROR: cannot find vibium binary" >&2; exit 1; fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2; exit 1
+fi
+
+mkdir -p "$RUN_DIR"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOG="$RUN_DIR/inventory.log"
+: > "$LOG"
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" | tee -a "$LOG"; }
+
+log "vibe-inventory $BASE_URL  (max_routes=$MAX_ROUTES)"
+
+$VIBIUM daemon start >/dev/null 2>&1 || true
+
+log "navigate"
+$VIBIUM go "$BASE_URL" >/dev/null 2>&1 || { log "ERROR: navigate failed"; exit 1; }
+sleep 3
+
+if [ "$AUTH_REQUIRED" = true ]; then
+  log "auth_required=true; pausing for operator login"
+  echo ""
+  echo "==> Sign in via the headed Chrome window. Press Enter when past the wall."
+  read -r _
+  $VIBIUM go "$BASE_URL" >/dev/null 2>&1
+  sleep 2
+fi
+
+log "bundle grep"
+LANDED_URL=$($VIBIUM eval 'location.href' 2>/dev/null | tr -d '"')
+LANDED_ORIGIN=$(printf '%s' "$LANDED_URL" | awk -F/ '{print $1"//"$3}')
+"$HERE/bundle-grep.sh" "$RUN_DIR" "$LANDED_ORIGIN" 2>&1 | tee -a "$LOG"
+
+# Build route list from bundle + always include home
+log "building route candidate list"
+{
+  echo "home:/"
+  if [ -s "$RUN_DIR/frontend-route-patterns.txt" ]; then
+    grep -v ':' "$RUN_DIR/frontend-route-patterns.txt" | grep -v '*' | head -$((MAX_ROUTES - 1)) | while read -r p; do
+      [ -z "$p" ] && continue
+      slug=$(echo "$p" | sed 's|^/||;s|/|-|g;s|[^a-zA-Z0-9-]|_|g')
+      [ -z "$slug" ] && slug="root"
+      echo "${slug}:${p}"
+    done
+  fi
+} | head -$MAX_ROUTES > "$RUN_DIR/route-list.txt"
+
+ROUTE_COUNT=$(wc -l < "$RUN_DIR/route-list.txt")
+log "  walking $ROUTE_COUNT routes"
+
+"$HERE/walk.sh" "$RUN_DIR" "$LANDED_ORIGIN" < "$RUN_DIR/route-list.txt" 2>&1 | tee -a "$LOG"
+
+log "done. artifacts in $RUN_DIR"
+log "next: read $RUN_DIR/walk.log + routes/*.json + api-endpoints.txt and write INVENTORY.md"

--- a/skills/vibe-inventory/probe.js
+++ b/skills/vibe-inventory/probe.js
@@ -1,0 +1,28 @@
+// Standard DOM probe for vibe-inventory walk. Captures per-route state.
+// Usage: cat probe.js | vibium eval --stdin
+// Returns JSON with everything a single page tells us.
+
+(() => {
+  const url = location.href;
+  const title = document.title;
+  const headings = [...document.querySelectorAll('h1,h2,h3,h4')].slice(0, 12).map(e => e.tagName + ': ' + (e.innerText || '').replace(/\s+/g, ' ').trim());
+  const tables = [...document.querySelectorAll('table')].slice(0, 5).map(t => ({
+    rows: t.querySelectorAll('tr').length,
+    headers: [...t.querySelectorAll('th')].map(th => (th.innerText || '').replace(/\s+/g, ' ').trim()),
+  }));
+  const grids = [...document.querySelectorAll('.MuiDataGrid-root, [role=grid]')].slice(0, 5).map(g => ({
+    rows: g.querySelectorAll('[role=row]').length,
+    headers: [...g.querySelectorAll('[role=columnheader]')].map(h => (h.innerText || '').replace(/\s+/g, ' ').trim()),
+  }));
+  const inputs = [...document.querySelectorAll('input,select,textarea')].slice(0, 25).map(e => ({
+    tag: e.tagName.toLowerCase(),
+    type: e.type || null,
+    name: e.name || null,
+    placeholder: e.placeholder || null,
+    label: e.getAttribute('aria-label') || null,
+  }));
+  const buttons = [...document.querySelectorAll('button')].slice(0, 30).map(b => (b.innerText || b.getAttribute('aria-label') || '').replace(/\s+/g, ' ').trim()).filter(Boolean);
+  const isErrPage = /sorry,?\s*it.s not you|page not found|something went wrong|forbidden|unauthori[sz]ed|access denied/i.test(document.body.innerText) || /\/(error|404)(\?|$)/.test(location.href);
+  const bodyText = (document.body.innerText || '').replace(/\s+/g, ' ').trim();
+  return JSON.stringify({ url, title, isErrPage, headings, tables, grids, inputs, buttons, bodyTextLen: bodyText.length, bodyText: bodyText.slice(0, 4000) });
+})()

--- a/skills/vibe-inventory/walk.sh
+++ b/skills/vibe-inventory/walk.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Walk a list of routes, JSON probe + PNG screenshot per route.
+# Args: <run-dir> <base-url>
+# stdin: lines of "slug:path"
+
+set -uo pipefail
+RUN_DIR="${1:?run dir}"
+BASE="${2:?base url}"
+BASE="${BASE%/}"
+
+if command -v vibium >/dev/null 2>&1; then VIBIUM=vibium
+elif [ -x ./clicker/bin/vibium ]; then VIBIUM=./clicker/bin/vibium
+elif [ -x ./node_modules/.bin/vibium ]; then VIBIUM=./node_modules/.bin/vibium
+else echo "ERROR: cannot find vibium binary" >&2; exit 1; fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PROBE="$HERE/probe.js"
+mkdir -p "$RUN_DIR/routes"
+LOG="$RUN_DIR/walk.log"
+: > "$LOG"
+
+while IFS=: read -r SLUG P; do
+  [ -z "$SLUG" ] && continue
+  echo "→ $SLUG $P" | tee -a "$LOG"
+  $VIBIUM go "${BASE}${P}" >/dev/null 2>&1
+  sleep 3
+  $VIBIUM eval --stdin < "$PROBE" > "$RUN_DIR/routes/${SLUG}.json" 2>/dev/null || echo "  eval-failed" >> "$LOG"
+  $VIBIUM screenshot -o "${SLUG}.png" >/dev/null 2>&1 || true
+  if [ -f "$HOME/Pictures/Vibium/${SLUG}.png" ]; then
+    mv "$HOME/Pictures/Vibium/${SLUG}.png" "$RUN_DIR/routes/${SLUG}.png"
+  fi
+  URL=$(jq -r '.url // "?"' "$RUN_DIR/routes/${SLUG}.json" 2>/dev/null)
+  ERR=$(jq -r '.isErrPage // false' "$RUN_DIR/routes/${SLUG}.json" 2>/dev/null)
+  LEN=$(jq -r '.bodyTextLen // 0' "$RUN_DIR/routes/${SLUG}.json" 2>/dev/null)
+  echo "    landed=$URL err=$ERR bodyLen=$LEN" | tee -a "$LOG"
+done

--- a/skills/vibe-recon/SKILL.md
+++ b/skills/vibe-recon/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: vibe-recon
+description: Map a web app's auth wall and edge surface without logging in. Captures HTTP headers, follows redirects to identity providers (Auth0, Microsoft Entra, Cloudflare Access, etc.), saves the login DOM, screenshots the landing page, and pulls any SPA bundle for grep-based route discovery. Use when handed an unfamiliar URL and asked "what is this and how does auth work?"
+---
+
+# Vibium Recon — auth-wall + edge mapping (no login)
+
+`vibe-recon` is the read-only "look but don't touch" mode. Hand it a URL; it returns a one-page map of the app's auth provider chain, edge headers, and any SPA route patterns that grep can extract from the JS bundle. **No login required.**
+
+## When to use this skill
+
+- New to a SaaS / internal tool — what's it built on, how does sign-in work?
+- Pre-pentest scoping — capture the auth chain before deciding whether to test inside or outside.
+- Pre-`vibe-inventory` — confirm there's something to inventory before logging in.
+- Compliance / security audit — document the auth provider, third-party scripts, CSP.
+
+## How to run
+
+```bash
+skills/vibe-recon/recon.sh <run-dir> <url>
+```
+
+Example:
+
+```bash
+skills/vibe-recon/recon.sh ./run https://example.com/
+```
+
+## Pipeline
+
+1. **Resolve binary**: `vibium` on PATH → `./clicker/bin/vibium` → `./node_modules/.bin/vibium`.
+2. **Edge curl**: `curl -sSI -L <url>` — capture redirect chain, server header, CSP, security headers.
+3. **Daemon start** (idempotent).
+4. **Navigate** — follow whatever redirects the browser would. Record final URL + title.
+5. **DOM probe**: capture form fields on the landing page (login form? marketing splash? error page?).
+6. **Bundle grep**: pull the largest `<script src="…">` from `<head>`. If it's a Vite/CRA SPA bundle, extract React Router `path:"…"` strings and `/api/*` endpoint references.
+7. **Screenshot**: `01-landing.png`.
+8. **Write `RECON.md`** in the run dir.
+
+## Deliverable: `RECON.md`
+
+Required sections:
+
+1. **Header** — URL, time, redirect chain length, final landed URL.
+2. **Edge** — server header, security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy), CDN, any unusual headers.
+3. **Auth flow** — provider detected (Auth0 / Microsoft Entra / Cloudflare Access / Okta / Google / custom), client_id / tenant if visible in the redirect URL, OAuth scopes if visible.
+4. **Stack inferred** — from the bundle URL pattern, CSP origins, embedded SDK references (PowerBI, Auth0, OpenCV, Stripe, etc.).
+5. **DOM at landing** — form fields, buttons, links visible without auth.
+6. **Bundle grep** — frontend route patterns + `/api/*` endpoints if found, or "N/A — not a SPA bundle".
+7. **What this means / next steps** — what the operator should do if they want to go deeper.
+
+## What this skill does NOT do
+
+- **No login attempts.** The whole point is to map the wall, not pass it.
+- **No clicking** beyond the initial navigation. Every observation comes from passive load.
+- **No data extraction.** The tool is for surface mapping; if you need data, that's a separate skill.
+
+## Files in this skill
+
+| File | Purpose |
+|---|---|
+| `SKILL.md` | This file. |
+| `recon.sh` | Bash runner — orchestrates curl + navigate + probe + bundle-grep + screenshot. |
+| `bundle-grep.sh` | Pulls the SPA's main JS bundle and extracts route + API patterns. |
+| `probe.js` | Standard DOM probe (URL, title, forms, inputs, buttons, error state). |
+
+## See also
+
+- `skills/vibe-check/SKILL.md` — full Vibium CLI reference for executing known plans.
+- `skills/vibe-inventory/SKILL.md` — once past the auth wall, walk every route the SPA declares.
+- `skills/vibe-explore/SKILL.md` — once past the auth wall, click every safe element.

--- a/skills/vibe-recon/bundle-grep.sh
+++ b/skills/vibe-recon/bundle-grep.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pull the SPA's main JS bundle, grep React Router paths + /api/* endpoints.
+# Usage: bundle-grep.sh <run-dir> <base-url>
+
+set -uo pipefail
+RUN_DIR="${1:?run dir}"
+BASE="${2:?base url}"
+BASE="${BASE%/}"
+
+INDEX=$(curl -sS -L --max-time 15 "${BASE}/" || true)
+# Match /assets/<name>.js but require a non-word boundary after .js so we don't
+# accidentally truncate /assets/manifest.json into /assets/manifest.js.
+BUNDLE_PATH=$(echo "$INDEX" | grep -oE '/assets/[a-zA-Z0-9._-]+\.js("|[^a-zA-Z])' | grep -v '\.json' | head -1 | sed 's/.$//')
+if [ -z "$BUNDLE_PATH" ]; then
+  BUNDLE_PATH=$(echo "$INDEX" | grep -oE 'src="[^"]+\.js"' | head -1 | sed 's/src="//;s/"$//')
+fi
+if [ -z "$BUNDLE_PATH" ]; then
+  echo "no JS bundle found in ${BASE}/" > "$RUN_DIR/bundle-grep.log"
+  : > "$RUN_DIR/api-endpoints.txt"
+  : > "$RUN_DIR/frontend-route-patterns.txt"
+  : > "$RUN_DIR/frontend-route-literals.txt"
+  echo "no SPA bundle"
+  exit 0
+fi
+
+BUNDLE_URL="${BASE}${BUNDLE_PATH}"
+[[ "$BUNDLE_PATH" =~ ^https?:// ]] && BUNDLE_URL="$BUNDLE_PATH"
+
+curl -sS --max-time 30 "$BUNDLE_URL" -o "$RUN_DIR/app.bundle.js"
+BUNDLE_SIZE=$(wc -c < "$RUN_DIR/app.bundle.js")
+echo "Bundle: $BUNDLE_URL (${BUNDLE_SIZE} bytes)"
+
+grep -oE 'path:"[^"]{1,120}"' "$RUN_DIR/app.bundle.js" | sort -u | sed 's/^path:"//;s/"$//' | grep '^/api' > "$RUN_DIR/api-endpoints.txt" 2>/dev/null || true
+grep -oE 'path:"[^"]{1,120}"' "$RUN_DIR/app.bundle.js" | sort -u | sed 's/^path:"//;s/"$//' | grep -v '^/api' > "$RUN_DIR/frontend-route-patterns.txt" 2>/dev/null || true
+echo "API endpoints: $(wc -l < "$RUN_DIR/api-endpoints.txt")"
+echo "Frontend route patterns: $(wc -l < "$RUN_DIR/frontend-route-patterns.txt")"
+
+awk -F'/' '{print $3}' "$RUN_DIR/api-endpoints.txt" | sort | uniq -c | sort -rn > "$RUN_DIR/api-domains.txt"
+echo "Distinct API domains: $(wc -l < "$RUN_DIR/api-domains.txt")"

--- a/skills/vibe-recon/probe.js
+++ b/skills/vibe-recon/probe.js
@@ -1,0 +1,21 @@
+// Standard DOM probe for vibe-recon. Captures landing-page state without login.
+// Usage: cat probe.js | vibium eval --stdin
+// Returns JSON.
+
+(() => {
+  const url = location.href;
+  const title = document.title;
+  const headings = [...document.querySelectorAll('h1,h2,h3,h4')].slice(0, 12).map(e => e.tagName + ': ' + (e.innerText || '').replace(/\s+/g, ' ').trim());
+  const inputs = [...document.querySelectorAll('input,select,textarea')].slice(0, 25).map(e => ({
+    tag: e.tagName.toLowerCase(),
+    type: e.type || null,
+    name: e.name || null,
+    placeholder: e.placeholder || null,
+    label: e.getAttribute('aria-label') || null,
+  }));
+  const buttons = [...document.querySelectorAll('button, [type=submit]')].slice(0, 30).map(b => (b.innerText || b.getAttribute('aria-label') || '').replace(/\s+/g, ' ').trim()).filter(Boolean);
+  const linksSample = [...document.querySelectorAll('a[href]')].slice(0, 30).map(a => ({ txt: (a.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 60), href: a.getAttribute('href') }));
+  const isErrPage = /sorry|page not found|forbidden|unauthori[sz]ed|access denied/i.test(document.body.innerText) || /\/error(\?|$)/.test(location.href);
+  const formCount = document.querySelectorAll('form').length;
+  return JSON.stringify({ url, title, headings, inputs, buttons, linksSample, isErrPage, formCount });
+})()

--- a/skills/vibe-recon/recon.sh
+++ b/skills/vibe-recon/recon.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# vibe-recon — map a web app's auth wall + edge surface. No login.
+# Usage: recon.sh <run-dir> <url>
+
+set -uo pipefail
+
+RUN_DIR="${1:?run-dir required}"
+BASE_URL="${2:?url required}"
+
+if command -v vibium >/dev/null 2>&1; then
+  VIBIUM=vibium
+elif [ -x ./clicker/bin/vibium ]; then
+  VIBIUM=./clicker/bin/vibium
+elif [ -x ./node_modules/.bin/vibium ]; then
+  VIBIUM=./node_modules/.bin/vibium
+else
+  echo "ERROR: cannot find vibium binary" >&2; exit 1
+fi
+
+mkdir -p "$RUN_DIR"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOG="$RUN_DIR/recon.log"
+: > "$LOG"
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" | tee -a "$LOG"; }
+
+log "vibe-recon $BASE_URL"
+
+# 1. Edge curl
+log "edge curl"
+curl -sSI -L --max-time 15 "$BASE_URL" > "$RUN_DIR/edge-headers.txt" 2>&1
+log "  redirect chain: $(grep -c '^HTTP/' "$RUN_DIR/edge-headers.txt") response(s)"
+
+# 2. Daemon
+$VIBIUM daemon start >/dev/null 2>&1 || true
+
+# 3. Navigate
+log "navigate"
+$VIBIUM go "$BASE_URL" >/dev/null 2>&1 || { log "ERROR: navigate failed"; exit 1; }
+sleep 3
+
+# 4. Probe
+log "DOM probe"
+$VIBIUM eval --stdin < "$HERE/probe.js" > "$RUN_DIR/landing.json" 2>/dev/null
+LANDED_URL=$($VIBIUM eval 'location.href' 2>/dev/null | tr -d '"')
+log "  landed at: $LANDED_URL"
+
+# 5. Bundle grep against the LANDED origin (post-redirect)
+LANDED_ORIGIN=$(printf '%s' "$LANDED_URL" | awk -F/ '{print $1"//"$3}')
+log "bundle grep against $LANDED_ORIGIN"
+"$HERE/bundle-grep.sh" "$RUN_DIR" "$LANDED_ORIGIN" 2>&1 | tee -a "$LOG"
+
+# 6. Screenshot
+log "screenshot"
+$VIBIUM screenshot -o 01-landing.png >/dev/null 2>&1 || true
+[ -f "$HOME/Pictures/Vibium/01-landing.png" ] && mv "$HOME/Pictures/Vibium/01-landing.png" "$RUN_DIR/01-landing.png"
+
+log "done. artifacts in $RUN_DIR"
+log "next: read $RUN_DIR/landing.json + edge-headers.txt + api-endpoints.txt and write RECON.md"

--- a/skills/vibe-screenshot-all/SKILL.md
+++ b/skills/vibe-screenshot-all/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: vibe-screenshot-all
+description: Walk every known frontend route of a SPA and capture one PNG per route. No JSON probe, no clicking — pure visual catalog. Use when you need a contact sheet of an app's UI surface for a stakeholder review, design comp comparison, or visual regression baseline.
+---
+
+# Vibium Screenshot-All — visual catalog of every route
+
+`vibe-screenshot-all` produces the visual catalog: one screenshot per route, plus a contact-sheet HTML that puts them all on one page with URL labels.
+
+The deliverable answers: **"show me what every page in this app looks like."**
+
+## When to use this skill
+
+- Stakeholder review — "here's every page in our app, look it over."
+- Design comp comparison — set side-by-side with mockups.
+- Visual regression baseline — snapshot now, re-run after a deploy, diff manually.
+- Quick UX audit before a redesign.
+
+## How to run
+
+```bash
+skills/vibe-screenshot-all/screenshot-all.sh <run-dir> <url> [--max-routes N] [--auth-required]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--max-routes N` | 50 | Cap on routes screenshotted. |
+| `--auth-required` | off | Pause for manual login before walking. |
+
+## Pipeline
+
+1. **Resolve binary**.
+2. **Daemon start** (idempotent).
+3. **Navigate** to the URL.
+4. **Auth pause** if `--auth-required`.
+5. **Discover routes**: pull the SPA bundle, extract React Router `path:"…"` patterns. Filter out parameterized routes (`/order/:id` etc.) — those need a real ID.
+6. **Cap at `--max-routes`**.
+7. **Walk and screenshot** — one PNG per route, named `<slug>.png`.
+8. **Build `contact-sheet.html`** — a single-page HTML with all screenshots inline, labeled by route + landed-URL.
+
+## Deliverable
+
+```
+run/
+├── contact-sheet.html       # open in a browser to see all screenshots
+├── screens/
+│   ├── home.png
+│   ├── orders.png
+│   └── …
+├── route-list.txt           # which routes were attempted
+└── walk.log                 # per-route landing URL + status
+```
+
+## What this skill does NOT do
+
+- **No DOM probe.** If you need structural data, use `skills/vibe-inventory`.
+- **No clicking.** If you need to know what each button does, use `skills/vibe-explore`.
+- **No diff.** If you want to compare against a previous run, use `skills/vibe-diff`.
+- **No parameterized routes.** Routes with `:id` patterns are skipped — provide concrete URLs another way.
+
+## Files in this skill
+
+| File | Purpose |
+|---|---|
+| `SKILL.md` | This file. |
+| `screenshot-all.sh` | Bash runner. |
+
+## See also
+
+- `skills/vibe-inventory/SKILL.md` — for the structural map (routes + APIs + permissions).
+- `skills/vibe-diff/SKILL.md` — for periodic re-runs and drift detection.

--- a/skills/vibe-screenshot-all/screenshot-all.sh
+++ b/skills/vibe-screenshot-all/screenshot-all.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# vibe-screenshot-all — one PNG per route + contact-sheet HTML.
+# Usage: screenshot-all.sh <run-dir> <url> [--max-routes N] [--auth-required]
+
+set -uo pipefail
+
+RUN_DIR="${1:?run-dir required}"
+BASE_URL="${2:?url required}"
+shift 2
+
+MAX_ROUTES=50
+AUTH_REQUIRED=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --max-routes) MAX_ROUTES="$2"; shift 2 ;;
+    --auth-required) AUTH_REQUIRED=true; shift ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if command -v vibium >/dev/null 2>&1; then VIBIUM=vibium
+elif [ -x ./clicker/bin/vibium ]; then VIBIUM=./clicker/bin/vibium
+elif [ -x ./node_modules/.bin/vibium ]; then VIBIUM=./node_modules/.bin/vibium
+else echo "ERROR: cannot find vibium binary" >&2; exit 1; fi
+
+mkdir -p "$RUN_DIR/screens"
+LOG="$RUN_DIR/walk.log"
+: > "$LOG"
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" | tee -a "$LOG"; }
+
+log "vibe-screenshot-all $BASE_URL  (max_routes=$MAX_ROUTES)"
+
+$VIBIUM daemon start >/dev/null 2>&1 || true
+$VIBIUM go "$BASE_URL" >/dev/null 2>&1 || { log "ERROR: navigate failed"; exit 1; }
+sleep 3
+
+if [ "$AUTH_REQUIRED" = true ]; then
+  log "auth_required=true; pausing for operator login"
+  echo ""
+  echo "==> Sign in via the headed Chrome window. Press Enter when past the wall."
+  read -r _
+  $VIBIUM go "$BASE_URL" >/dev/null 2>&1
+  sleep 2
+fi
+
+LANDED_URL=$($VIBIUM eval 'location.href' 2>/dev/null | tr -d '"')
+LANDED_ORIGIN=$(printf '%s' "$LANDED_URL" | awk -F/ '{print $1"//"$3}')
+
+# Pull bundle + extract routes
+log "extracting routes from bundle"
+INDEX=$(curl -sS -L --max-time 15 "${LANDED_ORIGIN}/" || true)
+BUNDLE_PATH=$(echo "$INDEX" | grep -oE '/assets/[a-zA-Z0-9._-]+\.js("|[^a-zA-Z])' | grep -v '\.json' | head -1 | sed 's/.$//')
+[ -z "$BUNDLE_PATH" ] && BUNDLE_PATH=$(echo "$INDEX" | grep -oE 'src="[^"]+\.js"' | head -1 | sed 's/src="//;s/"$//')
+
+if [ -n "$BUNDLE_PATH" ]; then
+  BUNDLE_URL="${LANDED_ORIGIN}${BUNDLE_PATH}"
+  [[ "$BUNDLE_PATH" =~ ^https?:// ]] && BUNDLE_URL="$BUNDLE_PATH"
+  curl -sS --max-time 30 "$BUNDLE_URL" | grep -oE 'path:"[^"]{1,120}"' | sort -u | sed 's/^path:"//;s/"$//' | grep -v '^/api' | grep -v ':' | grep -v '*' > "$RUN_DIR/route-list.txt"
+fi
+
+# Always include home
+{ echo "/"; cat "$RUN_DIR/route-list.txt" 2>/dev/null; } | sort -u | head -$MAX_ROUTES > "$RUN_DIR/route-list.txt.tmp"
+mv "$RUN_DIR/route-list.txt.tmp" "$RUN_DIR/route-list.txt"
+
+ROUTE_COUNT=$(wc -l < "$RUN_DIR/route-list.txt")
+log "  walking $ROUTE_COUNT routes"
+
+# Walk + screenshot
+declare -a SHOTS=()
+while read -r P; do
+  [ -z "$P" ] && continue
+  slug=$(echo "$P" | sed 's|^/||;s|/|-|g;s|[^a-zA-Z0-9-]|_|g')
+  [ -z "$slug" ] && slug="home"
+  log "→ $slug $P"
+  $VIBIUM go "${LANDED_ORIGIN}${P}" >/dev/null 2>&1
+  sleep 3
+  $VIBIUM screenshot -o "${slug}.png" >/dev/null 2>&1 || true
+  if [ -f "$HOME/Pictures/Vibium/${slug}.png" ]; then
+    mv "$HOME/Pictures/Vibium/${slug}.png" "$RUN_DIR/screens/${slug}.png"
+    LANDED=$($VIBIUM eval 'location.href' 2>/dev/null | tr -d '"')
+    log "    landed=$LANDED  saved=screens/${slug}.png"
+    SHOTS+=("$slug|$P|$LANDED")
+  else
+    log "    screenshot failed"
+  fi
+done < "$RUN_DIR/route-list.txt"
+
+# Contact sheet
+log "writing contact-sheet.html"
+{
+  cat <<'HEAD'
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>vibe-screenshot-all contact sheet</title>
+<style>
+body{font-family:system-ui,sans-serif;background:#111;color:#eee;margin:0;padding:1rem}
+h1{font-size:1rem;margin:0 0 1rem}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:1rem}
+.card{background:#222;border-radius:6px;overflow:hidden}
+.card img{width:100%;height:auto;display:block}
+.meta{padding:.5rem .75rem;font-size:.8rem;font-family:monospace}
+.meta .slug{color:#fa0;font-weight:600}
+.meta .url{color:#7df;word-break:break-all}
+.meta .landed{color:#888;font-size:.7rem;margin-top:.25rem}
+</style></head><body>
+HEAD
+  echo "<h1>$BASE_URL — ${#SHOTS[@]} routes</h1>"
+  echo "<div class=grid>"
+  for entry in "${SHOTS[@]}"; do
+    IFS='|' read -r slug path landed <<< "$entry"
+    printf '<div class=card><img src="screens/%s.png"><div class=meta><div class=slug>%s</div><div class=url>%s</div><div class=landed>landed: %s</div></div></div>\n' "$slug" "$slug" "$path" "$landed"
+  done
+  echo "</div></body></html>"
+} > "$RUN_DIR/contact-sheet.html"
+
+log "done. open $RUN_DIR/contact-sheet.html"


### PR DESCRIPTION
## Why

`vibe-check` covers the "execute a known plan against a known UI" use case. This PR adds five complementary skills for the workflows Vibium users hit before and around that:

| Skill | Question it answers |
|---|---|
| `vibe-recon` | What is this app and how does auth work? (no login) |
| `vibe-inventory` | What does it do, structurally? Routes + APIs + permissions |
| `vibe-explore` | What can I do here? Click everything safely and report |
| `vibe-screenshot-all` | Show me what every page looks like |
| `vibe-diff` | What changed since last time? |

Each skill is self-contained — `SKILL.md` + bash runner + helper JS where needed. Binary resolution mirrors `vibe-check`'s pattern (`vibium` → `./clicker/bin/vibium` → `./node_modules/.bin/vibium`). No Go binary changes; pure-additive PR.

## What changed

```
skills/
├── vibe-recon/             4 files — recon.sh + bundle-grep.sh + probe.js + SKILL.md
├── vibe-inventory/         5 files — inventory.sh + walk.sh + bundle-grep.sh + probe.js + SKILL.md
├── vibe-explore/           5 files — explore.sh + dismiss-consent.js + enumerate-clickables.js + probe-state.js + SKILL.md
├── vibe-screenshot-all/    2 files — screenshot-all.sh + SKILL.md
└── vibe-diff/              2 files — diff.sh + SKILL.md
```

+18 files, ~830 lines, 0 existing files modified.

### vibe-recon — auth-wall + edge mapping (no login)

Edge curl, redirect chain, security headers, navigates the landing page, captures any visible login DOM, pulls the SPA bundle for grep-based route discovery. Read-only mode for "look but don't touch."

### vibe-inventory — structural feature map

Walks every route the SPA bundle declares (capped at `--max-routes`, default 30), captures per-route status / tables / grids / inputs / buttons, screenshots each, and grep the bundle for `/api/*` endpoints + permission tokens (`Word:Word:Word`) + role names. Login-aware via `--auth-required` (pause for manual sign-in).

### vibe-explore — click safe elements + rank capabilities

Inverse of `vibe-check`: clicks every safe interactive element on the page, classifies each outcome (navigation / modal / inline-disclosure / external / noop / route-error), screenshots before+after, then produces a ranked **"what you can do here"** report.

Hard safety filter on by default — skips `delete` / `submit` / `pay` / `sign-out` / `send` / `post` / `checkout` patterns, form submits, external-origin links, `target=_blank` anchors. `--include-destructive` lifts the filter.

Includes a 4-strategy consent-banner dismissal (visible-button-text → vendor-specific Usercentrics/OneTrust/Cookiebot → shadow-DOM walk → force-hide-CSS). Required to make the click loop work on real-world consent-walled sites.

### vibe-screenshot-all — visual catalog

One PNG per route + a contact-sheet HTML for stakeholder review or visual regression baselines. No DOM probe, no clicking.

### vibe-diff — what changed between two snapshots

Pure file-based diff between two `vibe-inventory` run dirs. Surfaces new/removed routes, new/removed API endpoints, new/removed permission tokens, version bump, bundle-size delta. No browser, no daemon — just `comm` and `diff` against the artifacts.

## How to test

Each skill ships a self-contained bash runner. Smoke tests run against public sites, no login required:

```bash
make build-go

# vibe-recon
mkdir /tmp/recon && skills/vibe-recon/recon.sh /tmp/recon https://raven-eye.app
# expect: edge-headers.txt, app.bundle.js (~10 MB), api-endpoints.txt (~280 lines), 01-landing.png

# vibe-inventory (will only walk routes the bundle declares)
mkdir /tmp/inv && skills/vibe-inventory/inventory.sh /tmp/inv https://raven-eye.app --max-routes 5
# expect: per-route JSON + PNG in routes/, api-endpoints.txt, permissions.txt

# vibe-explore against any public site
mkdir /tmp/expl && skills/vibe-explore/explore.sh /tmp/expl https://github.com/VibiumDev/vibium --max 8
# expect: 8 clicks attempted, results.jsonl with outcome per click, before/after screenshots

# vibe-screenshot-all
mkdir /tmp/shots && skills/vibe-screenshot-all/screenshot-all.sh /tmp/shots https://raven-eye.app --max-routes 5
# expect: contact-sheet.html with embedded PNGs

# vibe-diff (after two inventory runs)
skills/vibe-diff/diff.sh /tmp/inv-old /tmp/inv-new
# expect: DIFF.md in /tmp/inv-new with route/endpoint/permission deltas
```

All bash scripts pass `bash -n`; all JS helpers pass `new Function(code)` parse. `vibe-recon` end-to-end against `https://raven-eye.app` produces 280 API endpoints across 60 domains, 25 React Router patterns. `vibe-explore` end-to-end against `https://github.com/VibiumDev/vibium` produces 7/8 clicks landing real outcomes including mega-menu disclosures.

## Notes

- Each skill stands alone — maintainers can accept any subset. The two commits split as `vibe-recon + vibe-inventory + vibe-screenshot-all + vibe-diff` first, then `vibe-explore` second; happy to squash if preferred.
- One bug surfaced and fixed during smoke-testing: the `bundle-grep.sh` regex `/assets/<name>.js` was matching `/assets/manifest.json` truncated to `.js` on greedy-prefix engines. Fix requires a non-word boundary after `.js` (commit `ce7df57`).
- `vibe-explore` was originally a separate branch (`feature/vibe-explore-skill`); consolidated into this suite branch and the standalone branch retired.
- Each skill is run via its bash entry point. The `SKILL.md` files are the agent-facing one-pagers (matching `vibe-check`'s style); the bash runners are what an operator would invoke directly.
- No new prerequisites beyond `vibium` and `jq` — both already required by other parts of the repo or trivially installable.