### PR TITLE
feat(skills): add vibe-aesthetic — design evaluation capture + LLM prompt

### DIFF
--- a/skills/vibe-aesthetic/PROMPT.md
+++ b/skills/vibe-aesthetic/PROMPT.md
@@ -1,0 +1,155 @@
+# Evaluator prompt — design assessment for {{URL}}
+
+You are evaluating the design of a deployed web page. The capture phase has
+already run: screenshots were taken at desktop + mobile viewports, and a
+design-token probe extracted the palette, typography, spacing, surface
+tokens, composition counts, and meta tags. All artifacts are attached or
+listed below.
+
+Your job is to score the page across **nine dimensions** and produce
+`AESTHETIC.md` in the run directory containing the assessment.
+
+## Run context
+
+- URL: `{{URL}}`
+- Captured: `{{TIMESTAMP}}`
+- Viewports: `{{VIEWPORT}}`
+
+(The brief, the screenshot list, and the probe JSON are appended below by
+the runner.)
+
+## Evaluation rubric
+
+Score each dimension 1–10 with the following anchors:
+
+| Score | Read |
+|---|---|
+| 9–10 | Industry-leading. The dimension is a source of strength. |
+| 8 | Strong. Acceptable for public launch at the page's register. |
+| 7 | Workable. Has clear weaknesses but no disqualifying flaws. |
+| 5–6 | Visible weakness. Will be noticed by the target audience. |
+| 3–4 | Distracting. Hurts the page's credibility at its target register. |
+| 1–2 | Disqualifying. Page is unfit for the stated brief. |
+
+### Dimensions
+
+1. **Visual Hierarchy** — Can the user's eye find the primary message in
+   under one second? Are sub-messages clearly secondary? Müller-Brockmann's
+   grid discipline applies.
+
+2. **Typography** — Type scale, leading, tracking, family pairing,
+   appropriateness for register. Vignelli-class restraint, no orphans, no
+   collisions at the cap-height/descender boundary, leading ≥ 1.1× for
+   display.
+
+3. **Color** — Palette discipline, contrast (formal a11y separate, this is
+   aesthetic temperature), warm/cool balance for the stated archetype. Use
+   the `palette.top` frequencies from the probe — what is the *rendered*
+   color ratio, not just the design-system intent?
+
+4. **Spacing & Layout** — Rhythm, alignment, white-space proportionality.
+   Does the grid hold across viewports? Is there visual rest?
+
+5. **Consistency** — Components reused with the same treatment. Two CTAs
+   for one funnel-stage should not differ in shape, fill, or weight.
+
+6. **Accessibility (visual)** — Contrast ratios for normal + large text +
+   placeholder + disabled states. (Formal axe-core audit is a separate
+   workstream — this dimension scores what is *visible* in the screenshots.)
+
+7. **Emotional Impact** — Does the page produce feeling in line with the
+   stated brief? An editorial atelier should feel intimate. A SaaS
+   dashboard should feel calm and capable.
+
+8. **Usability (perceived)** — From the screenshot alone, would a target
+   user know what to do next? Are CTAs legible, primary, and reachable?
+
+9. **Archetypal Coherence** — What archetype does the **visual** signal
+   right now (Ruler / Sage / Explorer / Magician / Caregiver / Lover /
+   Outlaw / Hero / Innocent / Jester / Creator / Everyperson)? What
+   archetype does the **copy** claim? Are they aligned? Misalignment is the
+   #1 cause of "the page feels off but I can't say why."
+
+## Output: AESTHETIC.md
+
+Write this file to the run directory with the exact structure below.
+
+```markdown
+# Aesthetic — <slug-from-URL>
+
+**Run:** <ISO timestamp> · <viewport(s)> · <N sections>
+**Base URL:** <url>
+**Brief used:** <one line>
+
+## Summary
+
+**Overall Score**: X.X/10
+**Primary Strength**: <one sentence>
+**Critical Aesthetic Issue**: <one sentence>
+**Archetypal Reading**: <what archetype the design currently embodies vs what the copy claims>
+
+## Dimension scores
+
+| Dimension | Score | Priority |
+|---|---|---|
+| Visual Hierarchy | X/10 | High / Med / Low |
+| Typography | X/10 | … |
+| Color | X/10 | … |
+| Spacing & Layout | X/10 | … |
+| Consistency | X/10 | … |
+| Accessibility (visual) | X/10 | … |
+| Emotional Impact | X/10 | … |
+| Usability (perceived) | X/10 | … |
+| Archetypal Coherence | X/10 | … |
+
+## Findings (Critical → Low)
+
+For each finding:
+
+### F-NN · <dimension> · <Critical|High|Medium|Low>
+- **Where**: <section file + viewport>, e.g. `s02_problem__desktop.png`
+- **What's wrong**: <one paragraph, principled — name the rule being broken>
+- **Reference**: <designer / movement / archetype that informs the critique>
+- **Fix**: <concrete CSS / token / copy change — actionable in one PR>
+
+## Per-section walkthrough
+
+For each section: one paragraph on what's working, one on what's weak.
+Reference the screenshot filename so the reader can look at it.
+
+## Archetypal read
+
+What archetype is the page currently signaling **visually**? What archetype
+does the **copy** claim? If they're aligned, say so. If they're not, name
+the dissonance and propose either a copy nudge or a visual nudge to close it.
+
+## Stable acceptance bar
+
+Tunable per project. Defaults:
+
+- [ ] Overall score ≥ 8/10
+- [ ] No dimension < 6/10
+- [ ] Archetypal Coherence ≥ 8/10
+- [ ] No Critical findings
+- [ ] ≤ 3 High findings
+```
+
+## Discipline
+
+- **Be brutal but constructive.** Every finding must cite (which
+  screenshot, which probe value), name the rule being violated, and propose
+  a concrete fix at the CSS / token / copy level.
+- **Score the rendered page, not the design system intent.** The probe
+  tells you what is actually painted on screen. If the design system says
+  the accent color is brass at 15% but the probe shows brass at 5%, the
+  finding is "brass under-applied at render," not "design system is fine."
+- **No marketing language.** No "robust", "powerful", "comprehensive."
+  Lead with what is, not how it feels to talk about.
+- **No emojis in `AESTHETIC.md`** unless the page being evaluated uses
+  them as design elements (which is itself a finding).
+- **Avoid AI tells.** No em dashes in the findings prose. No clipped
+  fragments for emphasis. No "It's not X; it's Y" antithesis.
+- **Photography ceiling.** For sites that need editorial imagery, a code-
+  only audit hits a hard ceiling around 8.2 out of 10. If you reach that
+  ceiling, name it explicitly — don't keep prescribing micro-CSS fixes that
+  can't move the score further.

--- a/skills/vibe-aesthetic/SKILL.md
+++ b/skills/vibe-aesthetic/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: vibe-aesthetic
+description: Design evaluation mode — walks a page at desktop + mobile, extracts a design-token probe (palette, typography, spacing, archetypal signals), captures section-by-section screenshots, and produces a prompt bundle a host LLM can use to score the page across nine dimensions (visual hierarchy, typography, color, spacing & layout, consistency, accessibility, emotional impact, usability, archetypal coherence). Use when the user has a deployed page and wants to know not just whether it works but whether it lands.
+---
+
+# Vibium Aesthetic — design evaluation capture
+
+`vibe-aesthetic` is the **design twin** of `vibe-explore`. Where `vibe-explore` asks *what does this page let me do*, `vibe-aesthetic` asks *what does this page feel like, and where is it weak?*
+
+The skill itself only captures evidence. The evaluation — the actual scoring and findings — is done by the host LLM (Claude, GPT, etc.) reading the artifacts this skill produces against the prompt template shipped at `PROMPT.md`. This split keeps the capture mechanical and reproducible while letting any LLM contribute the judgment.
+
+## When to use this skill
+
+- Pre-launch design review on a deployed site.
+- Post-rebrand verification — did the new identity actually land in the rendered page?
+- Comparing variants — run twice with the same brief, score the diffs.
+- Brand-family coherence check — score sibling sites and see who's lifting / dragging.
+- When the team has stopped finding things to fix and the page still "feels off."
+
+Complementary to `vibe-explore` (capability map) and any functional audit (broken-things scan). A page can be functionally clean and aesthetically weak, or vice versa.
+
+## How to run
+
+```bash
+skills/vibe-aesthetic/aesthetic.sh <run-dir> <url> [--viewport mobile|desktop|both] [--brief "..."]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--viewport mobile\|desktop\|both` | both | Capture viewports. |
+| `--quick` | off | Single viewport (desktop), 2 sections only (hero + one mid). ~30s. |
+| `--brief "..."` | (none) | One-line brand brief to pass to the evaluator. If absent, the bundle uses `<meta name="description">` + the H1 text as a generated brief. |
+| `--brief-from <path>` | (none) | Path to a longer brief file passed alongside `--brief`. |
+
+Example:
+
+```bash
+skills/vibe-aesthetic/aesthetic.sh ./run https://example.com/ \
+  --brief "Invite-only private aviation atelier"
+```
+
+## Pipeline
+
+1. **Resolve binary**: `vibium` on PATH → `./clicker/bin/vibium` → `./node_modules/.bin/vibium`.
+2. **Prep daemon**: `prep.sh` enforces `--headless` mode and clears zombie chromedriver / chrome processes (see `Daemon hygiene` below).
+3. **Walk per viewport** (`walk.sh`):
+   - Set viewport (390×844 dpr 3 mobile, 1280×800 dpr 1 desktop).
+   - Navigate + wait for hydration.
+   - Capture the design-token probe via `probe.js` → `probes/tokens_<viewport>.json`.
+   - Auto-discover section anchors: every `<section id="...">` with non-zero height in DOM order. Fall back to viewport-stepped intervals if no anchors found.
+   - Smooth-scroll to each anchor, capture screenshot → `sections/s<NN>_<id>__<viewport>.png`.
+   - Always capture top-of-page (`s00_top`) and bottom-of-page (`s99_bottom`).
+4. **Render the evaluator prompt**: `aesthetic.sh` interpolates the run's URL, brief, probe JSON, and screenshot filenames into `PROMPT.md`, writing the filled prompt to `<run-dir>/PROMPT.filled.md`.
+5. **Hand off** to the host LLM. The skill prints the path; the LLM reads the filled prompt + attaches the screenshots and produces `AESTHETIC.md` in the run dir.
+
+## Daemon hygiene
+
+Zombie `chromedriver` and `chrome-for-testing` processes accumulate from prior failed sessions and block new browser sessions with HTTP 500. When the daemon is started without `--headless` in an SSH or CI context where `DISPLAY` is empty, every capture command produces 0-byte output silently. The `prep.sh` script is the durable fix:
+
+```bash
+vibium daemon stop
+pkill -9 chromedriver
+pkill -9 -f chrome-for-testing
+rm -f ~/.cache/vibium/vibium.sock ~/.cache/vibium/vibium.pid
+vibium --headless daemon start
+```
+
+`aesthetic.sh` calls `prep.sh` automatically. Reach for `prep.sh` standalone whenever any vibium command times out, returns HTTP 500, or produces empty output.
+
+## Run dir layout
+
+```
+<run-dir>/
+├── RUN.md                    # what ran, params, timing
+├── probes/
+│   ├── tokens_desktop.json   # palette, typography, spacing, archetypal signals
+│   └── tokens_mobile.json
+├── sections/
+│   ├── s00_top__desktop.png
+│   ├── s01_hero__desktop.png
+│   ├── s02_<section-id>__desktop.png
+│   ├── ...
+│   ├── s99_bottom__desktop.png
+│   └── (same set per viewport)
+├── walk.log                  # per-section landing Y + status
+├── PROMPT.filled.md          # the prompt to feed to the host LLM
+└── AESTHETIC.md              # the LLM writes this; not produced by the skill itself
+```
+
+## The evaluator prompt (`PROMPT.md`)
+
+The shipped prompt asks the host LLM to score the page across nine dimensions:
+
+1. Visual Hierarchy
+2. Typography
+3. Color
+4. Spacing & Layout
+5. Consistency
+6. Accessibility (visual)
+7. Emotional Impact
+8. Usability (perceived)
+9. Archetypal Coherence
+
+It produces `AESTHETIC.md` with:
+
+- An overall score (1–10)
+- Per-dimension scores
+- Critical → Low findings, each with section + viewport reference, principle being violated, and a concrete fix in CSS / token / copy form
+- A per-section walkthrough
+- An archetypal read (what archetype the visual signals vs what the copy claims)
+- A stable acceptance bar (defaults: ≥ 8/10 overall, no dimension < 6/10, ≥ 8/10 on archetypal coherence)
+
+The full prompt template is at `skills/vibe-aesthetic/PROMPT.md`. Operators can edit it to retune the rubric (different dimension set, different acceptance bar, different domain register).
+
+## Bulk-extraction guardrail
+
+The skill reads the rendered page and screenshots. It never types, submits, clicks, or extracts data records. The mode is read-only by construction — no auth required for public pages, no destructive surface.
+
+## Files in this skill
+
+| File | Purpose |
+|---|---|
+| `SKILL.md` | This file. |
+| `aesthetic.sh` | Bash runner — orchestrates prep + walk + prompt-render. |
+| `walk.sh` | Section-aware walker (desktop + mobile), captures probe + section PNGs. |
+| `probe.js` | Design-token probe (palette frequencies, typography, surface tokens, composition counts, meta). |
+| `prep.sh` | Daemon hygiene — kills zombies, starts daemon with `--headless`. |
+| `PROMPT.md` | The evaluator prompt template fed to the host LLM. |
+| `examples/reference-run.md` | Anonymized 8-iteration trajectory (7.4 → 9.5) showing how the rubric scores move over real fixes. |
+
+## See also
+
+- `skills/vibe-check/SKILL.md` — the full Vibium CLI reference. `vibe-aesthetic` builds on it.
+- `skills/vibe-recon/SKILL.md` — pre-flight auth-wall mapping (useful if the target site is gated).
+- `skills/vibe-explore/SKILL.md` — capability inventory by clicking safe elements.
+
+## Acknowledgements
+
+The dimension rubric draws on the LibreUIUX design + archetypal frameworks. The headless-daemon hygiene lesson and the section-walk pattern come from a real 8-iteration polish loop on a deployed editorial site — that run is anonymized in `examples/reference-run.md` for operators to see what realistic score trajectories look like.

--- a/skills/vibe-aesthetic/aesthetic.sh
+++ b/skills/vibe-aesthetic/aesthetic.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# vibe-aesthetic — design evaluation capture.
+#
+# Orchestrates: prep daemon → walk page (desktop + mobile) → render
+# evaluator prompt. The host LLM reads the rendered prompt + attached
+# screenshots and writes AESTHETIC.md.
+#
+# Usage: aesthetic.sh <run-dir> <url> [--viewport mobile|desktop|both]
+#                                      [--quick] [--brief "..."]
+#                                      [--brief-from <path>]
+#
+# Output:
+#   <run-dir>/probes/tokens_<viewport>.json
+#   <run-dir>/sections/s<NN>_<id>__<viewport>.png
+#   <run-dir>/walk.log
+#   <run-dir>/PROMPT.filled.md
+#   <run-dir>/RUN.md
+
+set -euo pipefail
+IFS=$'\n\t'
+
+RUN_DIR="${1:?run dir required}"
+URL="${2:?url required}"
+shift 2
+
+VIEWPORT="both"
+QUICK=0
+BRIEF=""
+BRIEF_FROM=""
+while (( $# )); do
+  case "$1" in
+    --viewport)   VIEWPORT="$2"; shift 2;;
+    --quick)      QUICK=1; shift;;
+    --brief)      BRIEF="$2"; shift 2;;
+    --brief-from) BRIEF_FROM="$2"; shift 2;;
+    *) echo "WARNING: unknown arg $1" >&2; shift;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPT_TPL="$SCRIPT_DIR/PROMPT.md"
+
+mkdir -p "$RUN_DIR"
+TS_START="$(date -u +%FT%TZ)"
+
+echo "vibe-aesthetic → $URL"
+echo "  run-dir: $RUN_DIR"
+echo "  viewport: $VIEWPORT $([[ $QUICK == 1 ]] && echo '(quick)')"
+
+# 1. Prep daemon.
+echo "→ prepping daemon"
+"$SCRIPT_DIR/prep.sh"
+
+# 2. Walk.
+echo "→ walking page"
+walk_args=("$RUN_DIR" "$URL" --viewport "$VIEWPORT")
+(( QUICK )) && walk_args+=(--quick)
+"$SCRIPT_DIR/walk.sh" "${walk_args[@]}"
+
+# 3. Render the prompt.
+echo "→ rendering evaluator prompt"
+
+# Resolve brief: --brief wins, else --brief-from, else meta description from probe.
+RESOLVED_BRIEF=""
+if [[ -n "$BRIEF" ]]; then
+  RESOLVED_BRIEF="$BRIEF"
+elif [[ -n "$BRIEF_FROM" && -f "$BRIEF_FROM" ]]; then
+  RESOLVED_BRIEF="$(cat "$BRIEF_FROM")"
+else
+  # Try to pull meta description from the desktop probe.
+  if [[ -f "$RUN_DIR/probes/tokens_desktop.json" ]]; then
+    RESOLVED_BRIEF="$(python3 -c "
+import json, sys
+try:
+  d = json.load(open('$RUN_DIR/probes/tokens_desktop.json'))
+  print(d.get('meta', {}).get('description') or '')
+except Exception:
+  pass
+" 2>/dev/null || echo "")"
+  fi
+fi
+[[ -z "$RESOLVED_BRIEF" ]] && RESOLVED_BRIEF="(no brief provided — infer from page content)"
+
+# List section screenshots in scroll order, per viewport.
+section_list_for() {
+  local vp="$1"
+  find "$RUN_DIR/sections" -name "*__${vp}.png" 2>/dev/null | sort | while read -r p; do
+    echo "  - ${p#$RUN_DIR/}"
+  done
+}
+
+# Compose the filled prompt by inlining placeholders.
+FILLED="$RUN_DIR/PROMPT.filled.md"
+{
+  if [[ -f "$PROMPT_TPL" ]]; then
+    sed -e "s|{{URL}}|$URL|g" \
+        -e "s|{{TIMESTAMP}}|$TS_START|g" \
+        -e "s|{{VIEWPORT}}|$VIEWPORT|g" \
+        "$PROMPT_TPL"
+  fi
+  printf "\n## Brief\n\n%s\n" "$RESOLVED_BRIEF"
+
+  printf "\n## Captured screenshots\n"
+  for vp in desktop mobile; do
+    if find "$RUN_DIR/sections" -name "*__${vp}.png" 2>/dev/null | grep -q .; then
+      printf "\n### %s\n" "$vp"
+      section_list_for "$vp"
+    fi
+  done
+
+  printf "\n## Design-token probes\n"
+  for vp in desktop mobile; do
+    if [[ -f "$RUN_DIR/probes/tokens_${vp}.json" ]]; then
+      printf "\n### %s\n\n\`\`\`json\n" "$vp"
+      cat "$RUN_DIR/probes/tokens_${vp}.json"
+      printf "\n\`\`\`\n"
+    fi
+  done
+} > "$FILLED"
+
+# 4. RUN.md summary.
+TS_END="$(date -u +%FT%TZ)"
+shot_count=$(find "$RUN_DIR/sections" -name "*.png" 2>/dev/null | wc -l)
+probe_count=$(find "$RUN_DIR/probes" -name "*.json" 2>/dev/null | wc -l)
+
+cat > "$RUN_DIR/RUN.md" <<EOF
+# vibe-aesthetic run
+
+- URL: $URL
+- Started: $TS_START
+- Ended: $TS_END
+- Viewport: $VIEWPORT$([[ $QUICK == 1 ]] && echo " (quick)")
+- Brief: $RESOLVED_BRIEF
+- Sections captured: $shot_count
+- Probes captured: $probe_count
+
+## Next step
+
+The capture phase is complete. Hand the file \`PROMPT.filled.md\` to your
+host LLM (Claude, GPT, etc.) along with the screenshots in \`sections/\`.
+The LLM writes \`AESTHETIC.md\` in this run dir per the structure described
+in the prompt.
+EOF
+
+echo ""
+echo "DONE."
+echo "  $shot_count screenshots in $RUN_DIR/sections/"
+echo "  $probe_count probes in $RUN_DIR/probes/"
+echo "  Prompt ready: $FILLED"
+echo "  Run summary: $RUN_DIR/RUN.md"

--- a/skills/vibe-aesthetic/examples/reference-run.md
+++ b/skills/vibe-aesthetic/examples/reference-run.md
@@ -1,0 +1,136 @@
+# Reference run — 8-iteration polish loop on an editorial site
+
+This is an anonymized trajectory from the first real-world run of the
+aesthetic capture pattern, distilled to show operators (a) realistic score
+movement under code-only fixes, (b) where the photography ceiling lands,
+and (c) the durable lessons crystallized into this skill.
+
+The site under audit: a deployed Vercel landing page for an invitation-only
+service in the luxury / editorial register. Stack was Next.js + Tailwind +
+custom design tokens. The brief was specific (one-line invitation-only
+positioning) and the page had real founder copy already in place.
+
+## Score trajectory
+
+| Iter | Score | Δ | Notable changes |
+|------|-------|---|-----------------|
+| 0 (baseline) | 7.4 | — | First audit, before any iteration |
+| 1 | 7.7 | +0.3 | Copy refactor, nav, favicon, new section added |
+| 2 | 8.1 | +0.4 | H1 line-height fix, accent on hero eyebrows, warm overlay, footer vocabulary, og:image, placeholder contrast |
+| 3 | 8.5 | +0.4 | Section chapter overlays, accent on all eyebrows, card surface removed, personal-voice asides |
+| 4 | 8.7 | +0.2 | Blend-mode color, items-start chapter alignment, footer eyebrows brass |
+| 5 | 8.7 | +0.0 | Grain texture, hero fade, mobile image cap — **code ceiling confirmed** |
+| 6 | 9.2 | +0.5 | **Photography** wired in (real imagery, color-graded) |
+| 7 | 9.4 | +0.2 | Substitute photo replaced with authentic source |
+| 8 | 9.5 | +0.1 | Photo re-grade for palette harmony, mobile crop fix |
+
+**Total improvement: +2.1 from baseline.**
+
+## What moved the score and by how much
+
+### Code-only ceiling at 8.7 (iters 1–5)
+
+Five iterations of pure code work — typography token fixes, accent palette
+expansion from ~5% to ~12% of rendered surface, footer copy vocabulary,
+mobile button consistency, surface removal, og:image, contrast bumps,
+texture additions — collectively moved the score from 7.4 to 8.7 and then
+plateaued. The synthesis engine correctly identified at iter 5 that further
+code work was diminishing returns.
+
+**Takeaway**: code can carry a page about 1.3 points off a 7.4 baseline.
+Beyond that, the gating dependency is usually photography, real
+illustration, or videography. Don't keep prescribing micro-CSS fixes once
+the plateau is identified.
+
+### Photography breakthrough at 9.2 (iter 6)
+
+A single iteration with real imagery jumped the score 0.5 points. The
+mechanism: emotional impact rose from 8.5 to 9.5, archetypal coherence
+from 7.5 to 8.5, and the visual field of the hero section transitioned
+from 60% unoccupied near-black to a fully-occupied editorial photograph
+that signaled operator legitimacy.
+
+**Takeaway**: if the page can carry a hero image, ship it before iterating
+further on color or spacing. The image moves dimensions code cannot.
+
+### Diminishing returns at 9.5 (iters 7–8)
+
+Substitute-photo replacement (+0.2) and photo color regrade (+0.1) closed
+the remaining gap to ~9.5. The agent reported the realistic ceiling
+against the nine-dimension rubric is approximately 9.8 — 10/10 is
+structurally unreachable because the rubric always reserves at least one
+fractional finding for "what could be better."
+
+## Durable lessons crystallized into this skill
+
+### 1. Daemon must run headless under SSH
+
+The first eight runs all silently produced 0-byte screenshot files because
+the vibium daemon was started without `--headless` in an SSH session where
+`DISPLAY` was empty. Browser sessions failed with HTTP 500 and every
+capture helper logged success while writing nothing.
+
+**Fix**: `prep.sh` enforces `--headless` at daemon start. Reach for it
+whenever a capture command times out, returns HTTP 500, or produces empty
+output.
+
+### 2. Accent-color percentage is the single most movable archetypal lever
+
+For sites in the warm-luxury register (Sage / Ruler crossover), the
+percentage of rendered surface in the accent color is the lever that
+shifts the archetypal read. Moving warm accent from 5–6% to 12–15% of
+rendered pixels shifted the read from Ruler to Sage by approximately one
+full archetype unit, with no other change.
+
+**How to apply**: read `palette.top` from the probe. Sum the rendered
+percentages of brass / warm / accent colors. If the design system says
+15% target and the rendered ratio is 5%, the finding is "accent
+under-applied at render" with a specific fix (which eyebrow, divider,
+hover state should switch to accent).
+
+### 3. Photography is the consistent ceiling
+
+Across multiple iterations, the agent repeatedly flagged placeholder
+imagery as the dominant aesthetic gap. Without photography in motion, the
+loop hit a hard ceiling around 8.0–8.2 for any site that needs imagery.
+
+**How to apply**: when the agent's iter-N report says "the remaining gap
+is photography-dependent," believe it. Either source the photography or
+accept the ceiling. Don't run another iteration expecting code fixes to
+move the score.
+
+### 4. Plateau detection matters
+
+Iter 5 returned the same score as iter 4 (8.7 → 8.7). Without plateau
+detection, the operator would have run more code-only iterations chasing
+diminishing returns. The right move is to name the plateau, identify the
+gating dependency, and either resolve it (photography) or stop.
+
+**How to apply**: if two consecutive iterations move the score by less
+than 0.1, stop iterating code and either ship at the current score or
+unblock the non-code dependency.
+
+## Pre-launch blockers (not aesthetic)
+
+A reminder, not a finding: aesthetic score is orthogonal to
+functional readiness. The reference run identified several launch blockers
+that did not affect score:
+
+- Placeholder form action that would silently fail in production
+- A button not wired to its handler
+- A passphrase hard-coded in client JS
+- Robots blocked
+- Domain decision still open
+
+None of these moved the aesthetic score but all had to be resolved before
+public flip. Keep an `audit` pass separate from `aesthetic` for this
+reason.
+
+## What this skill produces vs what it doesn't
+
+This skill captures evidence and renders an evaluator prompt. The host LLM
+produces the scoring, findings, and per-section walkthrough. Operators
+opting for an autonomous loop (audit → fix → deploy → re-audit) build that
+on top of this capture as a separate workflow — the loop is opinionated
+about deploy commands and file editing in a way that doesn't generalize
+cleanly upstream, so it is intentionally not part of this skill.

--- a/skills/vibe-aesthetic/prep.sh
+++ b/skills/vibe-aesthetic/prep.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Ensure the vibium daemon is in a clean state, running headless.
+# Required for non-interactive sessions (SSH, CI) where DISPLAY is empty —
+# without --headless the daemon defaults to a visible browser and every
+# capture silently produces 0-byte output.
+#
+# Usage: skills/vibe-aesthetic/prep.sh
+# Exit codes: 0 on success, 1 if daemon won't start, 2 if browser won't launch.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# Binary resolution (same convention as the vibe-* skill family).
+resolve_vibium() {
+  if command -v vibium >/dev/null 2>&1; then echo "vibium"; return; fi
+  if [[ -x "./clicker/bin/vibium" ]]; then echo "./clicker/bin/vibium"; return; fi
+  if [[ -x "./node_modules/.bin/vibium" ]]; then echo "./node_modules/.bin/vibium"; return; fi
+  echo "ERROR: vibium binary not found" >&2
+  exit 127
+}
+VIBIUM="$(resolve_vibium)"
+
+# Bring down anything that might be stale.
+"$VIBIUM" daemon stop >/dev/null 2>&1 || true
+pkill -9 chromedriver 2>/dev/null || true
+pkill -9 -f "chrome-for-testing" 2>/dev/null || true
+sleep 1
+rm -f "$HOME/.cache/vibium/vibium.sock" "$HOME/.cache/vibium/vibium.pid" 2>/dev/null || true
+sleep 1
+
+# Start with --headless inherited by all subsequent commands.
+"$VIBIUM" --headless daemon start >/dev/null 2>&1
+sleep 3
+
+if ! "$VIBIUM" daemon status 2>&1 | grep -q "running"; then
+  echo "ERROR: vibium daemon failed to start" >&2
+  exit 1
+fi
+
+# Smoke-test browser session creation with a no-op JS expression.
+if ! "$VIBIUM" eval "1+1" 2>&1 | grep -q "2"; then
+  echo "ERROR: vibium browser session failed to launch" >&2
+  echo "Check: ~/.cache/vibium/chrome-for-testing/ has chrome + chromedriver" >&2
+  exit 2
+fi
+
+echo "vibium daemon ready (headless mode)"

--- a/skills/vibe-aesthetic/probe.js
+++ b/skills/vibe-aesthetic/probe.js
@@ -1,0 +1,158 @@
+// Aesthetic probe — extracts design tokens from a rendered page.
+// Invocation: vibium eval --stdin < probe.js
+// Output: JSON describing palette, typography, spacing, composition signals.
+
+(() => {
+  function rgb(s) {
+    if (!s) return null;
+    const m = s.match(/rgba?\(([^)]+)\)/);
+    if (!m) return s;
+    const parts = m[1].split(",").map((v) => parseFloat(v));
+    return parts.length >= 3
+      ? { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 }
+      : s;
+  }
+  function toHex({ r, g, b }) {
+    const h = (n) => Math.round(n).toString(16).padStart(2, "0");
+    return `#${h(r)}${h(g)}${h(b)}`;
+  }
+  function frequency(arr) {
+    const m = new Map();
+    for (const v of arr) m.set(v, (m.get(v) || 0) + 1);
+    return [...m.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([value, count]) => ({ value, count }));
+  }
+
+  const all = Array.from(document.querySelectorAll("*"));
+  const visible = all.filter((el) => {
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0 && el.offsetParent !== null;
+  });
+
+  const palette = [];
+  const fonts = [];
+  const sizes = [];
+  const weights = [];
+  const lineHeights = [];
+  const letterSpacings = [];
+  const radii = [];
+  const shadows = [];
+  const paddings = [];
+  const gaps = [];
+
+  for (const el of visible) {
+    const s = getComputedStyle(el);
+    const txt = (el.textContent || "").trim();
+    if (s.color && s.color !== "rgba(0, 0, 0, 0)") palette.push(s.color);
+    if (s.backgroundColor && s.backgroundColor !== "rgba(0, 0, 0, 0)")
+      palette.push(s.backgroundColor);
+    if (
+      s.borderTopColor &&
+      s.borderTopColor !== "rgba(0, 0, 0, 0)" &&
+      parseFloat(s.borderTopWidth) > 0
+    )
+      palette.push(s.borderTopColor);
+    if (s.fontFamily) fonts.push(s.fontFamily.split(",")[0].trim().replace(/['"]/g, ""));
+    if (txt.length > 0) {
+      sizes.push(s.fontSize);
+      weights.push(s.fontWeight);
+      lineHeights.push(s.lineHeight);
+      letterSpacings.push(s.letterSpacing);
+    }
+    if (s.borderRadius && s.borderRadius !== "0px") radii.push(s.borderRadius);
+    if (s.boxShadow && s.boxShadow !== "none") shadows.push(s.boxShadow);
+    if (s.padding && s.padding !== "0px") paddings.push(s.padding);
+    if (s.gap && s.gap !== "normal" && s.gap !== "0px") gaps.push(s.gap);
+  }
+
+  const paletteHex = palette
+    .map(rgb)
+    .filter((v) => v && typeof v === "object")
+    .filter((v) => (v.a ?? 1) > 0)
+    .map((v) => toHex(v));
+
+  const heading = (selector) => {
+    const els = Array.from(document.querySelectorAll(selector));
+    return els.slice(0, 3).map((el) => {
+      const s = getComputedStyle(el);
+      return {
+        text: (el.textContent || "").trim().slice(0, 80),
+        fontFamily: s.fontFamily.split(",")[0].trim().replace(/['"]/g, ""),
+        fontSize: s.fontSize,
+        fontWeight: s.fontWeight,
+        lineHeight: s.lineHeight,
+        letterSpacing: s.letterSpacing,
+        color: s.color,
+      };
+    });
+  };
+
+  const main = document.querySelector("main, body");
+  const mainW = main ? main.getBoundingClientRect().width : window.innerWidth;
+  const grain = getComputedStyle(document.body).backgroundImage;
+
+  return JSON.stringify({
+    url: location.href,
+    title: document.title,
+    viewport: {
+      w: window.innerWidth,
+      h: window.innerHeight,
+      dpr: window.devicePixelRatio,
+    },
+    docSize: {
+      scrollHeight: document.documentElement.scrollHeight,
+      scrollWidth: document.documentElement.scrollWidth,
+    },
+    palette: {
+      top: frequency(paletteHex).slice(0, 12),
+      uniqueCount: new Set(paletteHex).size,
+    },
+    typography: {
+      h1: heading("h1"),
+      h2: heading("h2"),
+      h3: heading("h3"),
+      body: heading("p, li, span:not(:empty)").slice(0, 5),
+      cta: heading("a[href], button"),
+      fonts: frequency(fonts).slice(0, 6),
+      sizes: frequency(sizes).slice(0, 12),
+      weights: frequency(weights).slice(0, 6),
+      lineHeights: frequency(lineHeights).slice(0, 6),
+      letterSpacings: frequency(letterSpacings).slice(0, 6),
+    },
+    surface: {
+      radii: frequency(radii).slice(0, 6),
+      shadows: frequency(shadows).slice(0, 4),
+      paddingSamples: frequency(paddings).slice(0, 10),
+      gaps: frequency(gaps).slice(0, 6),
+    },
+    layout: {
+      mainWidth: mainW,
+      viewportWidth: window.innerWidth,
+      bodyHasGrain: grain && grain !== "none" ? true : false,
+    },
+    composition: {
+      sections: document.querySelectorAll("section").length,
+      headings: {
+        h1: document.querySelectorAll("h1").length,
+        h2: document.querySelectorAll("h2").length,
+        h3: document.querySelectorAll("h3").length,
+      },
+      ctas: document.querySelectorAll("a[href^='mailto:'], a[href^='#'], button").length,
+      images: document.querySelectorAll("img").length,
+      videos: document.querySelectorAll("video").length,
+      canvases: document.querySelectorAll("canvas").length,
+      svgs: document.querySelectorAll("svg").length,
+    },
+    meta: {
+      description:
+        document.querySelector("meta[name='description']")?.getAttribute("content") || null,
+      ogImage:
+        document.querySelector("meta[property='og:image']")?.getAttribute("content") || null,
+      ogDescription:
+        document.querySelector("meta[property='og:description']")?.getAttribute("content") ||
+        null,
+      lang: document.documentElement.lang,
+    },
+  });
+})();

--- a/skills/vibe-aesthetic/walk.sh
+++ b/skills/vibe-aesthetic/walk.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Section-aware aesthetic walker — captures probe + per-section screenshots
+# at the requested viewport(s).
+#
+# Auto-discovers section anchors from the DOM (every `<section id="...">`
+# with non-zero rendered height). Falls back to viewport-height stepping
+# when no anchors are present.
+#
+# Usage: walk.sh <run-dir> <base-url> [--viewport mobile|desktop|both] [--quick]
+# Output: <run-dir>/sections/s<NN>_<id>__<viewport>.png
+#         <run-dir>/probes/tokens_<viewport>.json
+#         <run-dir>/walk.log
+
+set -euo pipefail
+IFS=$'\n\t'
+
+RUN_DIR="${1:?run dir required}"
+BASE="${2:?base url required}"
+shift 2
+
+VIEWPORT="both"
+QUICK=0
+while (( $# )); do
+  case "$1" in
+    --viewport) VIEWPORT="$2"; shift 2;;
+    --quick) QUICK=1; shift;;
+    *) shift;;
+  esac
+done
+
+BASE="${BASE%/}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROBE="$SCRIPT_DIR/probe.js"
+
+mkdir -p "$RUN_DIR/sections" "$RUN_DIR/probes"
+LOG="$RUN_DIR/walk.log"
+: > "$LOG"
+
+resolve_vibium() {
+  if command -v vibium >/dev/null 2>&1; then echo "vibium"; return; fi
+  if [[ -x "./clicker/bin/vibium" ]]; then echo "./clicker/bin/vibium"; return; fi
+  if [[ -x "./node_modules/.bin/vibium" ]]; then echo "./node_modules/.bin/vibium"; return; fi
+  echo "ERROR: vibium binary not found" >&2
+  exit 127
+}
+VIBIUM="$(resolve_vibium)"
+
+set_viewport() {
+  case "$1" in
+    mobile)  "$VIBIUM" viewport 390 844 --dpr 3 >/dev/null 2>&1 || true;;
+    desktop) "$VIBIUM" viewport 1280 800 --dpr 1 >/dev/null 2>&1 || true;;
+  esac
+}
+
+# Move screenshot from vibium's default save location into the run dir.
+# Older vibium builds save to ~/Pictures/Vibium/ regardless of -o; newer
+# builds (post-#119) honor the -o path. We handle both.
+relocate_shot() {
+  local out_name="$1"
+  local target="$RUN_DIR/sections/$out_name"
+  if [[ -f "$target" ]]; then return 0; fi
+  if [[ -f "$HOME/Pictures/Vibium/$out_name" ]]; then
+    mv "$HOME/Pictures/Vibium/$out_name" "$target"
+  fi
+}
+
+capture_at() {
+  local vp="$1" Y="$2" id="$3"
+  local out="${id}__${vp}.png"
+  "$VIBIUM" eval "window.scrollTo({top: $Y, behavior: 'smooth'}); '$id'" >/dev/null 2>&1 || true
+  sleep 3
+  "$VIBIUM" screenshot -o "$RUN_DIR/sections/$out" >/dev/null 2>&1 || true
+  relocate_shot "$out"
+  echo "  $id @ $vp y=$Y" >> "$LOG"
+}
+
+# Discover anchored sections in DOM order.
+# Returns a JSON array of {id, top, height}.
+discover_sections() {
+  "$VIBIUM" eval --stdin <<'EOF' 2>/dev/null | tail -1
+const sections = Array.from(document.querySelectorAll('section[id], main section[id], [data-section]'));
+const seen = new Set();
+const out = [];
+for (const el of sections) {
+  const r = el.getBoundingClientRect();
+  if (r.height < 50) continue;
+  const id = el.id || el.getAttribute('data-section') || '';
+  if (!id || seen.has(id)) continue;
+  seen.add(id);
+  out.push({ id, top: Math.round(r.top + window.scrollY), height: Math.round(r.height) });
+}
+JSON.stringify(out);
+EOF
+}
+
+probe_one_viewport() {
+  local vp="$1"
+  echo "→ $vp" | tee -a "$LOG"
+  set_viewport "$vp"
+  "$VIBIUM" go "$BASE" >/dev/null 2>&1 || true
+  sleep 5
+
+  # Top-of-page probe → tokens JSON.
+  if ! "$VIBIUM" eval --stdin < "$PROBE" > "$RUN_DIR/probes/tokens_${vp}.json" 2>/dev/null; then
+    echo "  probe-failed" >> "$LOG"
+  fi
+
+  # Always capture top.
+  capture_at "$vp" 0 "s00_top"
+
+  if (( QUICK )); then
+    # Quick mode: one mid shot + footer, done.
+    capture_at "$vp" 1200 "s01_mid"
+    local Y_BOT
+    Y_BOT=$("$VIBIUM" eval "document.documentElement.scrollHeight - window.innerHeight" 2>/dev/null | tail -1 | tr -d '"')
+    capture_at "$vp" "${Y_BOT:-4000}" "s99_bottom"
+    return
+  fi
+
+  # Discover section anchors.
+  local sections_json
+  sections_json="$(discover_sections || echo '[]')"
+  echo "  sections: $sections_json" >> "$LOG"
+
+  # Iterate sections by index.
+  local n
+  n=$(echo "$sections_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d))" 2>/dev/null || echo 0)
+
+  if (( n > 0 )); then
+    local i=0
+    while (( i < n )); do
+      local id_top
+      id_top=$(echo "$sections_json" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+e=d[$i]
+print(f\"{e['id']}|{e['top']}\")" 2>/dev/null)
+      local sec_id="${id_top%%|*}"
+      local sec_y="${id_top##*|}"
+      local idx
+      idx=$(printf "s%02d_%s" $((i + 1)) "$sec_id")
+      capture_at "$vp" "$sec_y" "$idx"
+      i=$((i + 1))
+    done
+  else
+    # Fallback: viewport-height stepping.
+    local doc_h
+    doc_h=$("$VIBIUM" eval "document.documentElement.scrollHeight" 2>/dev/null | tail -1 | tr -d '"')
+    doc_h="${doc_h:-4000}"
+    local step=${VP_H:-800}
+    local y=$step
+    local i=1
+    while (( y < doc_h - step )); do
+      local idx
+      idx=$(printf "s%02d_step" $i)
+      capture_at "$vp" "$y" "$idx"
+      y=$((y + step))
+      i=$((i + 1))
+      (( i > 8 )) && break  # safety cap
+    done
+  fi
+
+  # Always capture bottom.
+  local Y_BOT
+  Y_BOT=$("$VIBIUM" eval "document.documentElement.scrollHeight - window.innerHeight" 2>/dev/null | tail -1 | tr -d '"')
+  capture_at "$vp" "${Y_BOT:-4000}" "s99_bottom"
+}
+
+VP_H=844
+case "$VIEWPORT" in
+  mobile)  VP_H=844; probe_one_viewport "mobile";;
+  desktop) VP_H=800; probe_one_viewport "desktop";;
+  both)
+    VP_H=844; probe_one_viewport "mobile"
+    VP_H=800; probe_one_viewport "desktop"
+    ;;
+  *) echo "ERROR: --viewport must be mobile|desktop|both" >&2; exit 64;;
+esac
+
+shot_count=$(find "$RUN_DIR/sections" -name "*.png" 2>/dev/null | wc -l)
+probe_count=$(find "$RUN_DIR/probes" -name "*.json" 2>/dev/null | wc -l)
+echo "DONE. $shot_count section shots, $probe_count probes."


### PR DESCRIPTION
## Why

New skill in the `vibe-*` family for design evaluation. Where `vibe-explore` maps what a page lets you do and `vibe-recon` maps the auth wall, `vibe-aesthetic` asks *what does this page feel like, and where is it weak?*

Captures evidence (section screenshots at desktop + mobile, design-token probe), then renders an LLM-agnostic evaluator prompt that any host LLM can read to score the page across nine dimensions and produce an `AESTHETIC.md` deliverable.

Use cases the skill is built for:
- Pre-launch design review on a deployed site
- Post-rebrand verification — did the new identity actually land?
- Variant comparison — score two candidates on the same rubric
- Brand-family coherence — score sibling sites and see who's lifting / dragging

## What changed

New skill bundle at `skills/vibe-aesthetic/`:

- `SKILL.md` — entry brief, pipeline, daemon-hygiene notes
- `aesthetic.sh` — runner (prep + walk + prompt render)
- `walk.sh` — section-aware walker with auto-anchor discovery, viewport-stepped fallback when no `<section id>` elements exist
- `probe.js` — design-token probe (palette frequencies, typography, surface tokens, composition counts, meta). Returns `JSON.stringify(...)` so it serializes cleanly through `vibium eval --stdin`
- `prep.sh` — daemon hygiene enforcing `--headless` to prevent silent 0-byte captures on SSH/CI sessions with empty `DISPLAY`
- `PROMPT.md` — LLM-agnostic evaluator template with rubric, score anchors, output spec, and discipline notes
- `examples/reference-run.md` — anonymized 8-iteration trajectory (7.4 → 9.5) documenting realistic score movement, the code ceiling at ~8.7, and the photography-as-ceiling pattern

## How to test

From the repo root after building vibium:

```sh
make build-go
mkdir /tmp/aesthetic-test
skills/vibe-aesthetic/aesthetic.sh /tmp/aesthetic-test https://example.com/ --quick --viewport desktop
```

Expected:
- `/tmp/aesthetic-test/sections/s00_top__desktop.png` etc. exist and are non-zero
- `/tmp/aesthetic-test/probes/tokens_desktop.json` parses as valid JSON
- `/tmp/aesthetic-test/PROMPT.filled.md` contains the rubric + screenshot list + probe JSON
- `/tmp/aesthetic-test/RUN.md` has the run summary

For a fuller test against a real multi-section page (auto-anchor discovery exercised):

```sh
skills/vibe-aesthetic/aesthetic.sh /tmp/aesthetic-full https://news.ycombinator.com/ --viewport desktop
```

## Notes

- The skill is read-only by construction — no login required for public pages, no destructive surface.
- The shipped `PROMPT.md` template is editable — operators can retune the rubric (different dimension set, different acceptance bar, different domain register) without changing the capture pipeline.
- The daemon-headless lesson in `prep.sh` was discovered in the field — without it, every capture command logs success but writes nothing. Worth documenting upstream so future skill authors don't repeat the pattern.
- Tested against `example.com` (single-fold fallback path) and a real multi-section deployed site (auto-discovery captured 4 anchored sections plus top + bottom).
