### PR TITLE
Bind serve to loopback and reject non-local WebSocket origins

### DIFF
--- a/clicker/internal/api/server.go
+++ b/clicker/internal/api/server.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,6 +32,7 @@ type ClientTransport interface {
 
 // Server is a WebSocket server that accepts client connections.
 type Server struct {
+	host       string
 	port       int
 	httpServer *http.Server
 	upgrader   websocket.Upgrader
@@ -88,13 +91,11 @@ func WithOnClose(fn func(ClientTransport)) ServerOption {
 // NewServer creates a new WebSocket server.
 func NewServer(opts ...ServerOption) *Server {
 	s := &Server{
+		host: "127.0.0.1",
 		port: 9515, // default port
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  maxMessageSize,
 			WriteBufferSize: maxMessageSize,
-			CheckOrigin: func(r *http.Request) bool {
-				return true // Allow all origins
-			},
 		},
 	}
 
@@ -102,7 +103,45 @@ func NewServer(opts ...ServerOption) *Server {
 		opt(s)
 	}
 
+	s.upgrader.CheckOrigin = s.checkOrigin
+
 	return s
+}
+
+func (s *Server) listenAddr() string {
+	return fmt.Sprintf("%s:%d", s.host, s.port)
+}
+
+func (s *Server) checkOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	originHost := parsed.Hostname()
+	if originHost == "" {
+		return false
+	}
+
+	if isLoopbackHost(s.host) {
+		return isLoopbackHost(originHost)
+	}
+
+	return strings.EqualFold(originHost, s.host)
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // Port returns the port the server is listening on.
@@ -115,10 +154,8 @@ func (s *Server) Start() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.handleWebSocket)
 
-	addr := fmt.Sprintf(":%d", s.port)
-
 	// Bind to the port (port 0 = OS-assigned random port)
-	listener, err := net.Listen("tcp", addr)
+	listener, err := net.Listen("tcp", s.listenAddr())
 	if err != nil {
 		return fmt.Errorf("failed to listen on port %d: %w", s.port, err)
 	}

--- a/clicker/internal/api/server_test.go
+++ b/clicker/internal/api/server_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewServerRejectsNonLocalOrigins(t *testing.T) {
+	server := NewServer()
+
+	req := httptest.NewRequest("GET", "http://127.0.0.1:9515/", nil)
+	req.Header.Set("Origin", "https://evil.example")
+
+	if server.upgrader.CheckOrigin(req) {
+		t.Fatalf("expected cross-origin websocket request to be rejected")
+	}
+}
+
+func TestNewServerDefaultsToLoopbackListenAddress(t *testing.T) {
+	server := NewServer(WithPort(0))
+
+	if got, want := server.listenAddr(), "127.0.0.1:0"; got != want {
+		t.Fatalf("listenAddr() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Bind `vibium serve` to loopback by default and reject non-local WebSocket origins.

## Root Cause

The proxy server printed a `ws://localhost:...` endpoint, but `clicker/internal/api/server.go` actually listened on `:port`, which exposed the server on every interface. The same server also accepted every WebSocket origin via `CheckOrigin`, so any reachable browser page could attach if the port was accessible.

## What Changed

- default the WebSocket server host to `127.0.0.1`
- route `Start()` through the loopback listen address instead of all interfaces
- reject non-local `Origin` headers while still allowing clients that send no `Origin`
- add regression tests for loopback binding and cross-origin rejection

## Impact

This keeps `serve` aligned with its local-only contract and closes an avoidable remote-control surface for browser automation.

## Validation

- `cd clicker && GOCACHE=/private/tmp/vibium-go-build-cache go test ./internal/api`

## Notes

- `go test ./...` still fails for a pre-existing repository issue: `clicker/cmd/clicker/skill.go` embeds a missing `SKILL.md`.
