### PR TITLE
Quote pack-destination in packaging test for Windows paths with spaces

### DIFF
--- a/tests/cli/packaging.test.js
+++ b/tests/cli/packaging.test.js
@@ -21,11 +21,17 @@ describe('Packaging: npm tarball contents', () => {
     const dest = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-pack-'));
     // `npm pack --json` writes machine-readable output to stdout; the prepack
     // build logs go to stderr (see scripts/prepack.mjs).
-    const out = execFileSync(NPM, ['pack', '--json', '--pack-destination', dest], {
+    // On Windows we must spawn via the shell (Node blocks .cmd otherwise), but
+    // the shell doesn't auto-quote args — so quote the destination ourselves in
+    // case the temp path contains a space (e.g. a username with a space). On
+    // POSIX there's no shell, so the path is passed literally.
+    const useShell = process.platform === 'win32';
+    const destArg = useShell ? `"${dest}"` : dest;
+    const out = execFileSync(NPM, ['pack', '--json', '--pack-destination', destArg], {
       cwd: PKG_DIR,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'inherit'],
-      shell: process.platform === 'win32',
+      shell: useShell,
     });
 
     try {


### PR DESCRIPTION
## Summary

Follow-up hardening to the Windows packaging-test fix. On Windows the test spawns `npm` with `shell: true` (Node ≥20.12 blocks `.cmd` via `execFileSync` otherwise), but the shell doesn't auto-quote arguments. An unquoted `--pack-destination <tmpdir>` would be split by `cmd.exe` if the temp path contained a space (e.g. a Windows username with a space like `C:\Users\John Doe\...`).

Quote the destination when running through the shell; pass it literally on POSIX (no shell, no quoting needed). Temp paths can't contain `"` on Windows, so wrapping in double quotes is safe.

Verified the test still passes on macOS (where `useShell` is false, so behavior is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)