### PR TITLE
Harden CI Workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Opens PRs that bump the SHA-pinned actions in workflows, so the pins
+# stay current (the pinned majors target the deprecated Node 20 runtime).
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# CI only reads the repo. Keeps the job's GITHUB_TOKEN read-only even if
+# the repo default is ever write.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,22 +17,26 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Nothing here pushes, so keep the token out of .git/config where
+          # build and test steps could read it.
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: clicker/go.mod
           cache-dependency-path: clicker/go.sum
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: npm
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
           cache: pip
@@ -36,7 +45,7 @@ jobs:
             packages/python/vibium_linux_x64/pyproject.toml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: '21'
           distribution: temurin
@@ -49,17 +58,18 @@ jobs:
 
       # Keyed on installer.go so installer changes fetch a fresh Chrome.
       - name: Cache Chrome for Testing
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/vibium/chrome-for-testing
           key: ${{ runner.os }}-chrome-${{ hashFiles('clicker/internal/browser/installer.go') }}
           restore-keys: |
             ${{ runner.os }}-chrome-
 
-      # The lockfile is generated on macOS, so rollup's Linux native module
-      # is missing from it and npm install won't add it on its own.
+      # npm ci installs exactly what the lockfile pins. The lockfile is
+      # generated on macOS, so rollup's Linux native module is missing from
+      # it and has to be added separately.
       - name: Install npm dependencies
-        run: npm install && npm install --no-save @rollup/rollup-linux-x64-gnu
+        run: npm ci && npm install --no-save @rollup/rollup-linux-x64-gnu
 
       - name: Build
         run: make

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,9 +67,12 @@ jobs:
 
       # npm ci installs exactly what the lockfile pins. The lockfile is
       # generated on macOS, so rollup's Linux native module is missing from
-      # it and has to be added separately.
+      # it and has to be added separately, locked to the rollup version the
+      # lockfile installed so it cannot float to a newer release.
       - name: Install npm dependencies
-        run: npm ci && npm install --no-save @rollup/rollup-linux-x64-gnu
+        run: |
+          npm ci
+          npm install --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('rollup/package.json').version")
 
       - name: Build
         run: make


### PR DESCRIPTION
Small security hardening of test.yml. No change to what CI builds or tests.

- Pin all six actions to commit SHAs, with the version in a comment next to each pin, so a moved or compromised tag can't pull in new code. Each SHA can be checked against its release tag.

- Set permissions: contents: read at the workflow level. Nothing in the job needs write access.

- Add persist-credentials: false to checkout so the token is not stored in .git/config where build and test steps could read it.

- Switch npm install to npm ci so installs match the lockfile exactly. The rollup Linux native module workaround is kept, now locked to the lockfile's rollup version instead of installing the latest release.

- Add a Dependabot config for github-actions so the SHA pins get monthly update PRs instead of going stale.

Note: npm ci fails if package.json and package-lock.json are out of sync, instead of silently updating the lockfile. This is the right behavior for CI, but it means lockfile changes need to be committed along with dependency changes.