### PR TITLE
test(cli): hermetic input-tools fixtures + quiet expected-failure noise

### DIFF
--- a/tests/cli/actionability.test.js
+++ b/tests/cli/actionability.test.js
@@ -29,6 +29,7 @@ describe('CLI: Actionability', () => {
         execSync(`${VIBIUM} click https://example.com "#does-not-exist" --timeout 1s`, {
           encoding: 'utf-8',
           timeout: 10000,
+          stdio: 'pipe', // capture the expected failure instead of leaking it to the console
         });
       },
       /timeout|not found/i,
@@ -74,6 +75,7 @@ describe('CLI: --timeout flag formats', () => {
         execSync(`${VIBIUM} click "#does-not-exist" --timeout 800`, {
           encoding: 'utf-8',
           timeout: 10000,
+          stdio: 'pipe', // capture the expected failure instead of leaking it to the console
         });
       },
       /800ms|not found/i,
@@ -84,7 +86,7 @@ describe('CLI: --timeout flag formats', () => {
   test('rejects an invalid timeout value', () => {
     assert.throws(
       () => {
-        execSync(`${VIBIUM} click "#x" --timeout 5q`, { encoding: 'utf-8', timeout: 10000 });
+        execSync(`${VIBIUM} click "#x" --timeout 5q`, { encoding: 'utf-8', timeout: 10000, stdio: 'pipe' });
       },
       /invalid timeout/i,
       'Should reject "5q" with a clear message'

--- a/tests/cli/input-tools.test.js
+++ b/tests/cli/input-tools.test.js
@@ -63,7 +63,9 @@ describe('CLI: Negative value flag parsing', () => {
   });
 
   test('fill accepts negative numeric value', () => {
-    execSync(`${VIBIUM} go https://the-internet.herokuapp.com/login`, {
+    // Hermetic fixture — avoids a third-party site so the test only exercises
+    // flag parsing, not network reachability.
+    execSync(`${VIBIUM} content '<input id="username" value="">'`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -72,13 +74,29 @@ describe('CLI: Negative value flag parsing', () => {
       timeout: 30000,
     });
     assert.doesNotMatch(result, /unknown shorthand flag/, 'Should not treat -2 as a flag');
+    assert.match(result, /Filled/, 'fill should succeed');
+    const value = execSync(`${VIBIUM} eval 'document.getElementById("username").value'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(value, /-2/, 'field value should actually be set to -2');
   });
 
   test('type accepts negative numeric value', () => {
-    const result = execSync(`${VIBIUM} type https://the-internet.herokuapp.com/login "#username" "-2"`, {
+    execSync(`${VIBIUM} content '<input id="username" value="">'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const result = execSync(`${VIBIUM} type "#username" "-2"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
     assert.doesNotMatch(result, /unknown shorthand flag/, 'Should not treat -2 as a flag');
+    assert.match(result, /Typed/, 'type should succeed');
+    const value = execSync(`${VIBIUM} eval 'document.getElementById("username").value'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(value, /-2/, 'field value should actually be set to -2');
   });
 });


### PR DESCRIPTION
## What

Two test-only cleanups in the CLI suite. No production code touched.

### `input-tools.test.js` — make the negative-value tests hermetic + meaningful
The `fill`/`type` "negative numeric value" tests (added with #179) had two problems:
- They navigated to `https://the-internet.herokuapp.com/login` — a third-party demo site that's slow and goes down, so the tests could fail for reasons unrelated to flag parsing.
- They only asserted `doesNotMatch(/unknown shorthand flag/)` — they'd pass even if `fill` silently did nothing.

Now they use a hermetic `vibium content '<input id="username">'` fixture and assert the command succeeded **and** that the field value was actually set to `-2` (via `eval`). Side benefit: ~100× faster (no page load) and they work offline. Also adds the missing trailing newline.

### `actionability.test.js` — stop expected failures leaking to the console
The three deliberate-failure tests (short-timeout click, the 800ms bound, the invalid `5q` value) called `execSync` inside `assert.throws` without `stdio: 'pipe'`, so the subprocess stderr was inherited to the terminal. A fully green run printed scary-looking `Error: failed to click: …` / `invalid argument "5q"` lines that look like failures but aren't.

Piping stderr suppresses the noise. Verified empirically that the asserted text still lands in `err.message`, so the `assert.throws` matchers are unchanged.

## Verification

`make test-cli` green from a clean state (8/8 + 42/42 + 2/2). The previously-leaked `Error:` lines no longer appear in the output.
