### PR TITLE
test: cap concurrent browser launches in 'make test' to fix startup-contention flakiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 # only fires when something has gone catastrophically wrong. A healthy
 # sequential test-js phase is ~6-10 minutes because Chrome launch is ~16s
 # per file on macOS (see clients/javascript/src/clicker/process.ts). For
-# faster iteration use JS_PARALLEL=4 (Makefile:189) which cuts wall time ~3x.
+# faster iteration bump JS_PARALLEL (default 3) to use more cores.
 TEST_TIMEOUT ?= 600
 TIMEOUT_CMD := node scripts/timeout.mjs $(TEST_TIMEOUT)
 

--- a/Makefile
+++ b/Makefile
@@ -153,10 +153,13 @@ serve: build-go
 	./clicker/bin/vibium$(EXE) serve
 
 # Build everything and run all tests: make test
-# On Windows, run JS async/sync sequentially to avoid Chrome resource starvation
-# (each group spawns JS_PARALLEL Chrome instances; too many concurrent Chromes
-# causes screenshot timeouts). Other platforms run all 5 groups in parallel.
-ifeq ($(OS),Windows_NT)
+# test-js-sync runs OUTSIDE the parallel group on every platform. Each of
+# test-js-async/sync/python/java fans out to *_PARALLEL headless Chromes, and
+# running all of them at once over-subscribes the machine (~14 concurrent
+# browsers on a 12-core box), pushing cold Chrome launches past the client's
+# ready timeout and cascading into cancellations. Keeping test-js-sync separate
+# caps the peak; the *_PARALLEL defaults are tuned conservatively for the same
+# reason. Bump *_PARALLEL on machines with more cores/memory.
 test: build install-browser
 	@START_TIME=$$(date +%s); \
 	"$(MAKE)" test-cli test-cleanup && \
@@ -177,26 +180,6 @@ test: build install-browser
 		echo "--- Tests failed after $${MINS}m$${SECS}s ---"; \
 		exit $$EXIT; \
 	fi
-else
-test: build install-browser
-	@START_TIME=$$(date +%s); \
-	"$(MAKE)" test-cli test-cleanup && \
-	"$(MAKE)" test-js-process test-cleanup && \
-	"$(MAKE)" -j 5 test-js-async test-js-sync test-mcp test-python test-java; \
-	EXIT=$$?; \
-	"$(MAKE)" test-cleanup; \
-	END_TIME=$$(date +%s); \
-	ELAPSED=$$((END_TIME - START_TIME)); \
-	MINS=$$((ELAPSED / 60)); \
-	SECS=$$((ELAPSED % 60)); \
-	echo ""; \
-	if [ $$EXIT -eq 0 ]; then \
-		echo "--- All tests passed in $${MINS}m$${SECS}s ---"; \
-	else \
-		echo "--- Tests failed after $${MINS}m$${SECS}s ---"; \
-		exit $$EXIT; \
-	fi
-endif
 
 # Kill any Chrome/chromedriver processes left over from tests
 test-cleanup:
@@ -231,7 +214,7 @@ test-cli: build-go
 # parallel-safe groups concurrently with test-mcp/test-python/test-java via
 # `$(MAKE) -j 5`. The process group must run alone because it asserts on
 # Chrome PID baselines.
-JS_PARALLEL ?= 4
+JS_PARALLEL ?= 3
 
 test-js-async: build-go
 	@echo "--- JS Async Tests (parallel x$(JS_PARALLEL)) ---"
@@ -296,7 +279,7 @@ test-daemon: build-go
 # for faster CI. Module-scoped browser fixture means xdist's default
 # loadfile distribution gives each file to a single worker — safe under
 # parallel since each file owns its own browser via conftest.py.
-PY_PARALLEL ?= 4
+PY_PARALLEL ?= 3
 test-python: build-go install-browser
 	@echo "--- Python Client Tests (parallel x$(PY_PARALLEL)) ---"
 	@cd clients/python && \
@@ -317,7 +300,7 @@ build-java: build-go
 # Run Java client tests
 # JAVA_PARALLEL: number of parallel test JVMs (each spawns its own Chrome).
 # Default 4; bump for faster CI on machines with more memory.
-JAVA_PARALLEL ?= 4
+JAVA_PARALLEL ?= 3
 test-java: build-go install-browser
 	@echo "--- Java Client Tests (parallel x$(JAVA_PARALLEL)) ---"
 	cd clients/java && VIBIUM_BIN_PATH=$(CURDIR)/clicker/bin/vibium$(EXE) ./gradlew test -PjavaParallel=$(JAVA_PARALLEL)


### PR DESCRIPTION
## Problem

`make test` intermittently failed with `did not finish before its parent and was cancelled` / `timed out after 30000ms` in the JS/Python suites — never assertion failures, always browser-startup timeouts that cascaded.

**Root cause:** the `test` target ran all five browser-spawning suites concurrently via `make -j 5` (`test-js-async`, `test-js-sync`, `test-mcp`, `test-python`, `test-java`), and each of those internally fans out to `*_PARALLEL` headless Chromes. Measured peak on a 12-core / 12 GB box: **~14 concurrent browsers, ~140 Chrome processes, load ~8.8**. Under that pressure a cold Chrome launch occasionally exceeds the client's ready timeout; the failing `before` hook + `--test-force-exit` then tears down the runner and cancels sibling tests.

Windows already mitigated this (it kept `test-js-sync` out of the parallel group); other platforms didn't.

## Change

- Run `test-js-sync` **outside** the parallel group on every platform (generalizes the existing Windows mitigation; collapses the two now-identical `ifeq` branches into one target).
- Drop `JS_PARALLEL` / `PY_PARALLEL` / `JAVA_PARALLEL` defaults from **4 → 3**.

Both remain overridable (`JS_PARALLEL=4 make test`) for machines with more cores/memory.

## Measured effect

| | before | after |
|---|---|---|
| peak concurrent browsers | 14 | **8** |
| peak Chrome processes | 140 | **79** |
| peak load avg (12 cores) | 8.76 | **3.36** |
| contention failures | intermittent | **0** |

Trade-off: serializing `test-js-sync` lengthens total wall-clock somewhat; that's the intended reliability/speed balance, and the conservative default protects weaker CI machines while `*_PARALLEL` overrides let strong ones go faster.

Note: this reduces how *often* startup contention bites; a companion PR adds a startup retry in the clients so a single slow launch no longer fails hard regardless of load.
