### PR TITLE
Reap orphaned sync-test-server.js processes in cleanup targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ test-cleanup:
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@pkill -9 -f 'Chrome for Testing' 2>/dev/null || true
 	@pkill -9 -f 'chromedriver' 2>/dev/null || true
+	@pkill -9 -f 'sync-test-server.js' 2>/dev/null || true
 
 # Run CLI tests (tests the vibium binary directly)
 # Process tests run separately with --test-concurrency=1 to avoid interference
@@ -346,6 +347,7 @@ ifeq ($(OS),Windows_NT)
 else
 	@pkill -9 -f 'Chrome for Testing' 2>/dev/null || true
 	@pkill -9 -f chromedriver 2>/dev/null || true
+	@pkill -9 -f 'sync-test-server.js' 2>/dev/null || true
 endif
 	@sleep 1
 	@echo "Done."


### PR DESCRIPTION
## What

Add `sync-test-server.js` to the process-reaping in both `double-tap` and `test-cleanup`.

## Why

The JS sync test suites each `fork()` a `sync-test-server.js` fixture (HTTP + WS server). When a test run is interrupted or times out, the `after` hooks don't always run, leaving these node processes orphaned. `double-tap`/`test-cleanup` already kill `Chrome for Testing` and `chromedriver`, but **not** these forked servers — so they survived every cleanup.

Stale fixture servers load the machine and hold ports, which slows fresh headless-Chrome launches past the client's 60s ready window. Once that starts, a run times out → leaves more orphans → the next run is even more loaded: a self-perpetuating cascade of `waiting for vibium ready signal` / `browsingContext.create` timeouts. Reaping them alongside the browser processes lets cleanup return the machine to a genuinely clean state.

## Change

Two lines — `@pkill -9 -f 'sync-test-server.js'` added to the non-Windows branch of `double-tap` and to `test-cleanup`, matching the existing `pkill -f` pattern.

Verified: spawning orphan `sync-test-server.js` processes and running `make double-tap` reaps them (2 → 0).
