### PR TITLE
Fix daemon socket crash on payloads over 1MB (#209)

### DIFF
--- a/clicker/internal/daemon/client.go
+++ b/clicker/internal/daemon/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/vibium/clicker/internal/agent"
@@ -126,17 +127,21 @@ func sendRequest(method string, params json.RawMessage) (*agent.Response, error)
 	}
 
 	conn.SetReadDeadline(time.Now().Add(readTimeout))
-	scanner := bufio.NewScanner(conn)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return nil, fmt.Errorf("read response: %w", err)
-		}
+	// Responses can be arbitrarily large (e.g. page text, a11y trees), so
+	// read with bufio.Reader, which grows as needed — bufio.Scanner fails
+	// with "token too long" once a response exceeds its fixed buffer.
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	switch {
+	case err == io.EOF && len(line) > 0:
+		// Complete response without a trailing newline; parse it as-is.
+	case err == io.EOF:
 		return nil, fmt.Errorf("daemon closed connection without response")
+	case err != nil:
+		return nil, fmt.Errorf("read response: %w", err)
 	}
 
 	var resp agent.Response
-	if err := json.Unmarshal(scanner.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal(line, &resp); err != nil {
 		return nil, fmt.Errorf("unmarshal response: %w", err)
 	}
 

--- a/clicker/internal/daemon/router.go
+++ b/clicker/internal/daemon/router.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"time"
 
-	"github.com/vibium/clicker/internal/log"
 	"github.com/vibium/clicker/internal/agent"
+	"github.com/vibium/clicker/internal/log"
 )
 
 // StatusResult is returned by daemon/status.
@@ -31,14 +32,13 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 	// Set read deadline
 	conn.SetReadDeadline(time.Now().Add(60 * time.Second))
 
-	scanner := bufio.NewScanner(conn)
-	// Increase scanner buffer for large requests
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-
-	if !scanner.Scan() {
+	// Requests can be arbitrarily large (e.g. filling a form field with a
+	// long string), so read with bufio.Reader, which grows as needed —
+	// bufio.Scanner fails once a request exceeds its fixed buffer.
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if len(line) == 0 || (err != nil && err != io.EOF) {
 		return
 	}
-	line := scanner.Bytes()
 
 	response := d.handleRequest(line)
 	if response == nil {

--- a/tests/cli/page-reading.test.js
+++ b/tests/cli/page-reading.test.js
@@ -59,4 +59,29 @@ describe('CLI: Page Reading', () => {
     assert.match(result, /@e1/, 'Should contain @e1 ref');
     assert.ok(!result.includes('@e2'), 'Should not contain @e2 ref');
   });
+
+  // Regression test for #209: the daemon socket transport used a fixed-size
+  // scanner buffer, so any response over 1MB (large pages, JSON APIs) crashed
+  // with "read response: bufio.Scanner: token too long".
+  test('text command handles multi-megabyte page text', () => {
+    const size = 3 * 1024 * 1024;
+    execSync(`${VIBIUM} go https://example.com`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    execSync(
+      `${VIBIUM} eval "document.body.textContent = 'issue-209-marker ' + 'x'.repeat(${size}); 'big page ready'"`,
+      { encoding: 'utf-8', timeout: 30000 }
+    );
+    const result = execSync(`${VIBIUM} text`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    assert.match(result, /issue-209-marker/, 'Should contain marker text');
+    assert.ok(
+      result.length > size,
+      `Should return full page text, >${size} chars (got ${result.length})`
+    );
+  });
 });


### PR DESCRIPTION
## Summary

`vibium text` crashed with `read response: bufio.Scanner: token too long` on pages whose text produced a daemon response over 1MB (large JSON APIs, long articles).

**Root cause:** the CLI and daemon exchange newline-delimited JSON over a local socket, and both sides read it with a `bufio.Scanner` capped at a fixed 1MB buffer (`internal/daemon/client.go`, `internal/daemon/router.go`). Any response over the cap killed the read; oversized requests (e.g. `fill` with a very long string) hit the same wall on the daemon side.

**Fix:** read with `bufio.Reader.ReadBytes('\n')`, which grows its buffer as needed. This is the same idiom the MCP stdio server already uses (`internal/agent/server.go:168`), so both JSON-RPC transports now behave consistently, and payload size stays bounded by the BiDi WebSocket's documented 10MB message limit rather than an arbitrary transport cap. The existing "daemon closed connection without response" error path is preserved, as is the scanner's tolerance for a final line without a trailing newline.

Also includes a one-line import reorder in `router.go` that `gofmt` flagged (pre-existing).

Fixes #209

## Verification

Reproduced the issue on a pre-fix build, then confirmed the fix with the exact repro from the report:

```
vibium go "https://randomuser.me/api/?results=5000&format=pretty"
vibium wait load
vibium text
# before: Error: read response: bufio.Scanner: token too long (exit 1)
# after:  full ~8MB of page text (exit 0)
```

- New regression test in `tests/cli/page-reading.test.js` round-trips 3MB of page text through the daemon; it fails on the pre-fix binary with the issue's exact error and passes with the fix.
- `go vet ./...`, `go test ./...`, and `gofmt` all clean.
- CLI and daemon test suites produce results identical to a clean checkout of `main` run on the same machine (the only failures on Windows are pre-existing cmd.exe quoting issues in unrelated test files, verified by running the same suites on unmodified HEAD).

## Notes for reviewers

- The 1MB scanner cap predates the current tool surface (added with the original daemon mode); commands like `text`, `html`, and `a11y-tree` can legitimately exceed it.
- Unbounded line reads are safe here for the same reason they are on the MCP stdio path: the peer is a local, same-user process, and the BiDi layer already caps what the browser can send at 10MB.
