### PR TITLE
Fix orphaned Chrome cleanup on Linux

### DIFF
--- a/clicker/cmd/clicker/pipe.go
+++ b/clicker/cmd/clicker/pipe.go
@@ -113,11 +113,8 @@ func runPipe(connectURL string, connectHeaders http.Header) {
 		// Received SIGTERM/SIGINT
 	}
 
-	// Clean up — kill THIS process's chromedriver process tree, remove its
-	// user-data-dir, and sweep any Chrome subprocesses orphaned by the
-	// chromedriver kill (PPID=1). KillOrphanedChromeProcesses is safe
-	// under parallel runs because a sibling vibium's Chrome processes
-	// have PPID = sibling's chromedriver (not 1) — they're not matched.
+	// Clean up: kill THIS process's chromedriver process tree, remove its
+	// user-data-dir, and sweep any orphaned Chrome processes.
 	router.OnClientDisconnect(client)
 	router.CloseAll()
 	browser.KillOrphanedChromeProcesses()

--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/vibium/clicker/internal/bidi"
@@ -371,40 +372,67 @@ func killProcessTree(pid int) {
 	waitForProcessDead(pid, 2*time.Second)
 }
 
-// KillOrphanedChromeProcesses finds and kills Chrome/chromedriver processes
-// that have been orphaned (reparented to init/launchd).
-func KillOrphanedChromeProcesses() {
-	// Kill orphaned chromedriver and Chrome for Testing processes
-	patterns := []string{"chromedriver", "Chrome for Testing"}
+// isVibiumProcess reports whether comm (from `ps -o comm=`: bare name on
+// Linux, full path on macOS) names a vibium binary.
+func isVibiumProcess(comm string) bool {
+	name := filepath.Base(comm)
+	return name == "vibium" || name == "clicker"
+}
 
-	for _, pattern := range patterns {
-		cmd := exec.Command("pgrep", "-f", pattern)
-		output, err := cmd.Output()
+// KillOrphanedChromeProcesses kills processes running from vibium's Chrome
+// for Testing cache dir that no live vibium process owns. Ownership is
+// checked via the process tree rather than ppid==1 because systemd
+// re-parents orphans to the session subreaper, not PID 1. Only call during
+// shutdown, after CloseAll().
+func KillOrphanedChromeProcesses() {
+	cftDir, err := paths.GetChromeForTestingDir()
+	if err != nil {
+		return
+	}
+
+	// ^ anchor: only match processes running from the dir
+	output, err := exec.Command("pgrep", "-f", "^"+cftDir).Output()
+	if err != nil {
+		// pgrep exits 1 when nothing matched, which is the normal case
+		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
+			log.Debug("orphan sweep: pgrep failed", "error", err)
+		}
+		return
+	}
+
+	// Collect matched PIDs first to tell tree roots from descendants.
+	// (PID reuse between pgrep and ps is possible; the window is tiny.)
+	matched := make(map[int]bool)
+	for _, line := range bytes.Split(bytes.TrimSpace(output), []byte("\n")) {
+		var pid int
+		if _, err := fmt.Sscanf(string(line), "%d", &pid); err == nil {
+			matched[pid] = true
+		}
+	}
+
+	myPID := os.Getpid()
+	for pid := range matched {
+		ppidOut, err := exec.Command("ps", "-o", "ppid=", "-p", fmt.Sprintf("%d", pid)).Output()
 		if err != nil {
 			continue
 		}
-
-		lines := bytes.Split(bytes.TrimSpace(output), []byte("\n"))
-		for _, line := range lines {
-			if len(line) == 0 {
-				continue
-			}
-			var pid int
-			if _, err := fmt.Sscanf(string(line), "%d", &pid); err == nil {
-				// Check if this process's parent is 1 (orphaned)
-				ppidCmd := exec.Command("ps", "-o", "ppid=", "-p", fmt.Sprintf("%d", pid))
-				ppidOut, err := ppidCmd.Output()
-				if err != nil {
-					continue
-				}
-				var ppid int
-				if _, err := fmt.Sscanf(string(bytes.TrimSpace(ppidOut)), "%d", &ppid); err == nil {
-					if ppid == 1 {
-						killProcessGroup(pid)
-						killByPid(pid)
-					}
-				}
-			}
+		var ppid int
+		if _, err := fmt.Sscanf(string(bytes.TrimSpace(ppidOut)), "%d", &ppid); err != nil {
+			continue
+		}
+		// Descendant of another matched process; handled via its root.
+		if matched[ppid] {
+			continue
+		}
+		if ppid == myPID {
+			killProcessGroup(pid)
+			killByPid(pid)
+			continue
+		}
+		parentComm, err := exec.Command("ps", "-o", "comm=", "-p", fmt.Sprintf("%d", ppid)).Output()
+		if err != nil || !isVibiumProcess(strings.TrimSpace(string(parentComm))) {
+			killProcessGroup(pid)
+			killByPid(pid)
 		}
 	}
 }

--- a/tests/cli/process.test.js
+++ b/tests/cli/process.test.js
@@ -5,7 +5,10 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
-const { execSync, execFileSync, spawn } = require('node:child_process');
+const { execSync, execFileSync, spawn, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
 /**
@@ -151,5 +154,56 @@ describe('CLI: Process Cleanup', () => {
       0,
       `Chrome processes should be cleaned up after SIGTERM. New PIDs remaining: ${newPids.join(', ')}`
     );
+  });
+
+  test('shutdown cleanup ignores other tools\' chromedriver processes', async (t) => {
+    // Cleanup on Windows kills by executable name, not command line
+    if (process.platform === 'win32') {
+      t.skip('POSIX-only cleanup path');
+      return;
+    }
+
+    // Stand in for another tool's chromedriver (e.g. Selenium's): a script
+    // whose command line says "chromedriver" but does not run from vibium's
+    // cache dir. Orphaned so cleanup would consider it a leftover.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'other-tool-'));
+    const decoy = path.join(dir, 'chromedriver');
+    fs.writeFileSync(decoy, '#!/bin/sh\nsleep 120\n');
+    fs.chmodSync(decoy, 0o755);
+    // The shell backgrounds the decoy, prints its PID, and exits, which
+    // orphans the decoy. detached puts the shell (and so the decoy) in its
+    // own process group, so a group kill cannot take down this test runner.
+    const pid = Number(
+      spawnSync('sh', ['-c', `"${decoy}" 120 > /dev/null 2>&1 & echo $!`], {
+        encoding: 'utf-8',
+        detached: true,
+      }).stdout.trim()
+    );
+    assert.ok(Number.isInteger(pid) && pid > 0, 'decoy failed to start');
+
+    try {
+      // Trigger vibium's shutdown cleanup, same as the SIGTERM test above
+      const server = spawn(VIBIUM, ['serve'], { stdio: ['pipe', 'pipe', 'pipe'] });
+      await sleep(2000);
+      server.kill('SIGTERM');
+      await new Promise((resolve) => {
+        const timeout = setTimeout(resolve, 5000);
+        server.on('exit', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+
+      let alive = true;
+      try {
+        process.kill(pid, 0);
+      } catch {
+        alive = false;
+      }
+      assert.ok(alive, 'vibium cleanup killed a chromedriver process it does not own');
+    } finally {
+      try { process.kill(pid, 'SIGKILL'); } catch {}
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
KillOrphanedChromeProcesses matched any process with chromedriver or Chrome for Testing in its command line, so it could kill processes owned by other tools like Selenium. Its orphan check (parent PID 1) also never matches on systemd Linux, so leftovers there were never cleaned up.

Match only processes running from vibium's Chrome for Testing cache dir, and kill a match only if no live vibium process owns it. Adds a test that a decoy chromedriver from another tool survives vibium's shutdown.