### PR TITLE
Unify --timeout flag across CLI: accept both 5s and 5000 (ms)

### DIFF
--- a/clicker/cmd/clicker/check_cmd.go
+++ b/clicker/cmd/clicker/check_cmd.go
@@ -1,20 +1,29 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
 func newCheckCmd() *cobra.Command {
-	return &cobra.Command{
+	var timeout time.Duration
+	cmd := &cobra.Command{
 		Use:   "check [selector]",
 		Short: "Check a checkbox or radio button",
 		Example: `  vibium check "input[name=agree]"
-  # Check the "agree" checkbox (idempotent)`,
+  # Check the "agree" checkbox (idempotent)
+
+  vibium check "input[name=agree]" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
 
-			result, err := daemonCall("browser_check", map[string]interface{}{"selector": selector})
+			result, err := daemonCall("browser_check", map[string]interface{}{
+				"selector": selector,
+				"timeout":  float64(timeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -22,4 +31,6 @@ func newCheckCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	return cmd
 }

--- a/clicker/cmd/clicker/click.go
+++ b/clicker/cmd/clicker/click.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
-	"github.com/vibium/clicker/internal/api"
 )
 
 func newClickCmd() *cobra.Command {
+	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "click [url] [selector]",
 		Short: "Click an element (optionally navigate to URL first)",
@@ -16,7 +18,7 @@ func newClickCmd() *cobra.Command {
   # Navigates to URL first, then clicks
 
   vibium click https://example.com "a" --timeout 5s
-  # Custom timeout for actionability checks`,
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
 			var selector string
@@ -34,7 +36,6 @@ func newClickCmd() *cobra.Command {
 			}
 
 			// Click element
-			timeout, _ := cmd.Flags().GetDuration("timeout")
 			result, err := daemonCall("browser_click", map[string]interface{}{
 				"selector": selector,
 				"timeout":  float64(timeout.Milliseconds()),
@@ -46,6 +47,6 @@ func newClickCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	cmd.Flags().Duration("timeout", api.DefaultTimeout, "Timeout for actionability checks (e.g., 5s, 30s)")
+	addTimeoutFlag(cmd, &timeout)
 	return cmd
 }

--- a/clicker/cmd/clicker/dblclick.go
+++ b/clicker/cmd/clicker/dblclick.go
@@ -1,23 +1,32 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
 func newDblClickCmd() *cobra.Command {
-	return &cobra.Command{
+	var timeout time.Duration
+	cmd := &cobra.Command{
 		Use:   "dblclick [selector]",
 		Short: "Double-click an element",
 		Example: `  vibium dblclick "td.cell"
   # Double-click to edit a table cell
 
   vibium dblclick @e2
-  # Double-click element from map`,
+  # Double-click element from map
+
+  vibium dblclick "td.cell" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
 
-			result, err := daemonCall("browser_dblclick", map[string]interface{}{"selector": selector})
+			result, err := daemonCall("browser_dblclick", map[string]interface{}{
+				"selector": selector,
+				"timeout":  float64(timeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -25,4 +34,6 @@ func newDblClickCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	return cmd
 }

--- a/clicker/cmd/clicker/drag.go
+++ b/clicker/cmd/clicker/drag.go
@@ -1,26 +1,33 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
 func newDragCmd() *cobra.Command {
-	return &cobra.Command{
+	var timeout time.Duration
+	cmd := &cobra.Command{
 		Use:   "drag [source] [target]",
 		Short: "Drag from one element to another",
 		Example: `  vibium drag ".draggable" ".dropzone"
   # Drag element to drop target
 
   vibium drag @e1 @e3
-  # Drag using map refs`,
+  # Drag using map refs
+
+  vibium drag ".draggable" ".dropzone" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			source := args[0]
 			target := args[1]
 
 			result, err := daemonCall("browser_drag", map[string]interface{}{
-				"source": source,
-				"target": target,
+				"source":  source,
+				"target":  target,
+				"timeout": float64(timeout.Milliseconds()),
 			})
 			if err != nil {
 				printError(err)
@@ -29,4 +36,6 @@ func newDragCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	return cmd
 }

--- a/clicker/cmd/clicker/fill.go
+++ b/clicker/cmd/clicker/fill.go
@@ -1,25 +1,31 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
 func newFillCmd() *cobra.Command {
+	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "fill [selector] [text]",
 		Short: "Clear an input field and type new text",
 		Example: `  vibium fill "input[name=email]" "user@example.com"
   # Clear the field and type new value
   vibium fill "#search" "vibium"
-  # Replace search field contents`,
-		DisableFlagParsing: true,
-		Args:               cobra.ExactArgs(2),
+  # Replace search field contents
+
+  vibium fill "#search" "vibium" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
+		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
 			text := args[1]
 			result, err := daemonCall("browser_fill", map[string]interface{}{
 				"selector": selector,
 				"value":    text,
+				"timeout":  float64(timeout.Milliseconds()),
 			})
 			if err != nil {
 				printError(err)
@@ -28,5 +34,10 @@ func newFillCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	// fill now carries a --timeout flag, so it can't disable flag parsing the way
+	// #179 did for the flagless case. SetInterspersed(false) instead keeps negative
+	// positional values (e.g. fill "#x" "-2") from being parsed as shorthand flags.
+	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/clicker/cmd/clicker/focus.go
+++ b/clicker/cmd/clicker/focus.go
@@ -1,23 +1,32 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
 func newFocusCmd() *cobra.Command {
-	return &cobra.Command{
+	var timeout time.Duration
+	cmd := &cobra.Command{
 		Use:   "focus [selector]",
 		Short: "Focus an element",
 		Example: `  vibium focus "input[name=email]"
   # Focus the email input
 
   vibium focus @e1
-  # Focus element from map`,
+  # Focus element from map
+
+  vibium focus "input[name=email]" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
 
-			result, err := daemonCall("browser_focus", map[string]interface{}{"selector": selector})
+			result, err := daemonCall("browser_focus", map[string]interface{}{
+				"selector": selector,
+				"timeout":  float64(timeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -25,4 +34,6 @@ func newFocusCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	return cmd
 }

--- a/clicker/cmd/clicker/hover.go
+++ b/clicker/cmd/clicker/hover.go
@@ -1,18 +1,24 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
 func newHoverCmd() *cobra.Command {
-	return &cobra.Command{
+	var timeout time.Duration
+	cmd := &cobra.Command{
 		Use:   "hover [selector]",
 		Short: "Hover over an element by CSS selector",
 		Example: `  vibium hover "a"
   # Hover over first link
 
   vibium hover https://example.com "a"
-  # Navigate then hover`,
+  # Navigate then hover
+
+  vibium hover "a" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
 			var selector string
@@ -27,7 +33,10 @@ func newHoverCmd() *cobra.Command {
 				selector = args[0]
 			}
 
-			result, err := daemonCall("browser_hover", map[string]interface{}{"selector": selector})
+			result, err := daemonCall("browser_hover", map[string]interface{}{
+				"selector": selector,
+				"timeout":  float64(timeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -35,4 +44,6 @@ func newHoverCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	return cmd
 }

--- a/clicker/cmd/clicker/scroll.go
+++ b/clicker/cmd/clicker/scroll.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
@@ -47,14 +49,21 @@ func newScrollCmd() *cobra.Command {
 	cmd.Flags().Int("amount", 3, "Number of scroll increments")
 	cmd.Flags().String("selector", "", "CSS selector for element to scroll to")
 
+	var intoViewTimeout time.Duration
 	intoViewCmd := &cobra.Command{
 		Use:   "into-view [selector]",
 		Short: "Scroll an element into view",
 		Example: `  vibium scroll into-view "#footer"
-  # Scroll the footer element into view (centered on screen)`,
+  # Scroll the footer element into view (centered on screen)
+
+  vibium scroll into-view "#footer" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := daemonCall("browser_scroll_into_view", map[string]interface{}{"selector": args[0]})
+			result, err := daemonCall("browser_scroll_into_view", map[string]interface{}{
+				"selector": args[0],
+				"timeout":  float64(intoViewTimeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -62,6 +71,7 @@ func newScrollCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(intoViewCmd, &intoViewTimeout)
 
 	cmd.AddCommand(intoViewCmd)
 	return cmd

--- a/clicker/cmd/clicker/select_cmd.go
+++ b/clicker/cmd/clicker/select_cmd.go
@@ -1,15 +1,21 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
 func newSelectCmd() *cobra.Command {
-	return &cobra.Command{
+	var timeout time.Duration
+	cmd := &cobra.Command{
 		Use:   "select [selector] [value]",
 		Short: "Select an option in a <select> element",
 		Example: `  vibium select "select#color" "blue"
-  # Select "blue" in the color dropdown`,
+  # Select "blue" in the color dropdown
+
+  vibium select "select#color" "blue" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
@@ -18,6 +24,7 @@ func newSelectCmd() *cobra.Command {
 			result, err := daemonCall("browser_select", map[string]interface{}{
 				"selector": selector,
 				"value":    value,
+				"timeout":  float64(timeout.Milliseconds()),
 			})
 			if err != nil {
 				printError(err)
@@ -26,4 +33,6 @@ func newSelectCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	return cmd
 }

--- a/clicker/cmd/clicker/timeout_flag.go
+++ b/clicker/cmd/clicker/timeout_flag.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/vibium/clicker/internal/api"
+)
+
+// timeoutValue is a pflag.Value for --timeout that accepts either a Go duration
+// string ("5s", "500ms", "2m") or a bare number interpreted as milliseconds
+// ("5000"). The parsed value is stored as a time.Duration.
+type timeoutValue struct{ d *time.Duration }
+
+func (t *timeoutValue) String() string {
+	if t.d == nil {
+		return ""
+	}
+	return t.d.String()
+}
+
+func (t *timeoutValue) Type() string { return "timeout" }
+
+func (t *timeoutValue) Set(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return fmt.Errorf("empty timeout")
+	}
+	// A bare number means milliseconds (e.g. "5000", "1500").
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		if f < 0 {
+			return fmt.Errorf("negative timeout: %s", s)
+		}
+		*t.d = time.Duration(f * float64(time.Millisecond))
+		return nil
+	}
+	// Otherwise a Go duration string (e.g. "5s", "500ms", "2m").
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid timeout %q: use e.g. 5s or 5000 (bare number = milliseconds)", s)
+	}
+	if d < 0 {
+		return fmt.Errorf("negative timeout: %s", s)
+	}
+	*t.d = d
+	return nil
+}
+
+// addTimeoutFlag registers a unified --timeout flag on cmd, storing the parsed
+// value into *target. The target is seeded with the default so --help shows it
+// and commands can forward it unconditionally.
+func addTimeoutFlag(cmd *cobra.Command, target *time.Duration) {
+	*target = api.DefaultTimeout
+	cmd.Flags().Var(&timeoutValue{d: target}, "timeout",
+		"Max time to wait, e.g. 5s or 5000 (bare number = milliseconds)")
+}

--- a/clicker/cmd/clicker/timeout_flag_test.go
+++ b/clicker/cmd/clicker/timeout_flag_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeoutValueSet(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"5s", 5 * time.Second, false},
+		{"5000", 5000 * time.Millisecond, false},
+		{"500ms", 500 * time.Millisecond, false},
+		{"2m", 2 * time.Minute, false},
+		{"1.5s", 1500 * time.Millisecond, false},
+		{"1500", 1500 * time.Millisecond, false},
+		{" 5s ", 5 * time.Second, false},
+		{"0", 0, false},
+		{"-1", 0, true},
+		{"-5s", 0, true},
+		{"abc", 0, true},
+		{"", 0, true},
+	}
+	for _, c := range cases {
+		var d time.Duration
+		v := &timeoutValue{d: &d}
+		err := v.Set(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("Set(%q): expected error, got %v", c.in, d)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Set(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if d != c.want {
+			t.Errorf("Set(%q): got %v, want %v", c.in, d, c.want)
+		}
+	}
+}

--- a/clicker/cmd/clicker/type_cmd.go
+++ b/clicker/cmd/clicker/type_cmd.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
-	"github.com/vibium/clicker/internal/api"
 )
 
 func newTypeCmd() *cobra.Command {
+	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "type [url] [selector] [text]",
 		Short: "Type text into an element (optionally navigate to URL first)",
@@ -16,7 +18,7 @@ func newTypeCmd() *cobra.Command {
   # Navigates to URL first, then types
 
   vibium type https://the-internet.herokuapp.com/inputs "input" "12345" --timeout 5s
-  # Custom timeout for actionability checks`,
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.RangeArgs(2, 3),
 		Run: func(cmd *cobra.Command, args []string) {
 			var selector, text string
@@ -36,7 +38,6 @@ func newTypeCmd() *cobra.Command {
 			}
 
 			// Type into element
-			timeout, _ := cmd.Flags().GetDuration("timeout")
 			result, err := daemonCall("browser_type", map[string]interface{}{
 				"selector": selector,
 				"text":     text,
@@ -49,7 +50,7 @@ func newTypeCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	cmd.Flags().Duration("timeout", api.DefaultTimeout, "Timeout for actionability checks (e.g., 5s, 30s)")
+	addTimeoutFlag(cmd, &timeout)
 	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/clicker/cmd/clicker/uncheck.go
+++ b/clicker/cmd/clicker/uncheck.go
@@ -1,20 +1,29 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
 func newUncheckCmd() *cobra.Command {
-	return &cobra.Command{
+	var timeout time.Duration
+	cmd := &cobra.Command{
 		Use:   "uncheck [selector]",
 		Short: "Uncheck a checkbox",
 		Example: `  vibium uncheck "input[name=agree]"
-  # Uncheck the "agree" checkbox (idempotent)`,
+  # Uncheck the "agree" checkbox (idempotent)
+
+  vibium uncheck "input[name=agree]" --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
 
-			result, err := daemonCall("browser_uncheck", map[string]interface{}{"selector": selector})
+			result, err := daemonCall("browser_uncheck", map[string]interface{}{
+				"selector": selector,
+				"timeout":  float64(timeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -22,4 +31,6 @@ func newUncheckCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	return cmd
 }

--- a/clicker/cmd/clicker/upload.go
+++ b/clicker/cmd/clicker/upload.go
@@ -4,19 +4,24 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 func newUploadCmd() *cobra.Command {
-	return &cobra.Command{
+	var timeout time.Duration
+	cmd := &cobra.Command{
 		Use:   "upload [selector] [files...]",
 		Short: "Set files on an input[type=file] element",
 		Example: `  vibium upload "input[type=file]" ./photo.jpg
   # Upload a single file
 
   vibium upload "#file-input" ./photo.jpg ./doc.pdf
-  # Upload multiple files`,
+  # Upload multiple files
+
+  vibium upload "input[type=file]" ./photo.jpg --timeout 5s
+  # Custom timeout (5s, or 5000 for milliseconds)`,
 		Args: cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
@@ -36,6 +41,7 @@ func newUploadCmd() *cobra.Command {
 			result, err := daemonCall("browser_upload", map[string]interface{}{
 				"selector": selector,
 				"files":    absFiles,
+				"timeout":  float64(timeout.Milliseconds()),
 			})
 			if err != nil {
 				printError(err)
@@ -44,4 +50,6 @@ func newUploadCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	addTimeoutFlag(cmd, &timeout)
+	return cmd
 }

--- a/clicker/cmd/clicker/wait_cmd.go
+++ b/clicker/cmd/clicker/wait_cmd.go
@@ -4,10 +4,11 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/vibium/clicker/internal/api"
 )
 
 func newWaitCmd() *cobra.Command {
+	var waitTimeout, urlTimeout, textTimeout, loadTimeout, fnTimeout time.Duration
+
 	cmd := &cobra.Command{
 		Use:   "wait [selector]",
 		Short: "Wait for an element, URL, text, page load, or JS condition",
@@ -17,21 +18,18 @@ func newWaitCmd() *cobra.Command {
   vibium wait "div.loaded" --state visible
   # Wait for element to be visible
 
-  vibium wait "div.spinner" --state hidden --timeout 5000
-  # Wait for spinner to disappear`,
+  vibium wait "div.spinner" --state hidden --timeout 5s
+  # Wait for spinner to disappear (5s, or 5000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			selector := args[0]
 			state, _ := cmd.Flags().GetString("state")
-			timeoutMs, _ := cmd.Flags().GetInt("timeout")
 
-			toolArgs := map[string]interface{}{
+			result, err := daemonCall("browser_wait", map[string]interface{}{
 				"selector": selector,
 				"state":    state,
-				"timeout":  float64(timeoutMs),
-			}
-
-			result, err := daemonCall("browser_wait", toolArgs)
+				"timeout":  float64(waitTimeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -40,7 +38,7 @@ func newWaitCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().String("state", "attached", "State to wait for: attached, visible, hidden")
-	cmd.Flags().Int("timeout", int(api.DefaultTimeout/time.Millisecond), "Timeout in milliseconds")
+	addTimeoutFlag(cmd, &waitTimeout)
 
 	urlCmd := &cobra.Command{
 		Use:   "url [pattern]",
@@ -48,19 +46,14 @@ func newWaitCmd() *cobra.Command {
 		Example: `  vibium wait url "/dashboard"
   # Wait until URL contains "/dashboard"
 
-  vibium wait url "success" --timeout 10000
-  # Wait up to 10 seconds`,
+  vibium wait url "success" --timeout 10s
+  # Wait up to 10 seconds (or 10000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			pattern := args[0]
-			timeout, _ := cmd.Flags().GetInt("timeout")
-
-			toolArgs := map[string]interface{}{"pattern": pattern}
-			if cmd.Flags().Changed("timeout") {
-				toolArgs["timeout"] = float64(timeout)
-			}
-
-			result, err := daemonCall("browser_wait_for_url", toolArgs)
+			result, err := daemonCall("browser_wait_for_url", map[string]interface{}{
+				"pattern": args[0],
+				"timeout": float64(urlTimeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -68,7 +61,7 @@ func newWaitCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	urlCmd.Flags().Int("timeout", 30000, "Timeout in milliseconds")
+	addTimeoutFlag(urlCmd, &urlTimeout)
 
 	textCmd := &cobra.Command{
 		Use:   "text [text]",
@@ -76,18 +69,14 @@ func newWaitCmd() *cobra.Command {
 		Example: `  vibium wait text "Welcome"
   # Waits until "Welcome" appears on the page
 
-  vibium wait text "Success" --timeout 10000
-  # Wait with custom timeout (10 seconds)`,
+  vibium wait text "Success" --timeout 10s
+  # Wait with custom timeout (10s, or 10000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			text := args[0]
-			timeout, _ := cmd.Flags().GetFloat64("timeout")
-
-			callArgs := map[string]interface{}{"text": text}
-			if timeout > 0 {
-				callArgs["timeout"] = timeout
-			}
-			result, err := daemonCall("browser_wait_for_text", callArgs)
+			result, err := daemonCall("browser_wait_for_text", map[string]interface{}{
+				"text":    args[0],
+				"timeout": float64(textTimeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -95,7 +84,7 @@ func newWaitCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	textCmd.Flags().Float64("timeout", 30000, "Timeout in milliseconds")
+	addTimeoutFlag(textCmd, &textTimeout)
 
 	loadCmd := &cobra.Command{
 		Use:   "load",
@@ -103,18 +92,13 @@ func newWaitCmd() *cobra.Command {
 		Example: `  vibium wait load
   # Wait until document.readyState is "complete"
 
-  vibium wait load --timeout 10000
-  # Wait up to 10 seconds`,
+  vibium wait load --timeout 10s
+  # Wait up to 10 seconds (or 10000 for milliseconds)`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			timeout, _ := cmd.Flags().GetInt("timeout")
-
-			toolArgs := map[string]interface{}{}
-			if cmd.Flags().Changed("timeout") {
-				toolArgs["timeout"] = float64(timeout)
-			}
-
-			result, err := daemonCall("browser_wait_for_load", toolArgs)
+			result, err := daemonCall("browser_wait_for_load", map[string]interface{}{
+				"timeout": float64(loadTimeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -122,7 +106,7 @@ func newWaitCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	loadCmd.Flags().Int("timeout", 30000, "Timeout in milliseconds")
+	addTimeoutFlag(loadCmd, &loadTimeout)
 
 	fnCmd := &cobra.Command{
 		Use:   "fn [expression]",
@@ -130,18 +114,14 @@ func newWaitCmd() *cobra.Command {
 		Example: `  vibium wait fn "document.readyState === 'complete'"
   # Wait for page to be fully loaded
 
-  vibium wait fn "window.ready === true" --timeout 10000
-  # Wait for custom condition with timeout`,
+  vibium wait fn "window.ready === true" --timeout 10s
+  # Wait for custom condition (10s, or 10000 for milliseconds)`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			expression := args[0]
-			timeout, _ := cmd.Flags().GetFloat64("timeout")
-
-			callArgs := map[string]interface{}{"expression": expression}
-			if timeout > 0 {
-				callArgs["timeout"] = timeout
-			}
-			result, err := daemonCall("browser_wait_for_fn", callArgs)
+			result, err := daemonCall("browser_wait_for_fn", map[string]interface{}{
+				"expression": args[0],
+				"timeout":    float64(fnTimeout.Milliseconds()),
+			})
 			if err != nil {
 				printError(err)
 				return
@@ -149,7 +129,7 @@ func newWaitCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	fnCmd.Flags().Float64("timeout", 30000, "Timeout in milliseconds")
+	addTimeoutFlag(fnCmd, &fnTimeout)
 
 	cmd.AddCommand(urlCmd)
 	cmd.AddCommand(textCmd)

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -707,11 +707,7 @@ func (h *Handlers) browserClick(args map[string]interface{}) (*ToolsCallResult, 
 	if err != nil {
 		return nil, err
 	}
-	ep := api.ElementParams{Selector: selector}
-	if t, ok := argFloat(args, "timeout"); ok {
-		ep.Timeout = time.Duration(t) * time.Millisecond
-	}
-	if err := api.Click(s, ctx, ep); err != nil {
+	if err := api.Click(s, ctx, elementParamsWithTimeout(selector, args)); err != nil {
 		return nil, fmt.Errorf("failed to click: %w", err)
 	}
 
@@ -745,11 +741,7 @@ func (h *Handlers) browserType(args map[string]interface{}) (*ToolsCallResult, e
 	if err != nil {
 		return nil, err
 	}
-	ep := api.ElementParams{Selector: selector}
-	if t, ok := argFloat(args, "timeout"); ok {
-		ep.Timeout = time.Duration(t) * time.Millisecond
-	}
-	if err := api.TypeInto(s, ctx, ep, text); err != nil {
+	if err := api.TypeInto(s, ctx, elementParamsWithTimeout(selector, args), text); err != nil {
 		return nil, fmt.Errorf("failed to type: %w", err)
 	}
 
@@ -1452,7 +1444,7 @@ func (h *Handlers) browserHover(args map[string]interface{}) (*ToolsCallResult, 
 	if err != nil {
 		return nil, err
 	}
-	if err := api.Hover(s, ctx, api.ElementParams{Selector: selector}); err != nil {
+	if err := api.Hover(s, ctx, elementParamsWithTimeout(selector, args)); err != nil {
 		return nil, fmt.Errorf("failed to hover: %w", err)
 	}
 
@@ -1486,7 +1478,7 @@ func (h *Handlers) browserSelect(args map[string]interface{}) (*ToolsCallResult,
 	if err != nil {
 		return nil, err
 	}
-	if err := api.SelectOption(s, ctx, api.ElementParams{Selector: selector}, value); err != nil {
+	if err := api.SelectOption(s, ctx, elementParamsWithTimeout(selector, args), value); err != nil {
 		return nil, fmt.Errorf("failed to select: %w", err)
 	}
 
@@ -2094,7 +2086,7 @@ func (h *Handlers) browserFill(args map[string]interface{}) (*ToolsCallResult, e
 	if err != nil {
 		return nil, err
 	}
-	if err := api.Fill(s, ctx, api.ElementParams{Selector: selector}, value); err != nil {
+	if err := api.Fill(s, ctx, elementParamsWithTimeout(selector, args), value); err != nil {
 		return nil, fmt.Errorf("failed to fill: %w", err)
 	}
 
@@ -2330,7 +2322,7 @@ func (h *Handlers) browserCheck(args map[string]interface{}) (*ToolsCallResult, 
 	if err != nil {
 		return nil, err
 	}
-	toggled, err := api.Check(s, ctx, api.ElementParams{Selector: selector})
+	toggled, err := api.Check(s, ctx, elementParamsWithTimeout(selector, args))
 	if err != nil {
 		return nil, fmt.Errorf("failed to check: %w", err)
 	}
@@ -2365,7 +2357,7 @@ func (h *Handlers) browserUncheck(args map[string]interface{}) (*ToolsCallResult
 	if err != nil {
 		return nil, err
 	}
-	toggled, err := api.Uncheck(s, ctx, api.ElementParams{Selector: selector})
+	toggled, err := api.Uncheck(s, ctx, elementParamsWithTimeout(selector, args))
 	if err != nil {
 		return nil, fmt.Errorf("failed to uncheck: %w", err)
 	}
@@ -2400,7 +2392,7 @@ func (h *Handlers) browserScrollIntoView(args map[string]interface{}) (*ToolsCal
 	if err != nil {
 		return nil, err
 	}
-	if err := api.ScrollIntoView(s, ctx, api.ElementParams{Selector: selector}); err != nil {
+	if err := api.ScrollIntoView(s, ctx, elementParamsWithTimeout(selector, args)); err != nil {
 		return nil, fmt.Errorf("failed to scroll into view: %w", err)
 	}
 
@@ -2487,6 +2479,17 @@ func argFloat(args map[string]interface{}, key string) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// elementParamsWithTimeout builds ElementParams for a selector, applying a
+// caller-supplied "timeout" arg (milliseconds) when present. A zero/absent
+// timeout is normalized to the default by the api layer (withDefaultTimeout).
+func elementParamsWithTimeout(selector string, args map[string]interface{}) api.ElementParams {
+	ep := api.ElementParams{Selector: selector}
+	if t, ok := argFloat(args, "timeout"); ok {
+		ep.Timeout = time.Duration(t) * time.Millisecond
+	}
+	return ep
 }
 
 // browserSleep pauses execution for a specified number of milliseconds.
@@ -2840,7 +2843,7 @@ func (h *Handlers) browserDblClick(args map[string]interface{}) (*ToolsCallResul
 	if err != nil {
 		return nil, err
 	}
-	if err := api.DblClick(s, ctx, api.ElementParams{Selector: selector}); err != nil {
+	if err := api.DblClick(s, ctx, elementParamsWithTimeout(selector, args)); err != nil {
 		return nil, fmt.Errorf("failed to double-click: %w", err)
 	}
 
@@ -2869,7 +2872,7 @@ func (h *Handlers) browserFocus(args map[string]interface{}) (*ToolsCallResult, 
 	if err != nil {
 		return nil, err
 	}
-	if err := api.FocusElement(s, ctx, api.ElementParams{Selector: selector}); err != nil {
+	if err := api.FocusElement(s, ctx, elementParamsWithTimeout(selector, args)); err != nil {
 		return nil, fmt.Errorf("failed to focus: %w", err)
 	}
 
@@ -3355,7 +3358,7 @@ func (h *Handlers) browserDrag(args map[string]interface{}) (*ToolsCallResult, e
 	if err != nil {
 		return nil, err
 	}
-	if err := api.DragTo(s, ctx, api.ElementParams{Selector: source}, api.ElementParams{Selector: target}); err != nil {
+	if err := api.DragTo(s, ctx, elementParamsWithTimeout(source, args), elementParamsWithTimeout(target, args)); err != nil {
 		return nil, fmt.Errorf("failed to drag: %w", err)
 	}
 
@@ -3727,7 +3730,7 @@ func (h *Handlers) browserUpload(args map[string]interface{}) (*ToolsCallResult,
 	if err != nil {
 		return nil, err
 	}
-	if err := api.Upload(s, ctx, api.ElementParams{Selector: selector}, files); err != nil {
+	if err := api.Upload(s, ctx, elementParamsWithTimeout(selector, args), files); err != nil {
 		return nil, fmt.Errorf("failed to set files: %w", err)
 	}
 

--- a/clicker/internal/agent/schema.go
+++ b/clicker/internal/agent/schema.go
@@ -43,6 +43,11 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "CSS selector for the element to click",
 					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
+					},
 				},
 				"required":             []string{"selector"},
 				"additionalProperties": false,
@@ -61,6 +66,11 @@ func GetToolSchemas() []Tool {
 					"text": map[string]interface{}{
 						"type":        "string",
 						"description": "The text to type",
+					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
 					},
 				},
 				"required":             []string{"selector", "text"},
@@ -132,6 +142,11 @@ func GetToolSchemas() []Tool {
 					"title": map[string]interface{}{
 						"type":        "string",
 						"description": "Find element by title attribute",
+					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
 					},
 				},
 				"additionalProperties": false,
@@ -292,6 +307,11 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "CSS selector for the element to hover over",
 					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
+					},
 				},
 				"required":             []string{"selector"},
 				"additionalProperties": false,
@@ -310,6 +330,11 @@ func GetToolSchemas() []Tool {
 					"value": map[string]interface{}{
 						"type":        "string",
 						"description": "The value to select",
+					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
 					},
 				},
 				"required":             []string{"selector", "value"},
@@ -534,6 +559,11 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "The text to fill in",
 					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
+					},
 				},
 				"required":             []string{"selector", "text"},
 				"additionalProperties": false,
@@ -644,6 +674,11 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "CSS selector for the checkbox or radio button",
 					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
+					},
 				},
 				"required":             []string{"selector"},
 				"additionalProperties": false,
@@ -659,6 +694,11 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "CSS selector for the checkbox",
 					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
+					},
 				},
 				"required":             []string{"selector"},
 				"additionalProperties": false,
@@ -673,6 +713,11 @@ func GetToolSchemas() []Tool {
 					"selector": map[string]interface{}{
 						"type":        "string",
 						"description": "CSS selector for the element to scroll into view",
+					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
 					},
 				},
 				"required":             []string{"selector"},
@@ -791,6 +836,11 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "CSS selector or @ref for the element to double-click",
 					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
+					},
 				},
 				"required":             []string{"selector"},
 				"additionalProperties": false,
@@ -805,6 +855,11 @@ func GetToolSchemas() []Tool {
 					"selector": map[string]interface{}{
 						"type":        "string",
 						"description": "CSS selector or @ref for the element to focus",
+					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
 					},
 				},
 				"required":             []string{"selector"},
@@ -1056,6 +1111,11 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "CSS selector or @ref for the target element",
 					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
+					},
 				},
 				"required":             []string{"source", "target"},
 				"additionalProperties": false,
@@ -1250,6 +1310,11 @@ func GetToolSchemas() []Tool {
 						"items": map[string]interface{}{
 							"type": "string",
 						},
+					},
+					"timeout": map[string]interface{}{
+						"type":        "number",
+						"description": "Timeout in milliseconds (default: 30000)",
+						"default":     30000,
 					},
 				},
 				"required":             []string{"selector", "files"},

--- a/tests/cli/actionability.test.js
+++ b/tests/cli/actionability.test.js
@@ -6,6 +6,9 @@
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
 const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
 describe('CLI: Actionability', () => {
@@ -31,5 +34,82 @@ describe('CLI: Actionability', () => {
       /timeout|not found/i,
       'Should timeout or report not found'
     );
+  });
+});
+
+describe('CLI: --timeout flag formats', () => {
+  // Write a page where #late only appears ~1s after load, so a click must
+  // auto-wait for it. Uses a temp file to avoid shell-quoting a data: URL.
+  const tmpFile = path.join(os.tmpdir(), `vibium-timeout-${process.pid}.html`);
+  const html =
+    '<body><button id="late" style="display:none">Go</button>' +
+    '<script>setTimeout(function(){document.getElementById("late").style.display="block"},1000)</script></body>';
+  const fileURL = 'file://' + tmpFile;
+
+  test('setup: write delayed-element fixture', () => {
+    fs.writeFileSync(tmpFile, html);
+  });
+
+  test('accepts duration form (5s) and auto-waits for a late element', () => {
+    execSync(`${VIBIUM} go "${fileURL}"`, { encoding: 'utf-8', timeout: 30000 });
+    const result = execSync(`${VIBIUM} click "#late" --timeout 5s`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /Clicked/i, '5s timeout should auto-wait then click');
+  });
+
+  test('accepts bare-millisecond form (5000) and auto-waits for a late element', () => {
+    execSync(`${VIBIUM} go "${fileURL}"`, { encoding: 'utf-8', timeout: 30000 });
+    const result = execSync(`${VIBIUM} click "#late" --timeout 5000`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /Clicked/i, '5000ms timeout should auto-wait then click');
+  });
+
+  test('bare-millisecond timeout bounds the wait (reported in the error)', () => {
+    assert.throws(
+      () => {
+        execSync(`${VIBIUM} click "#does-not-exist" --timeout 800`, {
+          encoding: 'utf-8',
+          timeout: 10000,
+        });
+      },
+      /800ms|not found/i,
+      'Should fail reporting the 800ms bound'
+    );
+  });
+
+  test('rejects an invalid timeout value', () => {
+    assert.throws(
+      () => {
+        execSync(`${VIBIUM} click "#x" --timeout 5q`, { encoding: 'utf-8', timeout: 10000 });
+      },
+      /invalid timeout/i,
+      'Should reject "5q" with a clear message'
+    );
+  });
+
+  test('newly-flagged action (hover) accepts --timeout', () => {
+    execSync(`${VIBIUM} go "${fileURL}"`, { encoding: 'utf-8', timeout: 30000 });
+    const result = execSync(`${VIBIUM} hover "#late" --timeout 5s`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /Hovered/i, 'hover should honor --timeout and wait for #late');
+  });
+
+  test('wait command accepts duration form (5s)', () => {
+    execSync(`${VIBIUM} go "${fileURL}"`, { encoding: 'utf-8', timeout: 30000 });
+    const result = execSync(`${VIBIUM} wait "#late" --state visible --timeout 5s`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /visible/i, 'wait should accept 5s and resolve when #late shows');
+  });
+
+  test('teardown: remove fixture', () => {
+    fs.rmSync(tmpFile, { force: true });
   });
 });


### PR DESCRIPTION
## What

Unify the `--timeout` flag across the CLI so it accepts **both** Go-duration form (`5s`, `500ms`, `2m`) and a bare number interpreted as milliseconds (`5000`), everywhere.

Addresses **B6** of #112 (`vibium click --timeout` flag accepted but silently ignored). Before this change:

- `click`/`type` used a Duration flag (accepts `5s`, rejects bare `5000`)
- `wait`/`url`/`load` used int ms, `text`/`fn` used float64 ms (accept `5000`, reject `5s`)
- ~10 element-action commands (`hover`, `fill`, `select`, `check`, `uncheck`, `dblclick`, `focus`, `scroll`, `drag`, `upload`) had **no** `--timeout` at all, and their daemon handlers ignored a timeout arg.

## How

- New shared `timeoutValue` (a `pflag.Value`) + `addTimeoutFlag` helper that parses a bare number as milliseconds and anything else as a Go duration. Applied to every element-action and wait command.
- Plumbs the timeout through the action daemon handlers via `elementParamsWithTimeout`, so MCP callers can override it too, and documents `timeout` in the MCP schemas for those tools.
- Wire format is unchanged (float64 milliseconds); the dual parsing is a CLI-only affordance.

## Relationship to #179 (already merged)

#179 fixed a *different* set of #112 bugs (B14/B18/B22 — negative positional values being eaten by the flag parser) by disabling/limiting flag parsing on `fill`, `sleep`, `type`, `geolocation`.

This branch was rebased on top of #179. Two files overlapped (`fill.go`, `type_cmd.go`). The reconciliation worth calling out:

- **`fill`**: #179 made it flagless via `DisableFlagParsing: true`. Since this PR gives `fill` a real `--timeout` flag, that approach no longer works — so `fill` now uses `SetInterspersed(false)` instead (the same technique #179 used for its *flagged* commands). This keeps `--timeout` working **and** preserves #179's negative-value fix (`fill "#x" "-2"`). Naively merging without this would have regressed #179.
- **`type`**: composes cleanly — unified `addTimeoutFlag` + #179's `SetInterspersed(false)`.

## Tests

- Go table-test for the timeout parser (`timeout_flag_test.go`).
- CLI tests covering both `--timeout` formats, the auto-wait path (element appears after a delay), bound enforcement, invalid-value rejection, and a newly-flagged action (`hover`).
- Full `make test` green (CLI, JS sync/async, MCP, Python, Java).

Note: references #112 (B6) but does **not** auto-close it — #112 tracks 33 bugs and others remain open.
