### PR TITLE
fix: eval returns proper JSON for objects and arrays

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -1206,7 +1206,12 @@ func (h *Handlers) browserEvaluate(args map[string]interface{}) (*ToolsCallResul
 	case nil:
 		resultText = "null"
 	default:
-		resultText = fmt.Sprintf("%v", v)
+		b, err := json.Marshal(v)
+		if err != nil {
+			resultText = fmt.Sprintf("%v", v)
+		} else {
+			resultText = string(b)
+		}
 	}
 
 	return &ToolsCallResult{

--- a/clicker/internal/bidi/script.go
+++ b/clicker/internal/bidi/script.go
@@ -66,9 +66,9 @@ func (c *Client) Evaluate(context, expression string) (interface{}, error) {
 	}
 
 	params := map[string]interface{}{
-		"expression":    expression,
-		"target":        map[string]interface{}{"context": context},
-		"awaitPromise":  true,
+		"expression":      expression,
+		"target":          map[string]interface{}{"context": context},
+		"awaitPromise":    true,
 		"resultOwnership": "none",
 	}
 
@@ -96,7 +96,7 @@ func (c *Client) Evaluate(context, expression string) (interface{}, error) {
 		return nil, fmt.Errorf("failed to parse remote value: %w", err)
 	}
 
-	return remoteValue.Value, nil
+	return convertRemoteValue(remoteValue), nil
 }
 
 // CallFunction calls a JavaScript function with arguments.
@@ -152,7 +152,7 @@ func (c *Client) CallFunction(context, functionDeclaration string, args []interf
 		return nil, fmt.Errorf("failed to parse remote value: %w", err)
 	}
 
-	return remoteValue.Value, nil
+	return convertRemoteValue(remoteValue), nil
 }
 
 // serializeValue converts a Go value to a BiDi serialized value.
@@ -171,3 +171,58 @@ func serializeValue(v interface{}) map[string]interface{} {
 		return map[string]interface{}{"type": "string", "value": fmt.Sprintf("%v", val)}
 	}
 }
+
+// convertRemoteValue recursively converts a BiDi RemoteValue into a plain Go
+// value suitable for JSON serialization. Primitives pass through unchanged;
+// arrays and objects are reconstructed by converting each child element.
+func convertRemoteValue(rv RemoteValue) interface{} {
+	switch rv.Type {
+	case "string", "number", "boolean":
+		return rv.Value
+	case "null", "undefined":
+		return nil
+	case "array":
+		items, ok := rv.Value.([]interface{})
+		if !ok {
+			return rv.Value
+		}
+		result := make([]interface{}, len(items))
+		for i, item := range items {
+			b, _ := json.Marshal(item)
+			var child RemoteValue
+			if err := json.Unmarshal(b, &child); err == nil {
+				result[i] = convertRemoteValue(child)
+			} else {
+				result[i] = item
+			}
+		}
+		return result
+	case "object":
+		pairs, ok := rv.Value.([]interface{})
+		if !ok {
+			return rv.Value
+		}
+		result := make(map[string]interface{})
+		for _, pair := range pairs {
+			kv, ok := pair.([]interface{})
+			if !ok || len(kv) != 2 {
+				continue
+			}
+			key, ok := kv[0].(string)
+			if !ok {
+				continue
+			}
+			b, _ := json.Marshal(kv[1])
+			var child RemoteValue
+			if err := json.Unmarshal(b, &child); err == nil {
+				result[key] = convertRemoteValue(child)
+			} else {
+				result[key] = kv[1]
+			}
+		}
+		return result
+	default:
+		return rv.Value
+	}
+}
+

--- a/clicker/internal/bidi/script.go
+++ b/clicker/internal/bidi/script.go
@@ -188,13 +188,7 @@ func convertRemoteValue(rv RemoteValue) interface{} {
 		}
 		result := make([]interface{}, len(items))
 		for i, item := range items {
-			b, _ := json.Marshal(item)
-			var child RemoteValue
-			if err := json.Unmarshal(b, &child); err == nil {
-				result[i] = convertRemoteValue(child)
-			} else {
-				result[i] = item
-			}
+			result[i] = convertRemoteValue(remoteValueFrom(item))
 		}
 		return result
 	case "object":
@@ -202,26 +196,39 @@ func convertRemoteValue(rv RemoteValue) interface{} {
 		if !ok {
 			return rv.Value
 		}
-		result := make(map[string]interface{})
+		result := make(map[string]interface{}, len(pairs))
 		for _, pair := range pairs {
 			kv, ok := pair.([]interface{})
 			if !ok || len(kv) != 2 {
 				continue
 			}
+			// BiDi allows non-string keys (e.g. a Map keyed by objects), but a
+			// plain JS object always uses string keys. A non-string key can't be
+			// a Go map[string]interface{} key, so such entries are skipped.
 			key, ok := kv[0].(string)
 			if !ok {
 				continue
 			}
-			b, _ := json.Marshal(kv[1])
-			var child RemoteValue
-			if err := json.Unmarshal(b, &child); err == nil {
-				result[key] = convertRemoteValue(child)
-			} else {
-				result[key] = kv[1]
-			}
+			result[key] = convertRemoteValue(remoteValueFrom(kv[1]))
 		}
 		return result
 	default:
 		return rv.Value
 	}
+}
+
+// remoteValueFrom interprets a child element of an array/object RemoteValue
+// (decoded by encoding/json into interface{}) as a RemoteValue. Children arrive
+// as map[string]interface{} carrying "type"/"value" fields; anything else is
+// wrapped so its raw value passes through convertRemoteValue's default case.
+func remoteValueFrom(v interface{}) RemoteValue {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return RemoteValue{Value: v}
+	}
+	rv := RemoteValue{Value: m["value"]}
+	if t, ok := m["type"].(string); ok {
+		rv.Type = t
+	}
+	return rv
 }

--- a/clicker/internal/bidi/script.go
+++ b/clicker/internal/bidi/script.go
@@ -225,4 +225,3 @@ func convertRemoteValue(rv RemoteValue) interface{} {
 		return rv.Value
 	}
 }
-

--- a/clicker/internal/bidi/script_test.go
+++ b/clicker/internal/bidi/script_test.go
@@ -1,0 +1,101 @@
+package bidi
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// parseRemoteValue decodes a raw BiDi RemoteValue JSON payload the same way the
+// Evaluate/CallFunction code paths do, so tests exercise the real decode shape
+// (numbers become float64, nested values become map[string]interface{}).
+func parseRemoteValue(t *testing.T, raw string) RemoteValue {
+	t.Helper()
+	var rv RemoteValue
+	if err := json.Unmarshal([]byte(raw), &rv); err != nil {
+		t.Fatalf("unmarshal %q: %v", raw, err)
+	}
+	return rv
+}
+
+func TestConvertRemoteValue(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want interface{}
+	}{
+		{
+			name: "string",
+			raw:  `{"type":"string","value":"hello"}`,
+			want: "hello",
+		},
+		{
+			name: "number",
+			raw:  `{"type":"number","value":3}`,
+			want: float64(3),
+		},
+		{
+			name: "boolean",
+			raw:  `{"type":"boolean","value":true}`,
+			want: true,
+		},
+		{
+			name: "null",
+			raw:  `{"type":"null"}`,
+			want: nil,
+		},
+		{
+			name: "undefined",
+			raw:  `{"type":"undefined"}`,
+			want: nil,
+		},
+		{
+			name: "array of primitives",
+			raw: `{"type":"array","value":[` +
+				`{"type":"number","value":1},` +
+				`{"type":"number","value":2},` +
+				`{"type":"number","value":3}]}`,
+			want: []interface{}{float64(1), float64(2), float64(3)},
+		},
+		{
+			name: "flat object",
+			raw: `{"type":"object","value":[` +
+				`["title",{"type":"string","value":"Example"}],` +
+				`["count",{"type":"number","value":5}]]}`,
+			want: map[string]interface{}{"title": "Example", "count": float64(5)},
+		},
+		{
+			name: "nested object",
+			raw: `{"type":"object","value":[` +
+				`["a",{"type":"object","value":[` +
+				`["b",{"type":"number","value":1}]]}]]}`,
+			want: map[string]interface{}{
+				"a": map[string]interface{}{"b": float64(1)},
+			},
+		},
+		{
+			name: "array of objects",
+			raw: `{"type":"array","value":[` +
+				`{"type":"object","value":[["x",{"type":"number","value":1}]]}]}`,
+			want: []interface{}{
+				map[string]interface{}{"x": float64(1)},
+			},
+		},
+		{
+			name: "object with non-string key is skipped",
+			raw: `{"type":"object","value":[` +
+				`[{"type":"object","value":[]},{"type":"number","value":1}],` +
+				`["ok",{"type":"number","value":2}]]}`,
+			want: map[string]interface{}{"ok": float64(2)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertRemoteValue(parseRemoteValue(t, tt.raw))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertRemoteValue() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/cli/navigation.test.js
+++ b/tests/cli/navigation.test.js
@@ -59,4 +59,21 @@ describe('CLI: Navigation', () => {
     });
     assert.match(result, /Example Domain/i, 'Should return page title');
   });
+  test('eval returns valid JSON for objects', () => {
+    const result = execSync(`${VIBIUM} eval https://example.com "({title: document.title, url: location.href})"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const parsed = JSON.parse(result.trim());
+    assert.ok(parsed.title, 'Should have title key');
+    assert.ok(parsed.url, 'Should have url key');
+  });
+  test('eval returns valid JSON for arrays', () => {
+    const result = execSync(`${VIBIUM} eval https://example.com "[1, 2, 3]"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const parsed = JSON.parse(result.trim());
+    assert.deepStrictEqual(parsed, [1, 2, 3], 'Should return array as JSON');
+  });
 });


### PR DESCRIPTION
Fixes B9 from #112. 

`vibium eval` was printing Go's internal struct representation instead of JSON for objects and arrays (e.g., `map[type:string value:...]`). 

Cause: The BiDi protocol returns compound JS values as nested type maps.

Fixes:

- `convertRemoteValue` added to `bidi/script.go` to convert the BiDi value tree into plain Go maps/slices
- `browserEvaluate` in `agent/handlers.go` updated to use `json.Marshal` instead of `fmt.Sprintf` in the default case.

Also added regression tests for object and array output to `tests/cli/navigation.test.js`. Verified that they fail on the main branch and pass after these fixes.