### PR TITLE
Harden daemon control-file permissions

### DIFF
--- a/clicker/internal/daemon/daemon.go
+++ b/clicker/internal/daemon/daemon.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vibium/clicker/internal/log"
 	"github.com/vibium/clicker/internal/agent"
+	"github.com/vibium/clicker/internal/log"
 	"github.com/vibium/clicker/internal/paths"
 )
 
@@ -66,8 +66,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get daemon dir: %w", err)
 	}
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create daemon dir: %w", err)
+	if err := ensureDaemonDir(dir); err != nil {
+		return err
 	}
 
 	// Remove stale socket file
@@ -78,6 +78,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return fmt.Errorf("listen: %w", err)
 	}
 	d.listener = listener
+	if err := secureSocketPath(socketPath); err != nil {
+		listener.Close()
+		return err
+	}
 
 	// Write PID file
 	if err := WritePID(); err != nil {

--- a/clicker/internal/daemon/pidfile.go
+++ b/clicker/internal/daemon/pidfile.go
@@ -22,11 +22,17 @@ func WritePID() error {
 		return fmt.Errorf("get daemon dir: %w", err)
 	}
 
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create daemon dir: %w", err)
+	if err := ensureDaemonDir(dir); err != nil {
+		return err
 	}
 
-	return os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0644)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0600); err != nil {
+		return err
+	}
+	if err := os.Chmod(pidPath, 0600); err != nil {
+		return fmt.Errorf("chmod pid file: %w", err)
+	}
+	return nil
 }
 
 // ReadPID reads the PID from the PID file. Returns 0 if file doesn't exist.
@@ -87,4 +93,24 @@ func CleanStale() {
 			os.Remove(socketPath)
 		}
 	}
+}
+
+func ensureDaemonDir(dir string) error {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create daemon dir: %w", err)
+	}
+	if err := os.Chmod(dir, 0700); err != nil {
+		return fmt.Errorf("chmod daemon dir: %w", err)
+	}
+	return nil
+}
+
+func secureSocketPath(socketPath string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	if err := os.Chmod(socketPath, 0600); err != nil {
+		return fmt.Errorf("chmod socket: %w", err)
+	}
+	return nil
 }

--- a/clicker/internal/daemon/pidfile_test.go
+++ b/clicker/internal/daemon/pidfile_test.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/vibium/clicker/internal/paths"
+)
+
+func TestWritePIDUsesOwnerOnlyPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not meaningful on windows")
+	}
+
+	withTempCacheDir(t)
+
+	if err := WritePID(); err != nil {
+		t.Fatalf("WritePID() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := RemovePID(); err != nil {
+			t.Fatalf("RemovePID() error = %v", err)
+		}
+	})
+
+	dir, err := paths.GetDaemonDir()
+	if err != nil {
+		t.Fatalf("GetDaemonDir() error = %v", err)
+	}
+	assertMode(t, dir, 0o700)
+
+	pidPath, err := paths.GetPIDPath()
+	if err != nil {
+		t.Fatalf("GetPIDPath() error = %v", err)
+	}
+	assertMode(t, pidPath, 0o600)
+}
+
+func TestSecureSocketPathUsesOwnerOnlyPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket permissions do not apply on windows")
+	}
+
+	socketPath := filepath.Join(t.TempDir(), "vibium.sock")
+	if err := os.WriteFile(socketPath, []byte("socket placeholder"), 0o666); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := secureSocketPath(socketPath); err != nil {
+		t.Fatalf("secureSocketPath() error = %v", err)
+	}
+	assertMode(t, socketPath, 0o600)
+}
+
+func withTempCacheDir(t *testing.T) {
+	t.Helper()
+
+	baseDir, err := os.MkdirTemp("/tmp", "vibium-daemon-")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(baseDir); err != nil {
+			t.Fatalf("RemoveAll() error = %v", err)
+		}
+	})
+
+	cacheDir := filepath.Join(baseDir, "cache")
+	original := os.Getenv("VIBIUM_CACHE_DIR")
+	if err := os.Setenv("VIBIUM_CACHE_DIR", cacheDir); err != nil {
+		t.Fatalf("Setenv() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if original == "" {
+			if err := os.Unsetenv("VIBIUM_CACHE_DIR"); err != nil {
+				t.Fatalf("Unsetenv() error = %v", err)
+			}
+			return
+		}
+		if err := os.Setenv("VIBIUM_CACHE_DIR", original); err != nil {
+			t.Fatalf("restore env error = %v", err)
+		}
+	})
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q) error = %v", path, err)
+	}
+
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode for %s = %04o, want %04o", path, got, want)
+	}
+}


### PR DESCRIPTION
# Summary
- Harden the daemon control directory, PID file, and Unix socket to owner-only permissions.
- Add regression tests covering daemon dir, PID file, and socket-path permissions.
# Why
The local daemon exposes unauthenticated control RPCs, so permissive filesystem modes weakened the boundary around that control surface.
# Verification
```sh
cd clicker && GOCACHE=/tmp/vibium-gocache go test ./internal/daemon
cd clicker && GOCACHE=/tmp/vibium-gocache go test ./...
```