### PR TITLE
fix: vibium fill supports range and other value-bearing input types

### DIFF
--- a/clicker/internal/api/actionability.go
+++ b/clicker/internal/api/actionability.go
@@ -194,8 +194,13 @@ func actionabilityCheckBody() string {
 				const tag = el.tagName.toLowerCase();
 				if (tag === 'input') {
 					const t = (el.type || 'text').toLowerCase();
-					const textTypes = ['text','password','email','number','search','tel','url'];
-					if (!textTypes.includes(t))
+					// Types whose value can be set via fill. Includes the value-bearing
+					// picker types (range/color/date/time family), not just text inputs.
+					// Excludes checkbox/radio (use check), file (use upload), and
+					// button/submit/reset/image (not value inputs).
+					const fillableTypes = ['text','password','email','number','search','tel','url',
+						'range','color','date','time','datetime-local','month','week'];
+					if (!fillableTypes.includes(t))
 						return JSON.stringify({status:'failed', check:'editable', reason:'input type ' + t + ' not editable'});
 				} else if (tag !== 'textarea' && !el.isContentEditable) {
 					return JSON.stringify({status:'failed', check:'editable', reason:'not a text input element'});

--- a/tests/cli/actionability.test.js
+++ b/tests/cli/actionability.test.js
@@ -115,3 +115,42 @@ describe('CLI: --timeout flag formats', () => {
     fs.rmSync(tmpFile, { force: true });
   });
 });
+
+describe('CLI: fillable input types', () => {
+  test('fill sets an input[type=range] value (regression: #188)', () => {
+    execSync(`${VIBIUM} content '<input type="range" id="s" min="0" max="10" value="5">'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const result = execSync(`${VIBIUM} fill "#s" "3"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /Filled/, 'range should be fillable, not rejected as "not editable"');
+    const value = execSync(`${VIBIUM} eval 'document.getElementById("s").value'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.strictEqual(value.trim(), '3', 'range value should be set to 3');
+  });
+
+  test('fill still rejects a non-fillable input type (checkbox)', () => {
+    execSync(`${VIBIUM} content '<input type="checkbox" id="cb">'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.throws(
+      () => {
+        // --timeout before the positionals (fill uses SetInterspersed(false));
+        // 1s so the expected failure returns quickly instead of auto-waiting.
+        execSync(`${VIBIUM} fill --timeout 1s "#cb" "x"`, {
+          encoding: 'utf-8',
+          timeout: 10000,
+          stdio: 'pipe',
+        });
+      },
+      /not editable/i,
+      'checkbox should not be fillable'
+    );
+  });
+});


### PR DESCRIPTION
## What

`vibium fill` on an `input[type=range]` failed with `editable check failed — input type range not editable`, even though a range holds a settable value. (With auto-wait now the default, it also blocked for the full timeout before failing, rather than failing fast.)

## Root cause

The editable actionability check (`clicker/internal/api/actionability.go`) allowed only a whitelist of text-like input types (`text`, `password`, `email`, `number`, `search`, `tel`, `url`). `range` wasn't in it.

## Fix

Extend the fillable set to include the value-bearing picker types: `range`, `color`, `date`, `time`, `datetime-local`, `month`, `week`. Still excluded: `checkbox`/`radio` (use `check`), `file` (use `upload`), and `button`/`submit`/`reset`/`image`. Once `range` is recognized as editable, `fill` succeeds immediately, so the 30s hang for that case disappears too.

## Tests

CLI regression tests in `actionability.test.js`: a range input fills successfully (value verified), and a checkbox is still rejected as not editable. Full `make test` green (CLI 44, MCP 47, JS async 265, JS sync 109).

Fixes #188
