### PR TITLE
Use npm.cmd on Windows in prepack + packaging test

### DIFF
--- a/packages/vibium/scripts/prepack.mjs
+++ b/packages/vibium/scripts/prepack.mjs
@@ -18,6 +18,10 @@ import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+// On Windows `npm` is `npm.cmd`; execFileSync doesn't go through a shell, so it
+// can't resolve the bare name and fails with ENOENT.
+const NPM = process.platform === "win32" ? "npm.cmd" : "npm";
+
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 const distDir = join(pkgDir, "dist");
 // packages/vibium -> packages -> <repo root> -> clients/javascript
@@ -43,7 +47,7 @@ function buildClient() {
   console.error("[prepack] Building JS client in clients/javascript ...");
   // Send the child's stdout to our stderr (fd 2) so build logs don't pollute
   // stdout either.
-  execFileSync("npm", ["run", "build"], { cwd: clientDir, stdio: ["ignore", 2, 2] });
+  execFileSync(NPM, ["run", "build"], { cwd: clientDir, stdio: ["ignore", 2, 2] });
 }
 
 function copyDist() {

--- a/tests/cli/packaging.test.js
+++ b/tests/cli/packaging.test.js
@@ -13,13 +13,15 @@ const os = require('node:os');
 const path = require('node:path');
 
 const PKG_DIR = path.join(__dirname, '../../packages/vibium');
+// On Windows `npm` is `npm.cmd`; execFileSync has no shell to resolve the bare name.
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 describe('Packaging: npm tarball contents', () => {
   test('npm pack includes the built dist files (#103/#127/#100)', () => {
     const dest = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-pack-'));
     // `npm pack --json` writes machine-readable output to stdout; the prepack
     // build logs go to stderr (see scripts/prepack.mjs).
-    const out = execFileSync('npm', ['pack', '--json', '--pack-destination', dest], {
+    const out = execFileSync(NPM, ['pack', '--json', '--pack-destination', dest], {
       cwd: PKG_DIR,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'inherit'],


### PR DESCRIPTION
## Summary

Two files added in the 26.5.31 work call `npm` via `execFileSync`, which fails on **Windows** with `ENOENT` — on Windows `npm` is `npm.cmd`, and `execFileSync` doesn't go through a shell to resolve the bare name:

- `tests/cli/packaging.test.js` — runs during `make test` (the `test-cli` no-daemon group), so **`make test` fails on Windows** at the packaging test.
- `packages/vibium/scripts/prepack.mjs` — runs on `npm pack`/`npm publish`, so **publishing from Windows** would break.

Fix: pick `npm.cmd` on `win32` (`process.platform === 'win32' ? 'npm.cmd' : 'npm'`) in both.

Behavior-preserving on macOS/Linux — verified the packaging test still passes locally.

> Should merge into `main` before publishing 26.5.31 / before validating the release on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)