### PR TITLE
Fix - vibium storage restore fails to restore localStorage/sessionStorage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ test-cli: build-go
 	@echo "--- CLI Tests ---"
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon start --headless
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js tests/cli/storage.test.js
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@echo "--- CLI Process Tests (sequential) ---"
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -3949,14 +3949,14 @@ func (h *Handlers) browserStorageState(args map[string]interface{}) (*ToolsCallR
 		})()
 	})`
 
-	storageJSON, err := h.client.Evaluate("", script)
+	storageEvalResult, err := h.client.Evaluate("", script)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get storage: %w", err)
 	}
 
-	storageStr, ok := storageJSON.(string)
+	storageStr, ok := storageEvalResult.(string)
 	if !ok {
-		return nil, fmt.Errorf("unexpected storage result type: %T", storageJSON)
+		return nil, fmt.Errorf("unexpected storage result type: %T", storageEvalResult)
 	}
 
 	var storageResult interface{}

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -3949,9 +3949,19 @@ func (h *Handlers) browserStorageState(args map[string]interface{}) (*ToolsCallR
 		})()
 	})`
 
-	storageResult, err := h.client.Evaluate("", script)
+	storageJSON, err := h.client.Evaluate("", script)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get storage: %w", err)
+	}
+
+	storageStr, ok := storageJSON.(string)
+	if !ok {
+		return nil, fmt.Errorf("unexpected storage result type: %T", storageJSON)
+	}
+
+	var storageResult interface{}
+	if err := json.Unmarshal([]byte(storageStr), &storageResult); err != nil {
+		return nil, fmt.Errorf("failed to parse storage data: %w", err)
 	}
 
 	// Build combined state

--- a/tests/cli/storage.test.js
+++ b/tests/cli/storage.test.js
@@ -1,0 +1,90 @@
+/**
+ * CLI Tests: Storage export/restore
+ * Verifies `vibium storage` / `vibium storage restore` round-trip
+ * localStorage and sessionStorage correctly.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execSync, spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { VIBIUM } = require('../helpers');
+
+let serverProcess, baseURL, statePath;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+  execSync(`${VIBIUM} go ${baseURL}/`, { encoding: 'utf-8', timeout: 30000 });
+  statePath = path.join(os.tmpdir(), `vibium-storage-test-${Date.now()}.json`);
+});
+
+after(() => {
+  if (statePath && fs.existsSync(statePath)) fs.unlinkSync(statePath);
+  if (serverProcess) serverProcess.kill();
+});
+
+describe('CLI: storage export/restore', () => {
+  test('export produces a real nested JSON object, not a double-encoded string', () => {
+    execSync(`${VIBIUM} eval "localStorage.setItem('user', 'user_vibium')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    execSync(`${VIBIUM} eval "sessionStorage.setItem('session_id', 'session_vibium')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+
+    execSync(`${VIBIUM} storage -o ${statePath}`, { encoding: 'utf-8', timeout: 30000 });
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+
+    // Guard
+    assert.strictEqual(
+      typeof state.storage,
+      'object',
+      '"storage" must be a nested object, not a double-encoded string'
+    );
+    assert.strictEqual(state.storage.localStorage.user, 'user_vibium');
+    assert.strictEqual(state.storage.sessionStorage.session_id, 'session_vibium');
+  });
+
+  test('restore round-trip repopulates localStorage and sessionStorage', () => {
+    execSync(`${VIBIUM} eval "localStorage.clear(); sessionStorage.clear();"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+
+    // Sanity check: confirm storage is actually empty before restoring
+    const before = execSync(`${VIBIUM} eval "localStorage.getItem('user')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(before, 'null');
+
+    const result = execSync(`${VIBIUM} storage restore ${statePath}`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /restored/i, 'Should confirm storage was restored');
+
+    const user = execSync(`${VIBIUM} eval "localStorage.getItem('user')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    const sessionId = execSync(`${VIBIUM} eval "sessionStorage.getItem('session_id')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+
+    assert.strictEqual(user, 'user_vibium', 'localStorage should be restored');
+    assert.strictEqual(sessionId, 'session_vibium', 'sessionStorage should be restored');
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes #217  — `browserStorageState` double-encoded the exported storage state, so `vibium storage restore` silently failed to restore `localStorage`/`sessionStorage` even though it reported success.

## Root Cause

`browserStorageState` in `clicker/internal/agent/handlers.go` ran a script that already calls `JSON.stringify(...)` in the browser, and then embedded that resulting string directly into the exported `state` map before a second `json.MarshalIndent` pass — so the `"storage"` field ended up as an escaped JSON string instead of a nested JSON object. `browserRestoreStorage` interpolates that field directly into `var state = %s;` when restoring, so the escaped string became a JS string literal instead of an object, and `state.localStorage`/`state.sessionStorage` were `undefined` — nothing was restored, with no error reported.

## Why this matters

* `vibium storage` / `vibium storage restore` are the only CLI/MCP commands for saving and reusing browser session state (e.g. login sessions) across runs — this bug made that workflow completely non-functional
* The failure is silent: the CLI prints "Storage state restored" with no indication anything went wrong
* No impact on Python/JS/Java clients — `context.storage()`/`context.setStorage()` use a separate, unaffected wire-API code path (`vibium:context.storage`/`setStorage` → `handleContextStorage` in `clicker/internal/api/handlers_storage.go`)

## Validation

Executed:

```bash
vibium go "https://sahitest.com/demo/training/books.htm"
vibium eval "localStorage.setItem('user', 'alice')"
vibium eval "sessionStorage.setItem('session_id', 'abc123')"
vibium storage -o state.json
cat state.json
vibium eval "localStorage.clear(); sessionStorage.clear();"
vibium storage restore state.json
vibium eval "localStorage.getItem('user')"
vibium eval "sessionStorage.getItem('session_id')"
```

Before fix — `state.json` had `"storage"` as an escaped string, and restore silently failed:

```json
{
  "cookies": [],
  "storage": "{\"origin\":\"https://sahitest.com\",\"localStorage\":{\"user\":\"alice\"},\"sessionStorage\":{\"session_id\":\"abc123\"}}"
}
```

```
localStorage.getItem('user')          = null
sessionStorage.getItem('session_id')  = null
```

After fix — `state.json` has `"storage"` as a real nested object, and restore works:

```json
{
  "cookies": [],
  "storage": {
    "localStorage": {
      "user": "alice"
    },
    "origin": "https://sahitest.com",
    "sessionStorage": {
      "session_id": "abc123"
    }
  }
}
```

```
localStorage.getItem('user')          = alice
sessionStorage.getItem('session_id')  = abc123
```

Test added:
<img width="814" height="220" alt="image" src="https://github.com/user-attachments/assets/45e1d73c-e950-4b8b-89c6-6955719cdc0a" />
