### PR TITLE
feat(browser): support custom Chrome flags via VIBIUM_CHROME_ARGS

### DIFF
--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/vibium/clicker/internal/bidi"
@@ -250,7 +251,18 @@ func chromeArgs(headless bool) []string {
 	if headless {
 		args = append(args, "--headless=new")
 	}
+	// Append any custom flags from VIBIUM_CHROME_ARGS (space-separated) so users
+	// can pass --no-sandbox etc. in root/CI/container environments where Chrome
+	// refuses to start otherwise. Empty tokens (from extra whitespace) are skipped.
+	args = append(args, customChromeArgs()...)
 	return args
+}
+
+// customChromeArgs reads extra Chrome flags from the VIBIUM_CHROME_ARGS
+// environment variable, splitting on whitespace and dropping empty tokens.
+// Returns nil when the variable is unset or contains only whitespace.
+func customChromeArgs() []string {
+	return strings.Fields(os.Getenv("VIBIUM_CHROME_ARGS"))
 }
 
 // buildCapabilities returns the capabilities map for BiDi session.new.

--- a/clicker/internal/browser/launcher_test.go
+++ b/clicker/internal/browser/launcher_test.go
@@ -1,0 +1,52 @@
+package browser
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestChromeArgsCustomEnv verifies that flags supplied via VIBIUM_CHROME_ARGS
+// are appended to the Chrome argv so users can pass --no-sandbox etc. in
+// root/CI/container environments (issue #141).
+func TestChromeArgsCustomEnv(t *testing.T) {
+	t.Setenv("VIBIUM_CHROME_ARGS", "--no-sandbox --disable-gpu")
+
+	args := chromeArgs(false)
+
+	if !slices.Contains(args, "--no-sandbox") {
+		t.Errorf("expected --no-sandbox in chrome args, got %v", args)
+	}
+	if !slices.Contains(args, "--disable-gpu") {
+		t.Errorf("expected --disable-gpu in chrome args, got %v", args)
+	}
+}
+
+// TestChromeArgsCustomEnvUnset verifies the argv is unchanged when the env var
+// is absent, and that no empty-string args ever leak into the list.
+func TestChromeArgsCustomEnvUnset(t *testing.T) {
+	t.Setenv("VIBIUM_CHROME_ARGS", "")
+
+	args := chromeArgs(false)
+
+	if slices.Contains(args, "") {
+		t.Errorf("expected no empty-string args, got %v", args)
+	}
+	if slices.Contains(args, "--no-sandbox") {
+		t.Errorf("did not expect --no-sandbox when env unset, got %v", args)
+	}
+}
+
+// TestChromeArgsCustomEnvWhitespace verifies that extra whitespace between and
+// around flags is split cleanly without producing empty-string args.
+func TestChromeArgsCustomEnvWhitespace(t *testing.T) {
+	t.Setenv("VIBIUM_CHROME_ARGS", "  --no-sandbox   --disable-gpu  ")
+
+	args := chromeArgs(false)
+
+	if slices.Contains(args, "") {
+		t.Errorf("expected no empty-string args from whitespace, got %v", args)
+	}
+	if !slices.Contains(args, "--no-sandbox") || !slices.Contains(args, "--disable-gpu") {
+		t.Errorf("expected both flags parsed from padded input, got %v", args)
+	}
+}


### PR DESCRIPTION
## Summary

`chromeArgs` built a fixed flag list, so there was no way to pass extra Chrome flags (e.g. `--no-sandbox`) needed to run as root in CI/container environments (#141, option 1 from the issue).

## Fix

`clicker/internal/browser/launcher.go`: read `VIBIUM_CHROME_ARGS` (space-separated, empty tokens skipped) and append the flags to `goog:chromeOptions`, with no client-SDK changes — so it works across all language clients. Added launcher tests covering the set / unset / whitespace-padded env cases.

Closes #141
