### PR TITLE
Fix(cli): recover automatically after browser is closed or crashes

### DIFF
--- a/clicker/cmd/clicker/output.go
+++ b/clicker/cmd/clicker/output.go
@@ -32,6 +32,14 @@ func printResult(result *agent.ToolsCallResult) {
 	}
 
 	// Human-readable: just print the text content
+	// when Notice is set, prefix it to the primary text result.
+	if result.Notice != "" {
+		if text := extractText(result); text != "" {
+			fmt.Println(result.Notice + " - " + text)
+			return
+		}
+	}
+
 	for _, c := range result.Content {
 		if c.Type == "text" && c.Text != "" {
 			fmt.Println(c.Text)

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -85,6 +85,19 @@ func (h *Handlers) Call(name string, args map[string]interface{}) (*ToolsCallRes
 
 	result, err := h.dispatch(name, args)
 
+	// If the browser connection died mid-session, relaunch a
+	// fresh browser, retrying the command once so the failure is invisible
+	// whenever possible instead of surfacing a confusing "broken pipe".
+	if err != nil && isConnectionError(err) && name != "browser_start" {
+		log.Debug("browser connection lost, relaunching and retrying", "command", name, "error", err)
+		h.resetBrowserState()
+		result, err = h.dispatch(name, args)
+
+		if err == nil && result != nil {
+			result.Notice = "Browser connection lost, relaunched automatically"
+		}
+	}
+
 	endTime := time.Now()
 
 	// Read and clear the element box stashed by AgentSession.SetLastElementBox
@@ -2527,6 +2540,31 @@ func (h *Handlers) ensureBrowser() error {
 		}
 	}
 	return nil
+}
+
+// isConnectionError reports whether err indicates the underlying browser
+// connection died (crashed process, closed socket), as opposed to an
+// application-level failure (e.g. "element not found").
+func isConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "closed network connection") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "EOF")
+}
+
+// resetBrowserState discards a stale client/connection so the next
+// ensureBrowser() call relaunches a fresh browser session.
+func (h *Handlers) resetBrowserState() {
+	if h.conn != nil {
+		h.conn.Close()
+	}
+	h.client = nil
+	h.conn = nil
+	h.launchResult = nil
 }
 
 // resolveRefsInArgs returns a copy of args with any @ref selector resolved

--- a/clicker/internal/agent/server.go
+++ b/clicker/internal/agent/server.go
@@ -106,6 +106,7 @@ type ToolsCallParams struct {
 type ToolsCallResult struct {
 	Content []Content `json:"content"`
 	IsError bool      `json:"isError,omitempty"`
+	Notice  string    `json:"notice,omitempty"`
 }
 
 type Content struct {


### PR DESCRIPTION
## Summary

This PR fixes #219  the CLI not recovering when the browser is closed manually or crashes externally. Instead of failing with `broken pipe` error, Vibium now detects the dead connection, relaunches the browser, retries the command once, and prints a short notice to the user.

## Root Cause

`ensureBrowser()` only checked whether `h.client` was `nil`. When the browser process died externally, the daemon kept a stale WebSocket client reference. The failure only surfaced later as a low-level network error:

```
Error: failed to get browsing context: failed to send command: write tcp ...: write: broken pipe
```

The only workaround was running `vibium stop` and retrying manually.

## Why this matters

- Common scenario: user closes the browser window
- Error message gave no indication of what happened or how to recover
- Breaks the "zero config / just works" experience for CLI users and agents

## Fix

**Reactive retry in `Call()`** — if a command fails with a connection error (`broken pipe`, `closed network connection`, etc.), discard the stale state and retry once:

- `isConnectionError()` — classifies connection-death errors vs normal app errors
- `resetBrowserState()` — clears `client`, `conn`, and `launchResult`
- Retry via existing `ensureBrowser()` lazy-launch path (no changes to individual handlers)

**User notice via `ToolsCallResult.Notice`** — optional field so the command result stays clean; CLI prefixes it when present:

```
Browser connection lost, relaunched automatically - Navigated to https://example.com
```

## Validation

**Before fix:**

```bash
vibium go "https://example.com"
# close browser window manually (or kill Chrome process)
vibium go "https://sahitest.com/demo/training/books.htm"
```

```
Error: failed to get browsing context: failed to send command: write tcp [::1]:62525->[::1]:62519: write: broken pipe
```

**After fix:**

```
Browser connection lost, relaunched automatically - Navigated to https://sahitest.com/demo/training/books.htm
```

**Note:** after rebuilding, restart the daemon (`vibium daemon stop && vibium daemon start`) so it loads the new binary.

<img width="902" height="69" alt="image" src="https://github.com/user-attachments/assets/87b0d49c-a8ea-42b8-a21e-a780baf6fdbb" />
