### PR TITLE
Fix(python): Element.highlight() missing from client

### DIFF
--- a/clients/python/src/vibium/async_api/element.py
+++ b/clients/python/src/vibium/async_api/element.py
@@ -120,6 +120,9 @@ class Element:
             "files": files,
             "timeout": timeout,
         }))
+    
+    async def highlight(self) -> None:
+        await self._client.send("vibium:element.highlight", self._command_params())
 
     # --- State ---
 

--- a/clients/python/src/vibium/sync_api/element.py
+++ b/clients/python/src/vibium/sync_api/element.py
@@ -79,6 +79,9 @@ class Element:
 
     def set_files(self, files: List[str], timeout: Optional[int] = None) -> None:
         self._loop.run(self._async.set_files(files, timeout))
+    
+    def highlight(self) -> None:
+        self._loop.run(self._async.highlight())
 
     # --- State ---
 

--- a/tests/py/test_interaction.py
+++ b/tests/py/test_interaction.py
@@ -92,6 +92,12 @@ async def test_scroll_into_view(async_page, test_server):
     assert await el.is_visible()
 
 
+async def test_highlight(async_page, test_server):
+    await async_page.go(test_server)
+    el = await async_page.find("#info")
+    await el.highlight()
+
+
 async def test_dispatch_event(async_page, test_server):
     await async_page.go(test_server + "/inputs")
     inp = await async_page.find("#text-input")


### PR DESCRIPTION
## Summary

This PR Fixes #208 - the missing `Element.highlight()` method to the Python client (async and sync).

`el.highlight()` is documented in `docs/reference/api.md`, implemented in the Go backend (`vibium:element.highlight`), and available in the Java client — but was absent from `vibium.async_api.Element` and `vibium.sync_api.Element`.

## Root Cause

`Element.highlight()` was documented and supported by the Go backend and Java client, but had not yet been exposed on the Python `Element` class.

## Changes

### `clients/python/src/vibium/async_api/element.py`

- Added `async def highlight(self) -> None` in the Interaction section (after `set_files`, before State queries)
- Sends `vibium:element.highlight` with standard `_command_params()` (context, selector, index, semantic params)
- No `timeout` parameter — matches Java and the backend handler, which uses instant `evalElementScript` rather than actionability polling

### `clients/python/src/vibium/sync_api/element.py`

- Added sync wrapper delegating to the async implementation via `_loop.run()`

### `tests/py/test_interaction.py`

- Added `test_highlight` smoke test: resolves `#info`, calls `highlight()`, verifies the BiDi command succeeds without error (same intent as Java's `highlightIsImplemented` in `JavaClusterFixTest`)

## Why this matters

This closes a parity gap between the documented API and the Python client. Now python users can call `el.highlight()` as documented, consistent with the Java client and CLI.

## Validation

Executed:

```
pytest tests/py/test_interaction.py -k highlight -v
```

<img width="763" height="204" alt="image" src="https://github.com/user-attachments/assets/5030fb08-4e89-4366-be3f-25b5c5526924" />
