### PR TITLE
Ci/add test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # Backstop only — scripts/timeout.mjs fails a hung suite after 10 min.
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: clicker/go.mod
+          cache-dependency-path: clicker/go.sum
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: pip
+          cache-dependency-path: |
+            clients/python/pyproject.toml
+            packages/python/vibium_linux_x64/pyproject.toml
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: gradle
+
+      # Ubuntu 24.04 restricts unprivileged user namespaces, which breaks
+      # Chrome's sandbox (HTTP 500 on session creation).
+      - name: Configure kernel for Chrome sandbox
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
+      # Keyed on installer.go so installer changes fetch a fresh Chrome.
+      - name: Cache Chrome for Testing
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/vibium/chrome-for-testing
+          key: ${{ runner.os }}-chrome-${{ hashFiles('clicker/internal/browser/installer.go') }}
+          restore-keys: |
+            ${{ runner.os }}-chrome-
+
+      # The lockfile is generated on macOS, so rollup's Linux native module
+      # is missing from it and npm install won't add it on its own.
+      - name: Install npm dependencies
+        run: npm install && npm install --no-save @rollup/rollup-linux-x64-gnu
+
+      - name: Build
+        run: make
+
+      # xvfb: the Python suite's headed tests need a display.
+      # NODE_TEST_TIMEOUT: on Node 20, --test-timeout limits each test file,
+      # not each test, and the slowest file needs ~150s.
+      - name: Test
+        run: xvfb-run --auto-servernum make test NODE_TEST_TIMEOUT=300000
+
+      # In case the job is interrupted before make test's own cleanup runs.
+      - name: Clean up zombie processes
+        if: always()
+        run: make double-tap

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,10 @@ endif
 # page navigation"). 30s gives headroom while making a hung test surface
 # in 30s instead of 2 minutes — so a flake takes ~30s × N_stuck_tests to
 # trip the phase wrapper instead of ~120s × N.
-TEST_FLAGS := --test-timeout=30000 --test-force-exit
+# On Node 20, --test-timeout limits each test FILE, not each test; CI
+# overrides this to file scale (see .github/workflows/test.yml).
+NODE_TEST_TIMEOUT ?= 30000
+TEST_FLAGS := --test-timeout=$(NODE_TEST_TIMEOUT) --test-force-exit
 
 # Default target
 all: build

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,13 @@ endif
 # faster iteration bump JS_PARALLEL (default 3) to use more cores.
 TEST_TIMEOUT ?= 600
 TIMEOUT_CMD := node scripts/timeout.mjs $(TEST_TIMEOUT)
+# Same watchdog for recipes that cd out of the repo root (pytest, gradlew).
+# Empty on Windows: timeout.mjs spawns via cmd.exe, which can't run ./gradlew.
+ifeq ($(OS),Windows_NT)
+  TIMEOUT_CMD_ABS :=
+else
+  TIMEOUT_CMD_ABS := node $(CURDIR)/scripts/timeout.mjs $(TEST_TIMEOUT)
+endif
 
 # Node test runner flags: per-test timeout + force exit on dangling handles.
 # The slowest healthy test today is ~20s (websocket "monitoring survives
@@ -293,7 +300,7 @@ test-python: build-go install-browser
 			pip install -e ../../packages/python/$(PYTHON_PLATFORM_PKG) -e ".[test]"; \
 		fi && \
 		VIBIUM_BIN_PATH=$(CURDIR)/clicker/bin/vibium$(EXE) \
-		python -m pytest ../../tests/py/ -v --tb=short -x -n $(PY_PARALLEL) --dist=loadfile
+		$(TIMEOUT_CMD_ABS) python -m pytest ../../tests/py/ -v --tb=short -x -n $(PY_PARALLEL) --dist=loadfile
 
 # Build Java client JAR (dev — no native binaries, fast)
 build-java: build-go
@@ -306,7 +313,7 @@ build-java: build-go
 JAVA_PARALLEL ?= 3
 test-java: build-go install-browser
 	@echo "--- Java Client Tests (parallel x$(JAVA_PARALLEL)) ---"
-	cd clients/java && VIBIUM_BIN_PATH=$(CURDIR)/clicker/bin/vibium$(EXE) ./gradlew test -PjavaParallel=$(JAVA_PARALLEL)
+	cd clients/java && VIBIUM_BIN_PATH=$(CURDIR)/clicker/bin/vibium$(EXE) $(TIMEOUT_CMD_ABS) ./gradlew test -PjavaParallel=$(JAVA_PARALLEL)
 
 # Package Java JAR with native binaries
 package-java: build-go-all

--- a/Makefile
+++ b/Makefile
@@ -181,12 +181,15 @@ test: build install-browser
 		exit $$EXIT; \
 	fi
 
-# Kill any Chrome/chromedriver processes left over from tests
+# Kill any Chrome/chromedriver processes left over from tests.
+# The bracketed characters stop Linux pkill from SIGKILLing the recipe's
+# own shell, whose command line contains the pattern.
 test-cleanup:
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
-	@pkill -9 -f 'Chrome for Testing' 2>/dev/null || true
-	@pkill -9 -f 'chromedriver' 2>/dev/null || true
-	@pkill -9 -f 'sync-test-server.js' 2>/dev/null || true
+	@pkill -9 -f 'Chrome for [T]esting' 2>/dev/null || true
+	@pkill -9 -f 'chrome-for-testin[g]' 2>/dev/null || true
+	@pkill -9 -f 'chromedrive[r]' 2>/dev/null || true
+	@pkill -9 -f 'sync-test-server.j[s]' 2>/dev/null || true
 
 # Run CLI tests (tests the vibium binary directly)
 # Process tests run separately with --test-concurrency=1 to avoid interference
@@ -328,9 +331,10 @@ ifeq ($(OS),Windows_NT)
 	@cmd //c "taskkill /F /IM chrome.exe" 2>/dev/null || true
 	@cmd //c "taskkill /F /IM chromedriver.exe" 2>/dev/null || true
 else
-	@pkill -9 -f 'Chrome for Testing' 2>/dev/null || true
-	@pkill -9 -f chromedriver 2>/dev/null || true
-	@pkill -9 -f 'sync-test-server.js' 2>/dev/null || true
+	@pkill -9 -f 'Chrome for [T]esting' 2>/dev/null || true
+	@pkill -9 -f 'chrome-for-testin[g]' 2>/dev/null || true
+	@pkill -9 -f 'chromedrive[r]' 2>/dev/null || true
+	@pkill -9 -f 'sync-test-server.j[s]' 2>/dev/null || true
 endif
 	@sleep 1
 	@echo "Done."

--- a/scripts/timeout.mjs
+++ b/scripts/timeout.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 // Run a command with a timeout. Kills the command if it exceeds the limit.
 // Usage: node scripts/timeout.mjs SECONDS command [args...]
-import { spawn } from 'node:child_process';
+//
+// On POSIX the child runs in its own process group. On timeout: dump the
+// process table (shows what was stuck), SIGTERM the group, SIGKILL after
+// 10s, exit 124.
+import { spawn, spawnSync } from 'node:child_process';
 
 const [seconds, ...cmdArgs] = process.argv.slice(2);
 const limit = Number(seconds) * 1000;
@@ -9,14 +13,35 @@ const limit = Number(seconds) * 1000;
 const isWin = process.platform === 'win32';
 const child = isWin
   ? spawn(cmdArgs.join(' '), { stdio: 'inherit', shell: true })
-  : spawn(cmdArgs[0], cmdArgs.slice(1), { stdio: 'inherit' });
+  : spawn(cmdArgs[0], cmdArgs.slice(1), { stdio: 'inherit', detached: true });
 
+function killGroup(signal) {
+  try {
+    if (isWin) child.kill();
+    else process.kill(-child.pid, signal);
+  } catch {}
+}
+
+// The child is in its own group, so forward terminal signals explicitly.
+process.on('SIGINT', () => killGroup('SIGINT'));
+process.on('SIGTERM', () => killGroup('SIGTERM'));
+
+let timedOut = false;
 const timer = setTimeout(() => {
-  process.stderr.write(`\n--- TIMEOUT: killed after ${seconds}s ---\n`);
-  child.kill();
+  timedOut = true;
+  process.stderr.write(`\n--- TIMEOUT after ${seconds}s; process table before kill: ---\n`);
+  if (!isWin) {
+    const ps = spawnSync('ps', ['axo', 'pid,ppid,pgid,stat,etime,args'], { encoding: 'utf-8' });
+    if (ps.stdout) process.stderr.write(ps.stdout);
+  }
+  process.stderr.write(`--- killing process group ---\n`);
+  killGroup('SIGTERM');
+  setTimeout(() => killGroup('SIGKILL'), 10_000).unref();
+  // In case the child is unkillable.
+  setTimeout(() => process.exit(124), 15_000).unref();
 }, limit);
 
 child.on('exit', (code) => {
   clearTimeout(timer);
-  process.exit(code ?? 1);
+  process.exit(timedOut ? 124 : (code ?? 1));
 });

--- a/tests/cli/process.test.js
+++ b/tests/cli/process.test.js
@@ -18,11 +18,13 @@ function getClickerChromePids() {
     let cmd, opts;
 
     if (platform === 'darwin') {
-      // Find Chrome for Testing processes that have --remote-debugging-port (our flag)
-      cmd = "pgrep -f 'Chrome for Testing.*--remote-debugging-port' 2>/dev/null || true";
+      // Find Chrome for Testing processes that have --remote-debugging-port
+      // (our flag). The [-] class stops Linux pgrep from matching the sh -c
+      // wrapper, whose command line contains this pattern.
+      cmd = "pgrep -f 'Chrome for Testing.*--remote-debugging[-]port' 2>/dev/null || true";
       opts = { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] };
     } else if (platform === 'linux') {
-      cmd = "pgrep -f 'chrome.*--remote-debugging-port' 2>/dev/null || true";
+      cmd = "pgrep -f 'chrome.*--remote-debugging[-]port' 2>/dev/null || true";
       opts = { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] };
     } else if (platform === 'win32') {
       cmd = `powershell -NoProfile -Command "Get-CimInstance Win32_Process -Filter \\"name='chrome.exe' and commandline like '%--remote-debugging-port%'\\" | Select-Object -ExpandProperty ProcessId"`;

--- a/tests/js/async/process.test.js
+++ b/tests/js/async/process.test.js
@@ -30,9 +30,11 @@ function getClickerChromePids() {
     let cmd;
 
     if (platform === 'darwin') {
-      cmd = "pgrep -f 'Chrome for Testing.*--remote-debugging-port' 2>/dev/null || true";
+      // The [-] class stops Linux pgrep from matching the sh -c wrapper,
+      // whose command line contains this pattern.
+      cmd = "pgrep -f 'Chrome for Testing.*--remote-debugging[-]port' 2>/dev/null || true";
     } else if (platform === 'linux') {
-      cmd = "pgrep -f 'chrome.*--remote-debugging-port' 2>/dev/null || true";
+      cmd = "pgrep -f 'chrome.*--remote-debugging[-]port' 2>/dev/null || true";
     } else {
       return new Set();
     }

--- a/tests/js/sync/process.test.js
+++ b/tests/js/sync/process.test.js
@@ -39,9 +39,11 @@ function getClickerChromePids() {
     let cmd;
 
     if (platform === 'darwin') {
-      cmd = "pgrep -f 'Chrome for Testing.*--remote-debugging-port' 2>/dev/null || true";
+      // The [-] class stops Linux pgrep from matching the sh -c wrapper,
+      // whose command line contains this pattern.
+      cmd = "pgrep -f 'Chrome for Testing.*--remote-debugging[-]port' 2>/dev/null || true";
     } else if (platform === 'linux') {
-      cmd = "pgrep -f 'chrome.*--remote-debugging-port' 2>/dev/null || true";
+      cmd = "pgrep -f 'chrome.*--remote-debugging[-]port' 2>/dev/null || true";
     } else {
       return new Set();
     }


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `make test` on every push to main and every PR, plus the test fixes needed for the suite to pass on Linux:

- Fix pgrep/pkill patterns in the process tests and Makefile cleanup targets that matched their own shell on Linux
- Fix `scripts/timeout.mjs` so it actually kills hung test suites, and use it for test-python and test-java too
- Make the Node per-test timeout overridable (Node 20 applies it per file; CI needs a larger value)