### PR TITLE
test(py): use ThreadingHTTPServer to fix navigate-timeout flake under load

### DIFF
--- a/tests/py/test_server.py
+++ b/tests/py/test_server.py
@@ -5,7 +5,7 @@ All routes match the JS sync-test-server.js so tests are equivalent.
 
 import json
 import threading
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 
 
 HOME_HTML = """<html><head><title>Test App</title></head><body>
@@ -287,8 +287,16 @@ class VibiumTestHandler(BaseHTTPRequestHandler):
 
 
 def start_test_server() -> tuple:
-    """Start a test server on a random port. Returns (server, base_url)."""
-    server = HTTPServer(("127.0.0.1", 0), VibiumTestHandler)
+    """Start a test server on a random port. Returns (server, base_url).
+
+    Uses ThreadingHTTPServer so each connection is handled on its own thread.
+    A single-threaded HTTPServer serializes requests, so while it's busy
+    handling/draining one of the several parallel connections Chrome opens to
+    load a page, the main-document request waits behind it — under the
+    parallel test suite's CPU load that stall reached the 60s navigate
+    timeout and flaked (unlike the JS suite, whose server is a separate process).
+    """
+    server = ThreadingHTTPServer(("127.0.0.1", 0), VibiumTestHandler)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()


### PR DESCRIPTION
## Problem

After #191/#192 eliminated the browser-*startup* contention cascade, a **different**, rarer flake remained: `make test` occasionally failed with

```
vibium.errors.TimeoutError: Command 'vibium:page.navigate' timed out after 60s
ERROR tests/py/test_sync_api.py::test_go
```

The browser was up (startup retry worked) — an *operation* (navigate to the **local** `test_server` fixture) hung. Amplified by the Python suite's fail-fast config: one such timeout aborts the whole Python suite → whole `make test` fails. Seen ~1 in 3 full runs, only in the Python suite.

## Root cause

The local test server used `HTTPServer` — single-threaded, one request at a time — running in a daemon thread inside the pytest worker. Chrome opens several parallel connections to load a page; a single-threaded server can only handle one at a time, so while it's busy handling/draining one connection (slowed by CPU starvation under the parallel-group load), the main-document request waits behind it. Under enough contention that stall reaches the 60s navigate timeout.

The JS suite never hit this because its test server is a separate **forked process** (`fork(sync-test-server.js)`), not an in-process single-threaded server — which is exactly the asymmetry observed (only Python flaked).

## Fix

Use `ThreadingHTTPServer` (stdlib drop-in): each connection is handled on its own thread, so the accept loop is never blocked behind an in-flight request. `daemon_threads` defaults to true, so request threads don't block shutdown.

## Verification

- `test-python` green with the change (384 passed), no regression.
- Companion verification: re-running the full `make test` several times to confirm the navigate-timeout no longer recurs (the startup cascade from #191/#192 was already 0/3 runs).
