### PR TITLE
test(cli): pipe stderr in actionability's expected-failure tests

### DIFF
--- a/tests/cli/actionability.test.js
+++ b/tests/cli/actionability.test.js
@@ -29,6 +29,7 @@ describe('CLI: Actionability', () => {
         execSync(`${VIBIUM} click https://example.com "#does-not-exist" --timeout 1s`, {
           encoding: 'utf-8',
           timeout: 10000,
+          stdio: 'pipe', // capture the expected failure instead of leaking it to the console
         });
       },
       /timeout|not found/i,
@@ -74,6 +75,7 @@ describe('CLI: --timeout flag formats', () => {
         execSync(`${VIBIUM} click "#does-not-exist" --timeout 800`, {
           encoding: 'utf-8',
           timeout: 10000,
+          stdio: 'pipe', // capture the expected failure instead of leaking it to the console
         });
       },
       /800ms|not found/i,
@@ -84,7 +86,7 @@ describe('CLI: --timeout flag formats', () => {
   test('rejects an invalid timeout value', () => {
     assert.throws(
       () => {
-        execSync(`${VIBIUM} click "#x" --timeout 5q`, { encoding: 'utf-8', timeout: 10000 });
+        execSync(`${VIBIUM} click "#x" --timeout 5q`, { encoding: 'utf-8', timeout: 10000, stdio: 'pipe' });
       },
       /invalid timeout/i,
       'Should reject "5q" with a clear message'


### PR DESCRIPTION
## What

Quiet the expected-failure noise in `actionability.test.js`. Test-only.

The three deliberate-failure tests (short-timeout click, the 800ms bound, the invalid `5q` value) call `execSync` inside `assert.throws` without `stdio: 'pipe'`, so the subprocess stderr is inherited to the terminal. A fully green run prints scary-looking lines like:

```
Error: failed to click: timeout after 1s: element not found
invalid argument "5q" for "--timeout" flag: invalid timeout "5q": ...
```

…which look like failures but aren't. Piping stderr suppresses the noise. Verified empirically that the asserted text still lands in `err.message`, so the `assert.throws` matchers are unchanged.

## Verification

`make test-cli` green from clean; the previously-leaked `Error:` lines no longer appear.
