### PR TITLE
BiDi client: single reader goroutine with pending-command registry

### DIFF
--- a/clicker/cmd/clicker/diagnostics.go
+++ b/clicker/cmd/clicker/diagnostics.go
@@ -164,13 +164,22 @@ func newBiDiTestCmd() *cobra.Command {
 			fmt.Printf("       Session ID: %s\n", launchResult.SessionID)
 
 			fmt.Println("[2/5] WebDriver session created with BiDi enabled")
-			fmt.Printf("       WebSocket URL: %s\n", launchResult.WebSocketURL)
 
-			fmt.Println("[3/5] Connecting to BiDi WebSocket...")
-			conn, err := bidi.Connect(launchResult.WebSocketURL)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error connecting: %v\n", err)
-				os.Exit(1)
+			// The BiDi-first launch path hands back the open connection and
+			// leaves WebSocketURL empty; only the HTTP fallback needs a dial.
+			var conn *bidi.Connection
+			if launchResult.BidiConn != nil {
+				fmt.Println("[3/5] Reusing BiDi WebSocket from launch...")
+				conn = launchResult.BidiConn
+			} else {
+				fmt.Printf("       WebSocket URL: %s\n", launchResult.WebSocketURL)
+				fmt.Println("[3/5] Connecting to BiDi WebSocket...")
+				var err error
+				conn, err = bidi.Connect(launchResult.WebSocketURL)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error connecting: %v\n", err)
+					os.Exit(1)
+				}
 			}
 			defer conn.Close()
 			fmt.Println("       Connected!")

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -29,6 +29,7 @@ type Handlers struct {
 	refMap         map[string]string // @e1 -> CSS selector
 	lastMap        string            // last map output (for diff)
 	recorder       *api.Recorder
+	recordDropBase uint64 // client.DroppedEvents() at record start
 	downloadDir    string
 	lastElementBox *api.BoxInfo // stashed by AgentSession.SetLastElementBox via callback
 	activeContext  string         // last page context switched to or created
@@ -3778,6 +3779,7 @@ func (h *Handlers) browserRecordStart(args map[string]interface{}) (*ToolsCallRe
 			"browsingContext.fragmentNavigated",
 		},
 	})
+	h.recordDropBase = h.client.DroppedEvents()
 	h.client.SetEventHandler(func(msg string) {
 		h.recorder.RecordBidiEvent(msg)
 	})
@@ -3799,6 +3801,7 @@ func (h *Handlers) browserRecordStop(args map[string]interface{}) (*ToolsCallRes
 	// Stop forwarding events to the recorder
 	if h.client != nil {
 		h.client.SetEventHandler(nil)
+		h.recorder.NoteDroppedEvents(h.client.DroppedEvents() - h.recordDropBase)
 	}
 
 	// Stop screenshot goroutine before stopping the recorder

--- a/clicker/internal/api/recording.go
+++ b/clicker/internal/api/recording.go
@@ -178,6 +178,25 @@ func (t *Recorder) Start(opts RecordingStartOptions, viewport map[string]interfa
 	})
 }
 
+// NoteDroppedEvents stamps into the trace that count BiDi events were
+// dropped before reaching the recorder, so a recording with holes says so.
+func (t *Recorder) NoteDroppedEvents(count uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.recording || count == 0 {
+		return
+	}
+
+	t.events = append(t.events, recordEvent{
+		"type":   "event",
+		"method": "vibium.eventsDropped",
+		"params": map[string]interface{}{"count": count},
+		"time":   t.monotonicNow(),
+		"class":  "BrowserContext",
+	})
+}
+
 // Stop stops recording and returns the recording zip data.
 func (t *Recorder) Stop() ([]byte, error) {
 	t.mu.Lock()

--- a/clicker/internal/api/recording_test.go
+++ b/clicker/internal/api/recording_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+// traceLines unzips a recording and returns the decoded trace.trace events.
+func traceLines(t *testing.T, zipData []byte) []map[string]interface{} {
+	t.Helper()
+
+	zr, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		t.Fatalf("open recording zip: %v", err)
+	}
+	for _, f := range zr.File {
+		if f.Name != "trace.trace" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open trace entry: %v", err)
+		}
+		defer rc.Close()
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("read trace entry: %v", err)
+		}
+
+		var events []map[string]interface{}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
+				continue
+			}
+			var evt map[string]interface{}
+			if err := json.Unmarshal([]byte(line), &evt); err != nil {
+				t.Fatalf("parse trace line %q: %v", line, err)
+			}
+			events = append(events, evt)
+		}
+		return events
+	}
+	t.Fatal("recording zip has no trace.trace entry")
+	return nil
+}
+
+// findDropEvent returns the vibium.eventsDropped trace event, or nil.
+func findDropEvent(events []map[string]interface{}) map[string]interface{} {
+	for _, evt := range events {
+		if evt["method"] == "vibium.eventsDropped" {
+			return evt
+		}
+	}
+	return nil
+}
+
+// TestNoteDroppedEventsStampsTrace checks that a recording that lost BiDi
+// events says so in the trace, with the count.
+func TestNoteDroppedEventsStampsTrace(t *testing.T) {
+	rec := NewRecorder()
+	rec.Start(RecordingStartOptions{Name: "drops"}, nil)
+	rec.NoteDroppedEvents(7)
+
+	zipData, err := rec.Stop()
+	if err != nil {
+		t.Fatalf("stop recording: %v", err)
+	}
+
+	drop := findDropEvent(traceLines(t, zipData))
+	if drop == nil {
+		t.Fatal("trace has no vibium.eventsDropped event, want one with count 7")
+	}
+	params, _ := drop["params"].(map[string]interface{})
+	if count, _ := params["count"].(float64); count != 7 {
+		t.Fatalf("eventsDropped count = %v, want 7", params["count"])
+	}
+}
+
+// TestNoDropEventWhenNothingDropped checks that a clean recording does not
+// claim drops.
+func TestNoDropEventWhenNothingDropped(t *testing.T) {
+	rec := NewRecorder()
+	rec.Start(RecordingStartOptions{Name: "clean"}, nil)
+	rec.NoteDroppedEvents(0)
+
+	zipData, err := rec.Stop()
+	if err != nil {
+		t.Fatalf("stop recording: %v", err)
+	}
+
+	if drop := findDropEvent(traceLines(t, zipData)); drop != nil {
+		t.Fatalf("trace claims dropped events on a clean recording: %v", drop)
+	}
+}

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -21,7 +21,6 @@ const DefaultTimeout = 30 * time.Second
 type BrowserSession struct {
 	LaunchResult *browser.LaunchResult
 	BidiConn     *bidi.Connection
-	BidiClient   *bidi.Client
 	Client       ClientTransport
 	mu           sync.Mutex
 	closed       bool
@@ -97,14 +96,20 @@ func NewRouter(headless bool, connectURL string, connectHeaders http.Header) *Ro
 func (r *Router) OnClientConnect(client ClientTransport) {
 	var launchResult *browser.LaunchResult
 	var bidiConn *bidi.Connection
-	var bidiClient *bidi.Client
 	var err error
 
 	if r.connectURL != "" {
 		// Remote mode: connect to an existing BiDi endpoint and create a session
 		fmt.Fprintf(os.Stderr, "[router] Connecting to remote browser for client %d: %s\n", client.ID(), r.connectURL)
 
-		bidiConn, bidiClient, _, err = bidi.ConnectRemote(r.connectURL, r.connectHeaders)
+		// Handshake without a bidi.Client: this router reads the connection
+		// itself in routeBrowserToClient, so no client reader may own it.
+		bidiConn, err = bidi.ConnectWithHeaders(r.connectURL, r.connectHeaders)
+		if err == nil {
+			if _, err = bidi.SessionNewOnConn(bidiConn, map[string]interface{}{}); err != nil {
+				bidiConn.Close()
+			}
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[router] Failed to connect to remote browser for client %d: %v\n", client.ID(), err)
 			client.Send(fmt.Sprintf(`{"error":{"code":-32000,"message":"Failed to connect to remote browser: %s"}}`, err.Error()))
@@ -145,15 +150,11 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 
 			fmt.Fprintf(os.Stderr, "[router] BiDi connection established for client %d\n", client.ID())
 		}
-
-		// Local mode: browser.Launch() already called SessionNew, just wrap the connection
-		bidiClient = bidi.NewClient(bidiConn)
 	}
 
 	session := &BrowserSession{
 		LaunchResult:   launchResult,
 		BidiConn:       bidiConn,
-		BidiClient:     bidiClient,
 		Client:         client,
 		stopChan:       make(chan struct{}),
 		internalCmds:   make(map[int]chan json.RawMessage),
@@ -927,9 +928,11 @@ func (r *Router) closeSession(session *BrowserSession) {
 		session.recorder.StopScreenshots()
 	}
 
-	// Remote mode: end the BiDi session so chromedriver closes Chrome
-	if r.connectURL != "" && session.BidiClient != nil {
-		session.BidiClient.SendCommand("session.end", map[string]interface{}{})
+	// Remote mode: end the BiDi session so chromedriver closes Chrome.
+	// stopChan is already closed, so this sends the command and returns
+	// without waiting for the response; the connection is closed next anyway.
+	if r.connectURL != "" && session.BidiConn != nil {
+		r.sendInternalCommandWithTimeout(session, "session.end", map[string]interface{}{}, 5*time.Second)
 	}
 
 	// Close BiDi connection

--- a/clicker/internal/bidi/connect.go
+++ b/clicker/internal/bidi/connect.go
@@ -46,6 +46,10 @@ func SessionNewOnConn(conn *Connection, capabilities map[string]interface{}) (*S
 		return nil, fmt.Errorf("failed to send command: %w", err)
 	}
 
+	// The deadline is only checked between messages, so a connection that
+	// goes fully silent blocks in Receive until its 120s read deadline, not
+	// this 60s one. Acceptable for a handshake-only path and matches the
+	// behavior before the single-reader refactor.
 	deadline := time.Now().Add(defaultCommandTimeout)
 	for time.Now().Before(deadline) {
 		raw, err := conn.Receive()

--- a/clicker/internal/bidi/connect.go
+++ b/clicker/internal/bidi/connect.go
@@ -1,9 +1,16 @@
 package bidi
 
-import "net/http"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
 
 // ConnectRemote connects to a remote BiDi endpoint, creates a client,
 // and establishes a session. Returns the connection, client, and session ID.
+// The returned client owns all reads on the connection; callers that need to
+// read the connection themselves must use SessionNewOnConn instead.
 func ConnectRemote(url string, headers http.Header) (*Connection, *Client, string, error) {
 	conn, err := ConnectWithHeaders(url, headers)
 	if err != nil {
@@ -19,4 +26,54 @@ func ConnectRemote(url string, headers http.Header) (*Connection, *Client, strin
 	}
 
 	return conn, client, result.SessionID, nil
+}
+
+// SessionNewOnConn performs the session.new handshake with direct reads on a
+// connection that has no Client attached. Callers that will own reads on the
+// connection afterward (like the api router) use this instead of NewClient,
+// whose reader goroutine keeps the socket for the connection's lifetime.
+func SessionNewOnConn(conn *Connection, capabilities map[string]interface{}) (*SessionNewResult, error) {
+	cmd := NewCommand("session.new", map[string]interface{}{
+		"capabilities": capabilities,
+	})
+
+	data, err := cmd.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal command: %w", err)
+	}
+
+	if err := conn.Send(string(data)); err != nil {
+		return nil, fmt.Errorf("failed to send command: %w", err)
+	}
+
+	deadline := time.Now().Add(defaultCommandTimeout)
+	for time.Now().Before(deadline) {
+		raw, err := conn.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("failed to receive response: %w", err)
+		}
+
+		msg, err := UnmarshalMessage([]byte(raw))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse response: %w", err)
+		}
+
+		// Nothing is subscribed yet, so anything that is not the handshake
+		// response (early events, mostly) can be skipped.
+		if msg.ID == nil || *msg.ID != cmd.ID {
+			continue
+		}
+
+		if _, err := responseOrError(msg); err != nil {
+			return nil, err
+		}
+
+		var result SessionNewResult
+		if err := json.Unmarshal(msg.Result, &result); err != nil {
+			return nil, fmt.Errorf("failed to parse session.new result: %w", err)
+		}
+		return &result, nil
+	}
+
+	return nil, fmt.Errorf("timeout waiting for response to session.new after %s", defaultCommandTimeout)
 }

--- a/clicker/internal/bidi/session.go
+++ b/clicker/internal/bidi/session.go
@@ -3,30 +3,131 @@ package bidi
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// Client is a BiDi client that wraps a WebSocket connection.
+// eventBufferSize bounds the queue between the reader and the event
+// dispatcher. When the handler falls this far behind, events are dropped
+// rather than letting them stall the socket reader.
+const eventBufferSize = 256
+
+// Client is a BiDi client that wraps a WebSocket connection. A dedicated
+// reader goroutine owns all reads on the connection and routes responses to
+// waiting callers by command ID, so commands can be sent concurrently and
+// the socket stays drained even while no command is in flight.
 type Client struct {
-	conn         *Connection
-	verbose      bool
-	eventHandler func(msg string) // optional callback for BiDi events
+	conn    *Connection
+	verbose atomic.Bool
+
+	// mu guards pending and eventHandler.
+	mu           sync.Mutex
+	pending      map[int64]chan *Message
+	eventHandler func(msg string)
+
+	events chan string
+
+	// readErr is written by the reader before it closes readerDone, so it
+	// may only be read after readerDone is closed.
+	readErr    error
+	readerDone chan struct{}
 }
 
-// NewClient creates a new BiDi client from a WebSocket connection.
+// NewClient creates a new BiDi client from a WebSocket connection and starts
+// its reader. The client owns all reads on the connection from this point;
+// nothing else may call conn.Receive for the connection's lifetime.
 func NewClient(conn *Connection) *Client {
-	return &Client{conn: conn}
+	c := &Client{
+		conn:       conn,
+		pending:    make(map[int64]chan *Message),
+		events:     make(chan string, eventBufferSize),
+		readerDone: make(chan struct{}),
+	}
+	go c.readLoop()
+	go c.dispatchEvents()
+	return c
 }
 
 // SetVerbose enables or disables verbose logging of JSON messages.
 func (c *Client) SetVerbose(verbose bool) {
-	c.verbose = verbose
+	c.verbose.Store(verbose)
 }
 
-// SetEventHandler sets a callback for BiDi events received while waiting
-// for command responses. Pass nil to stop forwarding events.
+// SetEventHandler sets a callback for BiDi events. Pass nil to stop
+// forwarding events. Safe to call while the client is in use.
 func (c *Client) SetEventHandler(handler func(msg string)) {
+	c.mu.Lock()
 	c.eventHandler = handler
+	c.mu.Unlock()
+}
+
+// readLoop is the only reader of the connection. Routing every message
+// through one goroutine keeps concurrent SendCommand callers from stealing
+// each other's responses and keeps events flowing between commands.
+func (c *Client) readLoop() {
+	defer func() {
+		close(c.readerDone)
+		close(c.events)
+		// A connection without a reader is unusable; closing it stops the
+		// ping loop and makes later sends fail instead of hang.
+		c.conn.Close()
+	}()
+
+	for {
+		raw, err := c.conn.Receive()
+		if err != nil {
+			c.readErr = fmt.Errorf("connection read failed: %w", err)
+			return
+		}
+
+		if c.verbose.Load() {
+			fmt.Printf("       <-- %s\n", raw)
+		}
+
+		msg, err := UnmarshalMessage([]byte(raw))
+		if err != nil {
+			// A single malformed frame should not take down the connection.
+			continue
+		}
+
+		if msg.ID != nil {
+			c.mu.Lock()
+			ch, ok := c.pending[*msg.ID]
+			if ok {
+				delete(c.pending, *msg.ID)
+			}
+			c.mu.Unlock()
+			// A missing entry means the caller gave up; drop the response.
+			// The channel holds one message, so the send never blocks.
+			if ok {
+				ch <- msg
+			}
+			continue
+		}
+
+		if msg.IsEvent() {
+			select {
+			case c.events <- raw:
+			default:
+				// Dropping beats stalling every command response behind a
+				// slow event handler.
+			}
+		}
+	}
+}
+
+// dispatchEvents delivers events in arrival order on its own goroutine so a
+// blocking handler can never stall the reader.
+func (c *Client) dispatchEvents() {
+	for raw := range c.events {
+		c.mu.Lock()
+		handler := c.eventHandler
+		c.mu.Unlock()
+		if handler != nil {
+			handler(raw)
+		}
+	}
 }
 
 // defaultCommandTimeout is the maximum time to wait for a BiDi command response.
@@ -46,58 +147,63 @@ func (c *Client) SendCommandWithTimeout(method string, params interface{}, timeo
 		return nil, fmt.Errorf("failed to marshal command: %w", err)
 	}
 
-	if c.verbose {
+	if c.verbose.Load() {
 		fmt.Printf("       --> %s\n", string(data))
 	}
+
+	// Register before sending so the response cannot race past us.
+	ch := make(chan *Message, 1)
+	c.mu.Lock()
+	select {
+	case <-c.readerDone:
+		c.mu.Unlock()
+		return nil, fmt.Errorf("cannot send %s: %w", method, c.readErr)
+	default:
+	}
+	c.pending[cmd.ID] = ch
+	c.mu.Unlock()
+
+	// Unregister on every exit path so a late response finds no entry
+	// instead of a channel nobody reads.
+	defer func() {
+		c.mu.Lock()
+		delete(c.pending, cmd.ID)
+		c.mu.Unlock()
+	}()
 
 	if err := c.conn.Send(string(data)); err != nil {
 		return nil, fmt.Errorf("failed to send command: %w", err)
 	}
 
-	// Wait for response with matching ID (with timeout)
-	deadline := time.Now().Add(timeout)
-	for {
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("timeout waiting for response to %s after %s", method, timeout)
-		}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
-		resp, err := c.conn.Receive()
-		if err != nil {
-			return nil, fmt.Errorf("failed to receive response: %w", err)
+	select {
+	case msg := <-ch:
+		return responseOrError(msg)
+	case <-timer.C:
+		return nil, fmt.Errorf("timeout waiting for response to %s after %s", method, timeout)
+	case <-c.readerDone:
+		// The response may have been routed just before the reader died.
+		select {
+		case msg := <-ch:
+			return responseOrError(msg)
+		default:
 		}
-
-		if c.verbose {
-			fmt.Printf("       <-- %s\n", resp)
-		}
-
-		msg, err := UnmarshalMessage([]byte(resp))
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse response: %w", err)
-		}
-
-		// Check if this is the response we're waiting for
-		if msg.ID != nil && *msg.ID == cmd.ID {
-			if msg.IsError() {
-				errData, _ := msg.GetError()
-				if errData != nil {
-					return nil, fmt.Errorf("BiDi error: %s - %s", errData.Error, errData.Message)
-				}
-				return nil, fmt.Errorf("BiDi error: %s", string(msg.Error))
-			}
-			return msg, nil
-		}
-
-		// If it's an event, forward to handler if set, otherwise skip
-		if msg.IsEvent() {
-			if c.verbose {
-				fmt.Printf("       (event, skipping)\n")
-			}
-			if c.eventHandler != nil {
-				c.eventHandler(resp)
-			}
-			continue
-		}
+		return nil, fmt.Errorf("connection lost waiting for response to %s: %w", method, c.readErr)
 	}
+}
+
+// responseOrError converts a routed response message into the caller-facing result.
+func responseOrError(msg *Message) (*Message, error) {
+	if msg.IsError() {
+		errData, _ := msg.GetError()
+		if errData != nil {
+			return nil, fmt.Errorf("BiDi error: %s - %s", errData.Error, errData.Message)
+		}
+		return nil, fmt.Errorf("BiDi error: %s", string(msg.Error))
+	}
+	return msg, nil
 }
 
 // SessionStatusResult represents the result of session.status command.

--- a/clicker/internal/bidi/session.go
+++ b/clicker/internal/bidi/session.go
@@ -3,6 +3,7 @@ package bidi
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,6 +28,10 @@ type Client struct {
 	eventHandler func(msg string)
 
 	events chan string
+
+	// droppedEvents counts events discarded because the events buffer was
+	// full. Read it with DroppedEvents.
+	droppedEvents atomic.Uint64
 
 	// readErr is written by the reader before it closes readerDone, so it
 	// may only be read after readerDone is closed.
@@ -62,6 +67,13 @@ func (c *Client) SetEventHandler(handler func(msg string)) {
 	c.mu.Unlock()
 }
 
+// DroppedEvents returns how many events have been discarded over the
+// client's lifetime because the event buffer was full. Consumers that care
+// about gaps (like the recorder) can diff this counter across an interval.
+func (c *Client) DroppedEvents() uint64 {
+	return c.droppedEvents.Load()
+}
+
 // readLoop is the only reader of the connection. Routing every message
 // through one goroutine keeps concurrent SendCommand callers from stealing
 // each other's responses and keeps events flowing between commands.
@@ -81,14 +93,23 @@ func (c *Client) readLoop() {
 			return
 		}
 
-		if c.verbose.Load() {
-			fmt.Printf("       <-- %s\n", raw)
-		}
-
 		msg, err := UnmarshalMessage([]byte(raw))
 		if err != nil {
+			if c.verbose.Load() {
+				fmt.Printf("       <-- %s\n", raw)
+			}
 			// A single malformed frame should not take down the connection.
 			continue
+		}
+
+		// Concurrent commands interleave in verbose output; the [id] prefix
+		// matches each <-- line to its --> line.
+		if c.verbose.Load() {
+			if msg.ID != nil {
+				fmt.Printf("       <-- [%d] %s\n", *msg.ID, raw)
+			} else {
+				fmt.Printf("       <-- %s\n", raw)
+			}
 		}
 
 		if msg.ID != nil {
@@ -111,7 +132,12 @@ func (c *Client) readLoop() {
 			case c.events <- raw:
 			default:
 				// Dropping beats stalling every command response behind a
-				// slow event handler.
+				// slow event handler. Warn directly on stderr (once): the
+				// default log level discards Warn, and silent data loss is
+				// the one thing that must stay visible in quiet mode.
+				if c.droppedEvents.Add(1) == 1 {
+					fmt.Fprintln(os.Stderr, "vibium: BiDi event consumer too slow; dropping events (warned once, count available via DroppedEvents)")
+				}
 			}
 		}
 	}
@@ -148,7 +174,7 @@ func (c *Client) SendCommandWithTimeout(method string, params interface{}, timeo
 	}
 
 	if c.verbose.Load() {
-		fmt.Printf("       --> %s\n", string(data))
+		fmt.Printf("       --> [%d] %s\n", cmd.ID, string(data))
 	}
 
 	// Register before sending so the response cannot race past us.
@@ -252,7 +278,10 @@ func (c *Client) SessionNew(capabilities map[string]interface{}) (*SessionNewRes
 	return &result, nil
 }
 
-// Close closes the underlying connection.
+// Close closes the underlying connection and waits for the reader goroutine
+// to exit, so callers (tests especially) get a deterministic shutdown.
 func (c *Client) Close() error {
-	return c.conn.Close()
+	err := c.conn.Close()
+	<-c.readerDone
+	return err
 }

--- a/clicker/internal/bidi/session_test.go
+++ b/clicker/internal/bidi/session_test.go
@@ -1,0 +1,357 @@
+package bidi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// testCommand is the shape of commands as the fake server sees them.
+type testCommand struct {
+	ID     int64                  `json:"id"`
+	Method string                 `json:"method"`
+	Params map[string]interface{} `json:"params"`
+}
+
+// testServerConn wraps a server-side websocket with a write mutex so handler
+// goroutines can interleave writes safely.
+type testServerConn struct {
+	ws *websocket.Conn
+	mu sync.Mutex
+}
+
+func (s *testServerConn) writeJSON(v interface{}) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Write errors during teardown are expected; callers assert on the
+	// client side instead.
+	s.ws.WriteMessage(websocket.TextMessage, data)
+}
+
+func (s *testServerConn) readCommand() (testCommand, error) {
+	var cmd testCommand
+	_, data, err := s.ws.ReadMessage()
+	if err != nil {
+		return cmd, err
+	}
+	if err := json.Unmarshal(data, &cmd); err != nil {
+		return cmd, err
+	}
+	return cmd, nil
+}
+
+func (s *testServerConn) respond(id int64, result map[string]interface{}) {
+	s.writeJSON(map[string]interface{}{"type": "success", "id": id, "result": result})
+}
+
+func (s *testServerConn) event(method string, params map[string]interface{}) {
+	s.writeJSON(map[string]interface{}{"type": "event", "method": method, "params": params})
+}
+
+// newTestClient starts an in-process websocket server driven by handler and
+// returns a Client connected to it.
+func newTestClient(t *testing.T, handler func(*testServerConn)) *Client {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		handler(&testServerConn{ws: ws})
+	}))
+	t.Cleanup(srv.Close)
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, err := Connect(url)
+	if err != nil {
+		t.Fatalf("connect to fake server: %v", err)
+	}
+	client := NewClient(conn)
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+// TestConcurrentCommands sends commands from many goroutines while the server
+// answers out of order and interleaves events. Every caller must get the
+// response to its own command.
+func TestConcurrentCommands(t *testing.T) {
+	client := newTestClient(t, func(s *testServerConn) {
+		for {
+			cmd, err := s.readCommand()
+			if err != nil {
+				return
+			}
+			// Answer on a separate goroutine with an id-dependent delay so
+			// responses arrive out of order relative to the sends.
+			go func(cmd testCommand) {
+				time.Sleep(time.Duration(cmd.ID%7) * time.Millisecond)
+				s.event("log.entryAdded", map[string]interface{}{"text": "noise"})
+				s.respond(cmd.ID, map[string]interface{}{"tag": cmd.Params["tag"]})
+			}(cmd)
+		}
+	})
+
+	const goroutines = 8
+	const commands = 20
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines*commands)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < commands; i++ {
+				tag := fmt.Sprintf("g%d-c%d", g, i)
+				msg, err := client.SendCommandWithTimeout("test.echo", map[string]interface{}{"tag": tag}, 5*time.Second)
+				if err != nil {
+					errs <- fmt.Errorf("%s: %v", tag, err)
+					return
+				}
+				var result struct {
+					Tag string `json:"tag"`
+				}
+				if err := json.Unmarshal(msg.Result, &result); err != nil {
+					errs <- fmt.Errorf("%s: parse result: %v", tag, err)
+					return
+				}
+				if result.Tag != tag {
+					errs <- fmt.Errorf("caller %s got response for %q", tag, result.Tag)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// TestBlockedCommandDoesNotBlockOthers withholds the response to one command
+// until a second command has been sent and answered, proving a gated response
+// (like one waiting on a native dialog) no longer wedges the connection.
+func TestBlockedCommandDoesNotBlockOthers(t *testing.T) {
+	var slowID int64
+	slowSent := make(chan struct{})
+	client := newTestClient(t, func(s *testServerConn) {
+		for {
+			cmd, err := s.readCommand()
+			if err != nil {
+				return
+			}
+			switch cmd.Method {
+			case "test.slow":
+				slowID = cmd.ID
+				close(slowSent)
+			case "test.fast":
+				s.respond(cmd.ID, map[string]interface{}{"which": "fast"})
+				s.respond(slowID, map[string]interface{}{"which": "slow"})
+			}
+		}
+	})
+
+	slowErr := make(chan error, 1)
+	go func() {
+		_, err := client.SendCommandWithTimeout("test.slow", nil, 5*time.Second)
+		slowErr <- err
+	}()
+
+	select {
+	case <-slowSent:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never received test.slow")
+	}
+
+	if _, err := client.SendCommandWithTimeout("test.fast", nil, 2*time.Second); err != nil {
+		t.Fatalf("fast command blocked behind unanswered slow command: %v", err)
+	}
+
+	select {
+	case err := <-slowErr:
+		if err != nil {
+			t.Fatalf("slow command failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow command never completed after its response was sent")
+	}
+}
+
+// TestReaderDeathFailsPendingCommands closes the server mid-flight and
+// expects every pending caller to fail promptly, later sends to fail
+// immediately, and all client goroutines to exit.
+func TestReaderDeathFailsPendingCommands(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	const pending = 4
+	client := newTestClient(t, func(s *testServerConn) {
+		for i := 0; i < pending; i++ {
+			if _, err := s.readCommand(); err != nil {
+				return
+			}
+		}
+		s.ws.Close()
+	})
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, pending)
+	for i := 0; i < pending; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := client.SendCommandWithTimeout("test.hang", nil, 30*time.Second)
+			errCh <- err
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending commands did not fail after server closed the connection")
+	}
+	close(errCh)
+	for err := range errCh {
+		if err == nil {
+			t.Error("pending command succeeded after connection death, want error")
+		}
+	}
+
+	start := time.Now()
+	if _, err := client.SendCommand("test.after", nil); err == nil {
+		t.Error("send after reader death succeeded, want error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("send after reader death took %s, want immediate failure", elapsed)
+	}
+
+	// Teardown is asynchronous, so poll. The slack covers goroutines owned
+	// by the still-running httptest server, not the client.
+	deadline := time.Now().Add(5 * time.Second)
+	for runtime.NumGoroutine() > baseline+3 {
+		if time.Now().After(deadline) {
+			buf := make([]byte, 1<<20)
+			n := runtime.Stack(buf, true)
+			t.Fatalf("goroutines leaked: baseline %d, now %d\n%s", baseline, runtime.NumGoroutine(), buf[:n])
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestLateResponseAfterTimeoutIsDiscarded times out a command, then has the
+// server deliver the stale response while another command is in flight. The
+// stale response must be dropped, not delivered to the wrong caller.
+func TestLateResponseAfterTimeoutIsDiscarded(t *testing.T) {
+	client := newTestClient(t, func(s *testServerConn) {
+		var lateID int64
+		for {
+			cmd, err := s.readCommand()
+			if err != nil {
+				return
+			}
+			switch cmd.Method {
+			case "test.late":
+				lateID = cmd.ID
+			case "test.flush":
+				s.respond(lateID, map[string]interface{}{"which": "late"})
+				s.respond(cmd.ID, map[string]interface{}{"which": "flush"})
+			}
+		}
+	})
+
+	if _, err := client.SendCommandWithTimeout("test.late", nil, 50*time.Millisecond); err == nil {
+		t.Fatal("expected timeout error for withheld response")
+	}
+
+	msg, err := client.SendCommandWithTimeout("test.flush", nil, 2*time.Second)
+	if err != nil {
+		t.Fatalf("command after timeout failed: %v", err)
+	}
+	var result struct {
+		Which string `json:"which"`
+	}
+	if err := json.Unmarshal(msg.Result, &result); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if result.Which != "flush" {
+		t.Fatalf("got response %q, want %q", result.Which, "flush")
+	}
+}
+
+// TestEventsForwardedInOrder checks that events reach the handler in arrival
+// order and that event delivery does not depend on a command being in flight.
+func TestEventsForwardedInOrder(t *testing.T) {
+	const eventCount = 50
+	client := newTestClient(t, func(s *testServerConn) {
+		for {
+			cmd, err := s.readCommand()
+			if err != nil {
+				return
+			}
+			for i := 0; i < eventCount; i++ {
+				s.event("test.event", map[string]interface{}{"seq": i})
+			}
+			s.respond(cmd.ID, map[string]interface{}{})
+		}
+	})
+
+	var mu sync.Mutex
+	var got []int
+	allReceived := make(chan struct{})
+	client.SetEventHandler(func(raw string) {
+		var evt struct {
+			Params struct {
+				Seq int `json:"seq"`
+			} `json:"params"`
+		}
+		if err := json.Unmarshal([]byte(raw), &evt); err != nil {
+			return
+		}
+		mu.Lock()
+		got = append(got, evt.Params.Seq)
+		if len(got) == eventCount {
+			close(allReceived)
+		}
+		mu.Unlock()
+	})
+
+	if _, err := client.SendCommandWithTimeout("test.go", nil, 2*time.Second); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	select {
+	case <-allReceived:
+	case <-time.After(2 * time.Second):
+		mu.Lock()
+		n := len(got)
+		mu.Unlock()
+		t.Fatalf("received %d of %d events", n, eventCount)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i, seq := range got {
+		if seq != i {
+			t.Fatalf("event %d arrived at position %d", seq, i)
+		}
+	}
+}

--- a/clicker/internal/bidi/session_test.go
+++ b/clicker/internal/bidi/session_test.go
@@ -3,8 +3,10 @@ package bidi
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -233,12 +235,16 @@ func TestReaderDeathFailsPendingCommands(t *testing.T) {
 	for err := range errCh {
 		if err == nil {
 			t.Error("pending command succeeded after connection death, want error")
+		} else if !strings.Contains(err.Error(), "connection lost waiting for response") {
+			t.Errorf("pending command error = %q, want it to say the connection was lost", err)
 		}
 	}
 
 	start := time.Now()
 	if _, err := client.SendCommand("test.after", nil); err == nil {
 		t.Error("send after reader death succeeded, want error")
+	} else if !strings.Contains(err.Error(), "cannot send") {
+		t.Errorf("post-death send error = %q, want it to say the send was refused", err)
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Errorf("send after reader death took %s, want immediate failure", elapsed)
@@ -294,6 +300,145 @@ func TestLateResponseAfterTimeoutIsDiscarded(t *testing.T) {
 	}
 	if result.Which != "flush" {
 		t.Fatalf("got response %q, want %q", result.Which, "flush")
+	}
+}
+
+// TestDroppedEventsCounted blocks the event handler and floods the client
+// with more events than the buffer holds. The overflow must be counted, not
+// silently discarded, and command responses must keep flowing.
+func TestDroppedEventsCounted(t *testing.T) {
+	const eventCount = eventBufferSize + 144
+
+	client := newTestClient(t, func(s *testServerConn) {
+		for {
+			cmd, err := s.readCommand()
+			if err != nil {
+				return
+			}
+			if cmd.Method == "test.flood" {
+				for i := 0; i < eventCount; i++ {
+					s.event("test.event", map[string]interface{}{"seq": i})
+				}
+			}
+			s.respond(cmd.ID, map[string]interface{}{})
+		}
+	})
+
+	release := make(chan struct{})
+	defer close(release)
+	client.SetEventHandler(func(string) { <-release })
+
+	// The response is written after the events, so once it arrives every
+	// event has passed through the reader's buffer-or-drop select.
+	if _, err := client.SendCommandWithTimeout("test.flood", nil, 5*time.Second); err != nil {
+		t.Fatalf("command failed during event flood: %v", err)
+	}
+
+	// The blocked dispatcher holds at most one event beyond the full buffer.
+	dropped := client.DroppedEvents()
+	min := uint64(eventCount - eventBufferSize - 1)
+	max := uint64(eventCount - eventBufferSize)
+	if dropped < min || dropped > max {
+		t.Fatalf("DroppedEvents() = %d, want between %d and %d", dropped, min, max)
+	}
+}
+
+// TestFirstDropWarnsOnStderrOnce swaps stderr for a pipe and floods the
+// client twice. The drop warning must appear exactly once — visible without
+// verbose logging, but not repeated per drop or per storm.
+func TestFirstDropWarnsOnStderrOnce(t *testing.T) {
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	const eventCount = eventBufferSize + 50
+	client := newTestClient(t, func(s *testServerConn) {
+		for {
+			cmd, err := s.readCommand()
+			if err != nil {
+				return
+			}
+			if cmd.Method == "test.flood" {
+				for i := 0; i < eventCount; i++ {
+					s.event("test.event", map[string]interface{}{"seq": i})
+				}
+			}
+			s.respond(cmd.ID, map[string]interface{}{})
+		}
+	})
+
+	release := make(chan struct{})
+	defer close(release)
+	client.SetEventHandler(func(string) { <-release })
+
+	// Two storms; each response arrives after its events, so all drops have
+	// happened (and warned, if they were going to) before the read below.
+	for i := 0; i < 2; i++ {
+		if _, err := client.SendCommandWithTimeout("test.flood", nil, 5*time.Second); err != nil {
+			t.Fatalf("flood %d failed: %v", i, err)
+		}
+	}
+	if client.DroppedEvents() == 0 {
+		t.Fatal("test did not force any drops")
+	}
+
+	os.Stderr = origStderr
+	w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read captured stderr: %v", err)
+	}
+
+	warns := strings.Count(string(out), "dropping events")
+	if warns != 1 {
+		t.Fatalf("drop warning appeared %d times, want exactly 1; stderr:\n%s", warns, out)
+	}
+}
+
+// TestCloseShutsDownCleanly checks that Close returns only after the reader
+// has exited, later sends fail immediately, and no goroutines are left.
+func TestCloseShutsDownCleanly(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	client := newTestClient(t, func(s *testServerConn) {
+		for {
+			if _, err := s.readCommand(); err != nil {
+				return
+			}
+		}
+	})
+
+	closed := make(chan error, 1)
+	go func() { closed <- client.Close() }()
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return; reader never exited")
+	}
+
+	// Close waited on the reader, so readerDone is closed and the failure
+	// path is immediate, not a timeout.
+	start := time.Now()
+	if _, err := client.SendCommand("test.after", nil); err == nil {
+		t.Error("send after Close succeeded, want error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("send after Close took %s, want immediate failure", elapsed)
+	}
+
+	// Same slack for httptest-server goroutines as the reader-death test.
+	deadline := time.Now().Add(5 * time.Second)
+	for runtime.NumGoroutine() > baseline+3 {
+		if time.Now().After(deadline) {
+			buf := make([]byte, 1<<20)
+			n := runtime.Stack(buf, true)
+			t.Fatalf("goroutines leaked after Close: baseline %d, now %d\n%s", baseline, runtime.NumGoroutine(), buf[:n])
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -152,9 +152,11 @@ func Launch(opts LaunchOptions) (*LaunchResult, error) {
 	wsURL := fmt.Sprintf("ws://localhost:%d/session", port)
 	conn, connErr := bidi.Connect(wsURL)
 	if connErr == nil {
-		client := bidi.NewClient(conn)
 		caps := buildCapabilities(chromePath, opts.Headless)
-		result, sessionErr := client.SessionNew(caps)
+		// Handshake without NewClient: a Client's reader would own this
+		// connection forever, and the consumer of LaunchResult.BidiConn
+		// (agent or api router) must be able to take over reads itself.
+		result, sessionErr := bidi.SessionNewOnConn(conn, caps)
 		if sessionErr == nil {
 			userDataDir, _ := result.Capabilities["userDataDir"].(string)
 			log.Info("browser launched via BiDi session.new", "sessionId", result.SessionID)


### PR DESCRIPTION
## Summary

The BiDi client read the websocket inline in `SendCommandWithTimeout` and discarded responses that were not its own. Concurrent commands raced on the socket and stole each other's responses, and between commands nobody read at all, so one gated response (a native dialog, for example) wedged every later command. Root cause of #142, the BiDi half of #151, and the test failure on PR #143. #146 turned out to live in the Python client, see Issue verification.

Now a single reader goroutine owns all reads on the connection and routes responses to waiting callers by command ID. Events are dispatched on their own goroutine through a bounded buffer, so a slow event handler can never stall command responses. If the reader dies, pending and future commands fail with the read error instead of hanging. Public API unchanged, plus `DroppedEvents()` and `Close()`.

## Event drop policy

When the event handler falls behind, events are dropped rather than stalling command responses. Drops are not silent: an atomic counter tracks every drop via `Client.DroppedEvents()`, the first drop prints one warning to stderr, and the recorder diffs the counter across a recording and stamps a `vibium.eventsDropped` event into the trace, so a recording with holes says so.

## Pre-existing bugs fixed in callers

- `browser.Launch` created a throwaway Client for the session handshake and returned the bare connection, which the agent and api router then wrapped in a second Client. Launch now handshakes via the new `SessionNewOnConn`, which does not take over reads.
- The api router sent remote-mode `session.end` through a Client reading the same socket as its own proxy loop, a data race that could stall teardown. It now uses the router's internal command path and the router creates no Client.
- `vibium bidi-test` dialed `LaunchResult.WebSocketURL`, which the BiDi-first launch path leaves empty. Broken on main since that path landed in d7b634b, verified by running bidi-test from a main build. It now reuses the launcher's connection.

## Design notes

- The api router keeps its own read loop by design: it is a proxy and must see raw traffic. Exactly one reader per connection, enforced by call sites.
- Verbose log lines carry the command ID so interleaved concurrent commands are correlatable.

## Testing

New `internal/bidi` unit tests against a fake in-process websocket server cover concurrent commands with out-of-order responses, a blocked command not wedging others, reader death failing pending callers without goroutine leaks, late responses discarded after timeout, event ordering, drop accounting, and clean shutdown. Recorder tests cover the drop stamp. The core suite was written before the fix; the old code hangs it until the package timeout.

- `go test -race ./...` green, bidi package on repeated runs
- PR #143 compatibility: merged its commit onto this branch locally (test-only), built the binary with `-race`, MCP suite fully green
- The BiDi client and recorder produced zero race reports in any run. The detector does flag 3 races in `agent.Handlers.Close` on MCP shutdown; a race build of main produces identical reports, so they are pre-existing and untouched here
- Full `make test` green; one non-reproducing js test timeout under parallel load, consistent with browser startup contention on the test VM, not a recording-path bug

## Issue verification (repros against a race build of this branch)

- #142: fixed. The issue's repro click returns immediately where it previously hung, recording stops cleanly with a valid trace, no drops, no races.
- #151: BiDi wedge fixed, full fix needs a separate MCP change. `browser_click` on a native dialog now returns a clean timeout instead of deadlocking, `browser_dialog_accept` then succeeds, and the session stays usable (the click did land). The MCP serial command loop still cannot accept `dialog_accept` while `click` is in flight; out of scope here.
- #146: not fixed and not fixable from the Go side; the repro still deadlocks. The Python client's sync `capture.dialog(fn)` runs `fn` inline and never dismisses the dialog, so a blocking `evaluate` inside it can never return. The router path never used `bidi.Client`. Needs a Python client fix.