### PR TITLE
fix: vibium fill accepts empty string to clear a field

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -2072,12 +2072,15 @@ func (h *Handlers) browserFill(args map[string]interface{}) (*ToolsCallResult, e
 	}
 	selector = h.resolveSelector(selector)
 
-	value, _ := args["value"].(string)
-	if value == "" {
+	// Distinguish an omitted value from an intentionally empty one: an empty
+	// string is a valid value that clears the field, so key off key presence,
+	// not emptiness.
+	value, hasValue := args["value"].(string)
+	if !hasValue {
 		// Fall back to "text" for backwards compatibility with MCP clients
-		value, _ = args["text"].(string)
+		value, hasValue = args["text"].(string)
 	}
-	if value == "" {
+	if !hasValue {
 		return nil, fmt.Errorf("value is required")
 	}
 

--- a/tests/cli/input-tools.test.js
+++ b/tests/cli/input-tools.test.js
@@ -100,3 +100,22 @@ describe('CLI: Negative value flag parsing', () => {
     assert.match(value, /-2/, 'field value should actually be set to -2');
   });
 });
+
+describe('CLI: fill edge cases', () => {
+  test('fill "" clears an existing value (regression: #187)', () => {
+    execSync(`${VIBIUM} content '<input id="u" value="hello">'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const result = execSync(`${VIBIUM} fill "#u" ""`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /Filled/, 'fill "" should succeed, not error with "value is required"');
+    const value = execSync(`${VIBIUM} eval 'document.getElementById("u").value'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.strictEqual(value.trim(), '', 'field should be cleared');
+  });
+});


### PR DESCRIPTION
## What

`vibium fill "#x" ""` errored with `value is required`, so there was no way to clear a field via `fill`.

## Root cause

`browserFill` (`handlers.go`) read the value with `value, _ := args["value"].(string)` and then treated `value == ""` as "missing" — it couldn't distinguish an omitted value from an intentionally empty one. The CLI always sends the value arg, so `""` should mean "clear the field".

## Fix

Key off key **presence** instead of emptiness:
- `value, hasValue := args["value"].(string)` — an empty string is now a valid value.
- The `"text"` MCP-compat fallback triggers only when `value` is genuinely absent.
- The `value is required` error fires only when neither `value` nor `text` was provided.

## Tests

Adds a CLI regression test (`fill ""` clears a populated field, verified via `eval`). Full `make test` green (CLI 43, MCP 47, Python 265, JS sync 109, Java).

Fixes #187
