### PR TITLE
fix: negative values parsed as flags in sleep, fill, type, geolocation

### DIFF
--- a/clicker/cmd/clicker/fill.go
+++ b/clicker/cmd/clicker/fill.go
@@ -5,19 +5,18 @@ import (
 )
 
 func newFillCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "fill [selector] [text]",
 		Short: "Clear an input field and type new text",
 		Example: `  vibium fill "input[name=email]" "user@example.com"
   # Clear the field and type new value
-
   vibium fill "#search" "vibium"
   # Replace search field contents`,
-		Args: cobra.ExactArgs(2),
+		DisableFlagParsing: true,
+		Args:               cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
 			text := args[1]
-
 			result, err := daemonCall("browser_fill", map[string]interface{}{
 				"selector": selector,
 				"value":    text,
@@ -29,4 +28,5 @@ func newFillCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	return cmd
 }

--- a/clicker/cmd/clicker/geolocation.go
+++ b/clicker/cmd/clicker/geolocation.go
@@ -48,5 +48,6 @@ func newGeolocationCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Float64("accuracy", 0, "Accuracy in meters (default: 1)")
+	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/clicker/cmd/clicker/sleep_cmd.go
+++ b/clicker/cmd/clicker/sleep_cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 func newSleepCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "sleep [ms]",
 		Short: "Pause execution for a number of milliseconds",
 		Example: `  vibium sleep 1000
@@ -17,7 +17,8 @@ func newSleepCmd() *cobra.Command {
 
   vibium sleep 500
   # Wait 500ms`,
-		Args: cobra.ExactArgs(1),
+		DisableFlagParsing: true,
+		Args:               cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ms, err := strconv.ParseFloat(args[0], 64)
 			if err != nil {
@@ -33,4 +34,6 @@ func newSleepCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	cmd.Flags().SetInterspersed(false)
+	return cmd
 }

--- a/clicker/cmd/clicker/type_cmd.go
+++ b/clicker/cmd/clicker/type_cmd.go
@@ -50,5 +50,6 @@ func newTypeCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Duration("timeout", api.DefaultTimeout, "Timeout for actionability checks (e.g., 5s, 30s)")
+	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/tests/cli/input-tools.test.js
+++ b/tests/cli/input-tools.test.js
@@ -42,7 +42,7 @@ describe('CLI: Input Tools', () => {
   });
 });
 
-describe('CLI: Negative value flag parsing (B14, B18, B22)', () => {
+describe('CLI: Negative value flag parsing', () => {
   test('sleep rejects negative value with meaningful error, not flag parse error', () => {
     try {
       execSync(`${VIBIUM} sleep -1`, { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' });
@@ -52,5 +52,33 @@ describe('CLI: Negative value flag parsing (B14, B18, B22)', () => {
       assert.doesNotMatch(output, /unknown shorthand flag/, 'Should not treat -1 as a flag');
       assert.match(output, /positive|invalid/, 'Should give a meaningful error');
     }
+  });
+
+  test('geolocation accepts negative coordinates', () => {
+    const result = execSync(`${VIBIUM} geolocation 37.7749 -122.4194`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /Geolocation set/, 'Should set geolocation with negative longitude');
+  });
+
+  test('fill accepts negative numeric value', () => {
+    execSync(`${VIBIUM} go https://the-internet.herokuapp.com/login`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const result = execSync(`${VIBIUM} fill "#username" "-2"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.doesNotMatch(result, /unknown shorthand flag/, 'Should not treat -2 as a flag');
+  });
+
+  test('type accepts negative numeric value', () => {
+    const result = execSync(`${VIBIUM} type https://the-internet.herokuapp.com/login "#username" "-2"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.doesNotMatch(result, /unknown shorthand flag/, 'Should not treat -2 as a flag');
   });
 });

--- a/tests/cli/input-tools.test.js
+++ b/tests/cli/input-tools.test.js
@@ -41,3 +41,16 @@ describe('CLI: Input Tools', () => {
     assert.match(result, /SKILL\.md/, 'Should mention SKILL.md');
   });
 });
+
+describe('CLI: Negative value flag parsing (B14, B18, B22)', () => {
+  test('sleep rejects negative value with meaningful error, not flag parse error', () => {
+    try {
+      execSync(`${VIBIUM} sleep -1`, { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' });
+      assert.fail('Should have thrown');
+    } catch (err) {
+      const output = err.stderr + err.stdout;
+      assert.doesNotMatch(output, /unknown shorthand flag/, 'Should not treat -1 as a flag');
+      assert.match(output, /positive|invalid/, 'Should give a meaningful error');
+    }
+  });
+});


### PR DESCRIPTION
Fixes B14, B18, and B22 from #112.
Negative numeric values passed to `geolocation`, `fill`, `type`, and `sleep` were being intercepted by Cobra's flag parser and treated as flag shorthands (e.g. `-122` -> unknown flag `-1`).

- `sleep` and `fill` have no flags, so `DisableFlagParsing: true' is safe and fully fixes the issue.
- `type` and `geolocation` have flags (`--timeout`, `--accuracy`), so `SetInterspersed(false)` is used instead, which stops flag parsing once the first positional argument is seen.