### PR TITLE
fix(clients): retry + bound browser startup so a slow launch isn't fatal

### DIFF
--- a/clients/java/src/main/java/com/vibium/internal/VibiumProcess.java
+++ b/clients/java/src/main/java/com/vibium/internal/VibiumProcess.java
@@ -7,7 +7,12 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Manages the vibium subprocess lifecycle.
@@ -15,6 +20,13 @@ import java.util.concurrent.TimeUnit;
  * Spawns {@code vibium pipe [--headless]} and waits for the ready signal.
  */
 public class VibiumProcess {
+
+    /** Bound on how long to wait for the ready signal per launch attempt. */
+    private static final long READY_TIMEOUT_SECONDS = 60;
+    /** Number of launch attempts before giving up (retries transient failures). */
+    private static final int MAX_START_ATTEMPTS = 2;
+    /** Backoff between launch attempts. */
+    private static final long START_RETRY_BACKOFF_MS = 500;
 
     private final Process process;
     private final BufferedWriter stdin;
@@ -57,6 +69,34 @@ public class VibiumProcess {
             BrowserInstaller.ensureInstalled(binaryPath);
         }
 
+        // Startup is slow (~16s cold) and slower when many browsers launch at
+        // once (test suites, CI), where a cold launch can blow the ready timeout
+        // or crash under resource pressure. Retry a timed-out or crashed launch a
+        // couple of times with a short backoff so a single unlucky launch doesn't
+        // fail hard.
+        VibiumConnectionException lastError = null;
+        for (int attempt = 1; attempt <= MAX_START_ATTEMPTS; attempt++) {
+            try {
+                return startAttempt(cmd);
+            } catch (VibiumConnectionException e) {
+                lastError = e;
+                if (attempt < MAX_START_ATTEMPTS) {
+                    try {
+                        Thread.sleep(START_RETRY_BACKOFF_MS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw e;
+                    }
+                    continue;
+                }
+                throw e;
+            }
+        }
+        // Unreachable: the loop returns on success or throws on the final attempt.
+        throw lastError;
+    }
+
+    private static VibiumProcess startAttempt(List<String> cmd) {
         try {
             ProcessBuilder pb = new ProcessBuilder(cmd);
             pb.redirectErrorStream(false);
@@ -65,21 +105,50 @@ public class VibiumProcess {
             BufferedWriter stdin = new BufferedWriter(new OutputStreamWriter(process.getOutputStream(), "UTF-8"));
             BufferedReader stdout = new BufferedReader(new InputStreamReader(process.getInputStream(), "UTF-8"));
 
-            // Read lines until we get the ready signal
+            // Read lines until we get the ready signal, bounded by a timeout so a
+            // hung launch (process alive but never emitting ready) can't block
+            // forever — historically this readLine() loop could hang the suite.
             List<String> preReadyLines = new ArrayList<>();
-            String line;
-            boolean ready = false;
-
-            while ((line = stdout.readLine()) != null) {
-                if (line.contains("vibium:lifecycle.ready") || line.contains("\"method\":\"vibium:lifecycle.ready\"")) {
-                    ready = true;
-                    break;
+            boolean ready;
+            ExecutorService readerPool = Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "vibium-ready-wait");
+                t.setDaemon(true);
+                return t;
+            });
+            try {
+                Future<Boolean> readerTask = readerPool.submit(() -> {
+                    String line;
+                    while ((line = stdout.readLine()) != null) {
+                        if (line.contains("vibium:lifecycle.ready")) {
+                            return true;
+                        }
+                        preReadyLines.add(line);
+                    }
+                    return false; // EOF before ready — process exited
+                });
+                try {
+                    ready = readerTask.get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                } catch (TimeoutException te) {
+                    readerTask.cancel(true);
+                    process.destroyForcibly();
+                    throw new VibiumConnectionException(
+                        "Vibium failed to start: timed out waiting for ready signal");
+                } catch (ExecutionException ee) {
+                    process.destroyForcibly();
+                    Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
+                    throw new VibiumConnectionException(
+                        "Vibium failed to start: " + cause.getMessage(), cause);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    process.destroyForcibly();
+                    throw new VibiumConnectionException("Interrupted while starting vibium", ie);
                 }
-                preReadyLines.add(line);
+            } finally {
+                readerPool.shutdownNow();
             }
 
             if (!ready) {
-                // Process may have exited
+                // Process exited (EOF) before emitting ready.
                 String stderr = readStream(process.getErrorStream());
                 int exitCode = -1;
                 try {

--- a/clients/javascript/src/clicker/process.ts
+++ b/clients/javascript/src/clicker/process.ts
@@ -44,99 +44,119 @@ export class VibiumProcess {
       }
     }
 
-    const proc = spawn(binaryPath, args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    // If anything below throws — wait-for-ready timeout, the caller's await
-    // being interrupted by a test-runner timeout, an unhandled rejection —
-    // we must SIGKILL the spawned child. Otherwise its pipes stay open,
-    // keep Node's event loop alive, and the test process hangs with
-    // "Promise resolution is still pending but the event loop has already
-    // resolved". The `finally` runs before re-throwing.
-    const killSpawnedChild = () => {
-      try {
-        if (proc.exitCode === null) proc.kill('SIGKILL');
-      } catch {}
-    };
-
-    // Read lines from stdout until we get the vibium:lifecycle.ready signal.
-    // Events (e.g. browsingContext.contextCreated) may arrive first.
-    const preReadyLines: string[] = [];
-    let readyOK = false;
-    try {
-      await new Promise<void>((resolve, reject) => {
-        let buffer = '';
-        let resolved = false;
-
-        const timeout = setTimeout(() => {
-          if (!resolved) {
-            resolved = true;
-            reject(new TimeoutError('vibium', 60000, 'waiting for vibium ready signal'));
-          }
-        }, 60000);
-
-        const handleData = (data: Buffer) => {
-          buffer += data.toString();
-          let newlineIdx: number;
-          while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
-            const line = buffer.slice(0, newlineIdx).trim();
-            buffer = buffer.slice(newlineIdx + 1);
-            if (!line) continue;
-
-            try {
-              const msg = JSON.parse(line);
-              if (msg.method === 'vibium:lifecycle.ready') {
-                if (!resolved) {
-                  resolved = true;
-                  clearTimeout(timeout);
-                  // Stop listening for data — the BiDiClient will take over
-                  proc.stdout?.removeListener('data', handleData);
-                  resolve();
-                }
-                return;
-              }
-            } catch {
-              // Not JSON, ignore
-            }
-            // Buffer pre-ready lines for replay
-            preReadyLines.push(line);
-          }
-        };
-
-        proc.stdout?.on('data', handleData);
-
-        proc.on('error', (err) => {
-          if (!resolved) {
-            resolved = true;
-            clearTimeout(timeout);
-            reject(err);
-          }
-        });
-
-        proc.on('exit', (code) => {
-          if (!resolved) {
-            resolved = true;
-            clearTimeout(timeout);
-            reject(new BrowserCrashedError(code ?? 1, buffer));
-          }
-        });
+    // Startup is slow (~16s cold) and gets slower when many browsers launch at
+    // once (test suites, CI), where a cold launch can blow the ready timeout or
+    // crash under resource pressure. A single unlucky launch shouldn't fail
+    // hard, so retry a timed-out or crashed launch a couple of times with a
+    // short backoff. Failures that won't change on retry (e.g. a missing
+    // binary) are surfaced immediately.
+    const maxAttempts = 2;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const proc = spawn(binaryPath, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
       });
-      readyOK = true;
-    } finally {
-      if (!readyOK) killSpawnedChild();
+
+      // If the ready-wait throws — timeout, the caller's await being interrupted
+      // by a test-runner timeout, an unhandled rejection — we must SIGKILL the
+      // spawned child. Otherwise its pipes stay open, keep Node's event loop
+      // alive, and the test process hangs with "Promise resolution is still
+      // pending but the event loop has already resolved".
+      const killSpawnedChild = () => {
+        try {
+          if (proc.exitCode === null) proc.kill('SIGKILL');
+        } catch {}
+      };
+
+      // Read lines from stdout until we get the vibium:lifecycle.ready signal.
+      // Events (e.g. browsingContext.contextCreated) may arrive first.
+      const preReadyLines: string[] = [];
+      try {
+        await new Promise<void>((resolve, reject) => {
+          let buffer = '';
+          let resolved = false;
+
+          const timeout = setTimeout(() => {
+            if (!resolved) {
+              resolved = true;
+              reject(new TimeoutError('vibium', 60000, 'waiting for vibium ready signal'));
+            }
+          }, 60000);
+
+          const handleData = (data: Buffer) => {
+            buffer += data.toString();
+            let newlineIdx: number;
+            while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+              const line = buffer.slice(0, newlineIdx).trim();
+              buffer = buffer.slice(newlineIdx + 1);
+              if (!line) continue;
+
+              try {
+                const msg = JSON.parse(line);
+                if (msg.method === 'vibium:lifecycle.ready') {
+                  if (!resolved) {
+                    resolved = true;
+                    clearTimeout(timeout);
+                    // Stop listening for data — the BiDiClient will take over
+                    proc.stdout?.removeListener('data', handleData);
+                    resolve();
+                  }
+                  return;
+                }
+              } catch {
+                // Not JSON, ignore
+              }
+              // Buffer pre-ready lines for replay
+              preReadyLines.push(line);
+            }
+          };
+
+          proc.stdout?.on('data', handleData);
+
+          proc.on('error', (err) => {
+            if (!resolved) {
+              resolved = true;
+              clearTimeout(timeout);
+              reject(err);
+            }
+          });
+
+          proc.on('exit', (code) => {
+            if (!resolved) {
+              resolved = true;
+              clearTimeout(timeout);
+              reject(new BrowserCrashedError(code ?? 1, buffer));
+            }
+          });
+        });
+      } catch (err) {
+        killSpawnedChild();
+        lastError = err;
+        // Only startup timeouts and crashes are worth retrying; a spawn error
+        // (e.g. ENOENT) would fail identically, so surface it immediately.
+        const retryable = err instanceof TimeoutError || err instanceof BrowserCrashedError;
+        if (retryable && attempt < maxAttempts) {
+          await new Promise((r) => setTimeout(r, 500));
+          continue;
+        }
+        throw err;
+      }
+
+      const vp = new VibiumProcess(proc, preReadyLines);
+
+      // Clean up child process when Node exits unexpectedly
+      const cleanup = () => vp.stop();
+      process.on('exit', cleanup);
+      process.on('SIGINT', cleanup);
+      process.on('SIGTERM', cleanup);
+      vp._cleanupListeners = cleanup;
+
+      return vp;
     }
 
-    const vp = new VibiumProcess(proc, preReadyLines);
-
-    // Clean up child process when Node exits unexpectedly
-    const cleanup = () => vp.stop();
-    process.on('exit', cleanup);
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
-    vp._cleanupListeners = cleanup;
-
-    return vp;
+    // Unreachable — the loop either returns on success or throws on the final
+    // attempt — but the type checker needs a terminal statement here.
+    throw lastError instanceof Error ? lastError : new Error('failed to start vibium');
   }
 
   private _cleanupListeners: (() => void) | null = null;

--- a/clients/python/src/vibium/binary.py
+++ b/clients/python/src/vibium/binary.py
@@ -190,51 +190,72 @@ class VibiumProcess:
             for key, value in connect_headers.items():
                 args.extend(["--connect-header", f"{key}: {value}"])
 
-        process = await asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=(sys.platform != "win32"),
-            # Raise the StreamReader buffer well above asyncio's 64 KiB default:
-            # a single newline-delimited message (e.g. a base64 screenshot) can be
-            # several MB, and readline() raises LimitOverrunError past the limit,
-            # killing the receiver loop (issue #110).
-            limit=_STREAM_LIMIT,
-        )
-
         # Read lines from stdout until we get the vibium:lifecycle.ready signal.
-        # Events (e.g. browsingContext.contextCreated) may arrive first.
+        # Startup is slow (~16s cold) and slower still when many browsers launch
+        # at once (test suites, CI), where a cold launch can blow the ready
+        # timeout or crash under resource pressure. Retry a timed-out or crashed
+        # launch a couple of times with a short backoff so a single unlucky
+        # launch doesn't fail hard. (Setup errors like a missing binary raise
+        # before this point.)
         import json
-        pre_ready_lines = []
-        try:
-            while True:
-                line_bytes = await asyncio.wait_for(
-                    process.stdout.readline(),  # type: ignore[union-attr]
-                    timeout=30,
-                )
-                if not line_bytes:
-                    # EOF — process died
-                    stderr_bytes = await process.stderr.read() if process.stderr else b""  # type: ignore[union-attr]
-                    raise BrowserCrashedError(f"Vibium failed to start: {stderr_bytes.decode(errors='replace')}")
-                line = line_bytes.decode().strip()
-                if not line:
-                    continue
-                try:
-                    msg = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
-                    continue
-                if msg.get("method") == "vibium:lifecycle.ready":
-                    break
-                # Buffer pre-ready events for later replay
-                pre_ready_lines.append(line)
-        except asyncio.TimeoutError:
-            process.kill()
-            raise BrowserCrashedError("Vibium failed to start: timed out waiting for ready signal")
+        max_attempts = 2
+        for attempt in range(1, max_attempts + 1):
+            process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=(sys.platform != "win32"),
+                # Raise the StreamReader buffer well above asyncio's 64 KiB default:
+                # a single newline-delimited message (e.g. a base64 screenshot) can be
+                # several MB, and readline() raises LimitOverrunError past the limit,
+                # killing the receiver loop (issue #110).
+                limit=_STREAM_LIMIT,
+            )
 
-        instance = cls(process)
-        instance._pre_ready_lines = pre_ready_lines
-        return instance
+            # Events (e.g. browsingContext.contextCreated) may arrive first.
+            pre_ready_lines = []
+            try:
+                while True:
+                    line_bytes = await asyncio.wait_for(
+                        process.stdout.readline(),  # type: ignore[union-attr]
+                        timeout=30,
+                    )
+                    if not line_bytes:
+                        # EOF — process died
+                        stderr_bytes = await process.stderr.read() if process.stderr else b""  # type: ignore[union-attr]
+                        raise BrowserCrashedError(f"Vibium failed to start: {stderr_bytes.decode(errors='replace')}")
+                    line = line_bytes.decode().strip()
+                    if not line:
+                        continue
+                    try:
+                        msg = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if msg.get("method") == "vibium:lifecycle.ready":
+                        break
+                    # Buffer pre-ready events for later replay
+                    pre_ready_lines.append(line)
+            except (asyncio.TimeoutError, BrowserCrashedError) as err:
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+                if attempt < max_attempts:
+                    await asyncio.sleep(0.5)
+                    continue
+                if isinstance(err, asyncio.TimeoutError):
+                    raise BrowserCrashedError(
+                        "Vibium failed to start: timed out waiting for ready signal"
+                    )
+                raise
+
+            instance = cls(process)
+            instance._pre_ready_lines = pre_ready_lines
+            return instance
+
+        # Unreachable: the final attempt either returns or raises above.
+        raise BrowserCrashedError("Vibium failed to start")
 
     def _cleanup(self) -> None:
         """Kill the subprocess if still running (called at exit)."""


### PR DESCRIPTION
## Problem

None of the clients retried a failed browser launch, and their ready-wait timeouts were inconsistent:

| Client | ready timeout | retry |
|---|---|---|
| JavaScript | 60s | none |
| Python | 30s | none |
| Java | **unbounded** (`readLine()` could hang forever) | none |

Under concurrent load (test suites, CI — see companion PR #191), a single cold Chrome launch that exceeded its ready window or crashed under resource pressure failed hard, and the resulting `before`-hook failure cascaded into sibling-test cancellations. Java's unbounded wait could hang an entire suite until the outer 600s wrapper.

## Change

Add a small, uniform retry to browser startup in all three clients — **2 attempts, 500ms backoff** — plus bound Java's wait:

- **JS** (`process.ts`): wrap spawn + ready-wait in the retry loop; retry only `TimeoutError`/`BrowserCrashedError`, surface spawn errors (e.g. `ENOENT`) immediately.
- **Python** (`binary.py`): same retry around the spawn + ready loop; timeouts/crashes are retried, then normalized to the prior error on final failure.
- **Java** (`VibiumProcess.java`): run the ready-wait on a daemon thread via an executor and bound it with a **60s** `Future.get(...)` timeout (a hung launch can no longer block forever), plus the same 2-attempt retry.

Source-only change (JS `dist/` is gitignored / built at publish).

## Verification

- Retry fires on a transient crash: **JS ~688ms**, **Python ~731ms** (both > the 500ms backoff ⇒ retried once, then surfaced).
- Fails fast on a missing binary (`ENOENT` ~2ms, not retried).
- Happy path unchanged (normal ~16s cold start still works).
- Full `make test` green across CLI, JS (sync/async), MCP, Python, Java — with **0 contention-failure signals**, run on the *pre-#191* (contention-prone) config.

Companion to #191 (which reduces how often startup contention occurs); this makes a single slow launch non-fatal regardless of load.
