### PR TITLE
fix: show script exception text instead of empty message

### DIFF
--- a/clicker/internal/bidi/script.go
+++ b/clicker/internal/bidi/script.go
@@ -81,13 +81,16 @@ func (c *Client) Evaluate(context, expression string) (interface{}, error) {
 	var evalResult struct {
 		Type   string          `json:"type"`
 		Result json.RawMessage `json:"result"`
+		ExceptionDetails struct {
+			Text string `json:"text"`
+		} `json:"exceptionDetails"`
 	}
 	if err := json.Unmarshal(msg.Result, &evalResult); err != nil {
 		return nil, fmt.Errorf("failed to parse script.evaluate result: %w", err)
 	}
 
 	if evalResult.Type == "exception" {
-		return nil, fmt.Errorf("script exception: %s", string(evalResult.Result))
+		return nil, fmt.Errorf("script exception: %s", evalResult.ExceptionDetails.Text)
 	}
 
 	// Parse the remote value
@@ -137,13 +140,16 @@ func (c *Client) CallFunction(context, functionDeclaration string, args []interf
 	var callResult struct {
 		Type   string          `json:"type"`
 		Result json.RawMessage `json:"result"`
+		ExceptionDetails struct {
+			Text string `json:"text"`
+		} `json:"exceptionDetails"`
 	}
 	if err := json.Unmarshal(msg.Result, &callResult); err != nil {
 		return nil, fmt.Errorf("failed to parse script.callFunction result: %w", err)
 	}
 
 	if callResult.Type == "exception" {
-		return nil, fmt.Errorf("script exception: %s", string(callResult.Result))
+		return nil, fmt.Errorf("script exception: %s", callResult.ExceptionDetails.Text)
 	}
 
 	// Parse the remote value


### PR DESCRIPTION
## Summary

This PR fixes #221  — when `vibium eval` or MCP `browser_evaluate` runs JavaScript that throws, the CLI previously reported an empty error:

```
Error: failed to evaluate: script exception:
```

The browser did throw a real exception, but `bidi.Client` read the wrong field from the WebDriver BiDi response. This change parses `exceptionDetails.text` so users see the actual JavaScript error message.

## Why this matters

- Makes `vibium eval` debuggable when scripts fail (wrong variable, `SecurityError` on `localStorage`, etc.)
- Same fix applies to MCP `browser_evaluate` and any path using `CallFunction()` through the BiDi client
- Aligns with existing correct handling in `parseScriptResult()` (`clicker/internal/api/helpers.go`), which already reads `exceptionDetails`

## Validation

**Before fix:**

```bash
vibium eval "localStorage.setItem('key', 'value')"
```

```
Error: failed to evaluate: script exception:
```

**After fix:**

```
Error: failed to evaluate: script exception: SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
```
<img width="831" height="62" alt="image" src="https://github.com/user-attachments/assets/59b20102-7b02-4268-9ef7-c5a96c630d36" />

**Note:** rebuild and restart the daemon (`vibium daemon stop && vibium daemon start`) to load the new binary.
