### PR TITLE
Add AI Resolver interface and Anthropic backend

### DIFF
--- a/clicker/internal/ai/anthropic.go
+++ b/clicker/internal/ai/anthropic.go
@@ -1,0 +1,195 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+const (
+	anthropicAPIURL    = "https://api.anthropic.com/v1/messages"
+	anthropicVersion   = "2023-06-01"
+	anthropicBetaCache = "prompt-caching-2024-07-31"
+
+	ModelHaiku  = "claude-haiku-4-5-20251001"
+	ModelSonnet = "claude-sonnet-4-6"
+)
+
+// AnthropicResolver calls the Anthropic Messages API.
+// Prompt caching is enabled: the image (if present) or the text block is marked
+// ephemeral so repeated calls on the same page context get a cache hit.
+type AnthropicResolver struct {
+	apiKey  string
+	model   string
+	client  *http.Client
+	baseURL string // overridable for tests; defaults to anthropicAPIURL
+}
+
+// NewAnthropicResolver creates a resolver for the given model.
+// apiKey may be empty — if so, VIBIUM_ANTHROPIC_API_KEY is read at call time.
+func NewAnthropicResolver(model, apiKey string) *AnthropicResolver {
+	return &AnthropicResolver{
+		apiKey: apiKey,
+		model:  model,
+		client: &http.Client{},
+	}
+}
+
+// NewAnthropicResolverFromEnv creates a resolver reading the API key from
+// VIBIUM_ANTHROPIC_API_KEY. Returns an error if the key is not set.
+func NewAnthropicResolverFromEnv(model string) (*AnthropicResolver, error) {
+	key := os.Getenv("VIBIUM_ANTHROPIC_API_KEY")
+	if key == "" {
+		return nil, fmt.Errorf("VIBIUM_ANTHROPIC_API_KEY is not set")
+	}
+	return NewAnthropicResolver(model, key), nil
+}
+
+// NewAnthropicResolverForTest creates a resolver pointed at a custom base URL,
+// for use in unit tests with httptest.Server.
+func NewAnthropicResolverForTest(model, apiKey, baseURL string) *AnthropicResolver {
+	r := NewAnthropicResolver(model, apiKey)
+	r.baseURL = baseURL
+	return r
+}
+
+// Resolve sends the prompt (and optional screenshot) to the Anthropic API and
+// returns the model's text response.
+func (r *AnthropicResolver) Resolve(ctx context.Context, req Request) (Response, error) {
+	body, err := r.buildRequest(req)
+	if err != nil {
+		return Response{}, fmt.Errorf("build request: %w", err)
+	}
+
+	url := r.baseURL
+	if url == "" {
+		url = anthropicAPIURL
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return Response{}, fmt.Errorf("create request: %w", err)
+	}
+
+	apiKey := r.apiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("VIBIUM_ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return Response{}, fmt.Errorf("VIBIUM_ANTHROPIC_API_KEY is not set")
+	}
+
+	httpReq.Header.Set("x-api-key", apiKey)
+	httpReq.Header.Set("anthropic-version", anthropicVersion)
+	httpReq.Header.Set("anthropic-beta", anthropicBetaCache)
+	httpReq.Header.Set("content-type", "application/json")
+
+	resp, err := r.client.Do(httpReq)
+	if err != nil {
+		return Response{}, fmt.Errorf("call API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Response{}, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return Response{}, fmt.Errorf("API error %d: %s", resp.StatusCode, respBody)
+	}
+
+	return parseResponse(respBody)
+}
+
+// buildRequest constructs the Anthropic Messages API request body.
+// When an image is present it is sent first with cache_control so the vision
+// context is cached across multiple calls on the same screenshot.
+// When text-only, the text block itself is cached.
+func (r *AnthropicResolver) buildRequest(req Request) ([]byte, error) {
+	type cacheControl struct {
+		Type string `json:"type"`
+	}
+	type textBlock struct {
+		Type         string        `json:"type"`
+		Text         string        `json:"text"`
+		CacheControl *cacheControl `json:"cache_control,omitempty"`
+	}
+	type imageSource struct {
+		Type      string `json:"type"`
+		MediaType string `json:"media_type"`
+		Data      string `json:"data"`
+	}
+	type imageBlock struct {
+		Type         string        `json:"type"`
+		Source       imageSource   `json:"source"`
+		CacheControl *cacheControl `json:"cache_control,omitempty"`
+	}
+
+	var content []any
+
+	if len(req.Image) > 0 {
+		// Image cached; prompt text is not (it's the variable part)
+		content = []any{
+			imageBlock{
+				Type: "image",
+				Source: imageSource{
+					Type:      "base64",
+					MediaType: "image/png",
+					Data:      base64.StdEncoding.EncodeToString(req.Image),
+				},
+				CacheControl: &cacheControl{Type: "ephemeral"},
+			},
+			textBlock{Type: "text", Text: req.Prompt},
+		}
+	} else {
+		// Text-only: cache the prompt (a11y tree / map data is stable per page)
+		content = []any{
+			textBlock{
+				Type:         "text",
+				Text:         req.Prompt,
+				CacheControl: &cacheControl{Type: "ephemeral"},
+			},
+		}
+	}
+
+	payload := map[string]any{
+		"model":      r.model,
+		"max_tokens": 256,
+		"messages": []map[string]any{
+			{"role": "user", "content": content},
+		},
+	}
+
+	return json.Marshal(payload)
+}
+
+type anthropicResponse struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func parseResponse(body []byte) (Response, error) {
+	var r anthropicResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return Response{}, fmt.Errorf("parse response: %w", err)
+	}
+	if r.Error != nil {
+		return Response{}, fmt.Errorf("API error: %s", r.Error.Message)
+	}
+	for _, block := range r.Content {
+		if block.Type == "text" {
+			return Response{Text: block.Text}, nil
+		}
+	}
+	return Response{}, fmt.Errorf("no text content in response")
+}

--- a/clicker/internal/ai/resolver.go
+++ b/clicker/internal/ai/resolver.go
@@ -1,0 +1,20 @@
+package ai
+
+import "context"
+
+// Request is the input to a Resolver. Image is optional — nil means text-only.
+type Request struct {
+	Prompt string
+	Image  []byte // PNG bytes; nil for text-only requests
+}
+
+// Response is the output from a Resolver.
+type Response struct {
+	Text string
+}
+
+// Resolver resolves a natural language prompt (with optional screenshot) to a text response.
+// Implementations must be safe for concurrent use.
+type Resolver interface {
+	Resolve(ctx context.Context, req Request) (Response, error)
+}

--- a/clicker/internal/ai/resolver_test.go
+++ b/clicker/internal/ai/resolver_test.go
@@ -1,0 +1,144 @@
+package ai_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/vibium/clicker/internal/ai"
+)
+
+// mockResolver is a test double that returns a fixed response.
+type mockResolver struct {
+	text string
+	err  error
+}
+
+func (m *mockResolver) Resolve(_ context.Context, _ ai.Request) (ai.Response, error) {
+	return ai.Response{Text: m.text}, m.err
+}
+
+func TestMockResolver(t *testing.T) {
+	r := &mockResolver{text: "@e3"}
+	resp, err := r.Resolve(context.Background(), ai.Request{Prompt: "click login"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Text != "@e3" {
+		t.Fatalf("got %q, want %q", resp.Text, "@e3")
+	}
+}
+
+func TestAnthropicResolver_TextOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") == "" {
+			http.Error(w, "missing api key", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": "@e2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	// Point resolver at test server by temporarily overriding the URL.
+	// We test the full request/response cycle without hitting the real API.
+	r := ai.NewAnthropicResolverForTest(ai.ModelHaiku, "test-key", srv.URL)
+	resp, err := r.Resolve(context.Background(), ai.Request{Prompt: "click login"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Text != "@e2" {
+		t.Fatalf("got %q, want %q", resp.Text, "@e2")
+	}
+}
+
+func TestAnthropicResolver_WithImage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+
+		// Verify image block is present and cached
+		msgs := body["messages"].([]any)
+		content := msgs[0].(map[string]any)["content"].([]any)
+		imgBlock := content[0].(map[string]any)
+		if imgBlock["type"] != "image" {
+			http.Error(w, "expected image block first", http.StatusBadRequest)
+			return
+		}
+		cc := imgBlock["cache_control"].(map[string]any)
+		if cc["type"] != "ephemeral" {
+			http.Error(w, "expected cache_control ephemeral on image", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("content-type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": "@e5"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	r := ai.NewAnthropicResolverForTest(ai.ModelSonnet, "test-key", srv.URL)
+	resp, err := r.Resolve(context.Background(), ai.Request{
+		Prompt: "which element is the submit button?",
+		Image:  []byte{0x89, 0x50, 0x4e, 0x47}, // minimal PNG header
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Text != "@e5" {
+		t.Fatalf("got %q, want %q", resp.Text, "@e5")
+	}
+}
+
+func TestAnthropicResolver_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer srv.Close()
+
+	r := ai.NewAnthropicResolverForTest(ai.ModelHaiku, "bad-key", srv.URL)
+	_, err := r.Resolve(context.Background(), ai.Request{Prompt: "click login"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestAnthropicResolver_MissingAPIKey(t *testing.T) {
+	os.Unsetenv("VIBIUM_ANTHROPIC_API_KEY")
+	_, err := ai.NewAnthropicResolverFromEnv(ai.ModelHaiku)
+	if err == nil {
+		t.Fatal("expected error for missing API key, got nil")
+	}
+}
+
+// TestAnthropicResolver_Integration calls the real Anthropic API.
+// Skipped unless VIBIUM_ANTHROPIC_API_KEY is set.
+func TestAnthropicResolver_Integration(t *testing.T) {
+	key := os.Getenv("VIBIUM_ANTHROPIC_API_KEY")
+	if key == "" {
+		t.Skip("VIBIUM_ANTHROPIC_API_KEY not set")
+	}
+
+	r := ai.NewAnthropicResolver(ai.ModelHaiku, key)
+	resp, err := r.Resolve(context.Background(), ai.Request{
+		Prompt: "Reply with exactly: @e1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Text == "" {
+		t.Fatal("expected non-empty response")
+	}
+	t.Logf("response: %s", resp.Text)
+}


### PR DESCRIPTION
## Summary

- Introduces `clicker/internal/ai` — a model-agnostic `Resolver` interface with a single `Resolve(ctx, Request) (Response, error)` method
- Concrete `AnthropicResolver` implementation calls the Anthropic Messages API via standard `net/http` (no SDK dependency)
- Prompt caching enabled via `cache_control: ephemeral` — on the image block for vision requests, on the text block for text-only requests (~90% input token cost reduction on repeated calls within the same page context)
- API key read from `VIBIUM_ANTHROPIC_API_KEY`, consistent with existing `VIBIUM_` env var convention
- `ModelHaiku` and `ModelSonnet` constants exported for use by the locator pipeline

## Test plan

- [x] `go test ./clicker/internal/ai/...` — 5 unit tests pass (mock + httptest server, no API key needed)
- [x] `go test ./clicker/internal/ai/... -run Integration -v` — real Anthropic API call verified (Haiku, 1.37s)
- [x] `go build ./clicker/internal/...` compiles clean

## Context

This is PR 1 of 8 for the AI-powered locator feature.
Architecture discussion: https://github.com/VibiumDev/vibium/discussions/138