### PR TITLE
Add Java (JDK) + Python prerequisites to Windows and Linux setup docs

### DIFF
--- a/docs/how-to-guides/local-dev-setup-x86-linux.md
+++ b/docs/how-to-guides/local-dev-setup-x86-linux.md
@@ -157,6 +157,30 @@ npm --version
 
 ---
 
+## Install Java (JDK)
+
+`make build` builds the Java client with Gradle, which needs a JDK (11 or newer — the build targets Java 11).
+
+```bash
+sudo apt install -y openjdk-21-jdk
+java -version
+```
+
+The apt package puts `java` on `PATH`, which is all Gradle needs.
+
+---
+
+## Install Python
+
+`make test` runs the Python client test suite, which uses a virtualenv. Ubuntu ships `python3` but not the `venv`/`pip` modules by default:
+
+```bash
+sudo apt install -y python3 python3-venv python3-pip
+python3 --version
+```
+
+---
+
 ## Install Tools
 
 ```bash

--- a/docs/how-to-guides/local-dev-setup-x86-windows.md
+++ b/docs/how-to-guides/local-dev-setup-x86-windows.md
@@ -201,6 +201,44 @@ npm --version
 
 ---
 
+## Install Java (JDK)
+
+`make build` builds the Java client with Gradle, which needs a JDK (11 or newer — the build targets Java 11).
+
+```powershell
+winget install Microsoft.OpenJDK.21
+```
+
+Restart terminal, then verify:
+```powershell
+java -version
+echo $env:JAVA_HOME
+```
+
+The Microsoft OpenJDK package sets `JAVA_HOME` automatically. If `./gradlew` still reports `JAVA_HOME is not set and no 'java' command could be found`, set it manually (point it at your JDK install — typically under `C:\Program Files\Microsoft\`) and restart the terminal:
+
+```powershell
+[Environment]::SetEnvironmentVariable("JAVA_HOME", "C:\Program Files\Microsoft\jdk-21.0.x.x-hotspot", "User")
+```
+
+---
+
+## Install Python
+
+`make test` runs the Python client test suite, which needs Python 3.
+
+```powershell
+winget install Python.Python.3.12
+```
+
+Restart terminal, then verify:
+```powershell
+python --version
+pip --version
+```
+
+---
+
 ## Install Claude Code
 
 ```powershell


### PR DESCRIPTION
## Summary

Both the Windows and Linux dev-setup guides installed Git/Make/Go/Node but **not a JDK or Python**, so following them and running `make build` fails:

```
ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
make: *** [build-java] Error 1
```

`make build` runs `build-java` (`./gradlew build`), which needs a JDK; and `make test` runs the Python client suite, which needs Python 3 (+ `venv`/`pip` on Linux). The macOS guide already covers both — this brings Windows and Linux in line.

- **Windows** (`local-dev-setup-x86-windows.md`): add `winget install Microsoft.OpenJDK.21` and `winget install Python.Python.3.12`, with a `JAVA_HOME` fallback note.
- **Linux** (`local-dev-setup-x86-linux.md`): add `sudo apt install -y openjdk-21-jdk` and `python3 python3-venv python3-pip` (Ubuntu ships `python3` but not `venv`/`pip`).

Reported from a real Windows VM run that hit the `JAVA_HOME` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)