### PR TITLE
Fix MCP shutdown races on the browser session fields

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vibium/clicker/internal/bidi"
@@ -19,6 +20,10 @@ import (
 
 // Handlers manages browser session state and executes tool calls.
 type Handlers struct {
+	// sessionMu guards launchResult, client, and conn. The MCP shutdown
+	// goroutine calls Close while the serve loop may be launching or
+	// quitting the browser on these same fields.
+	sessionMu      sync.Mutex
 	launchResult   *browser.LaunchResult
 	client         *bidi.Client
 	conn           *bidi.Connection
@@ -580,21 +585,25 @@ func mcpToolToMethod(name string) string {
 	}
 }
 
-// Close cleans up any active browser sessions.
+// Close cleans up any active browser sessions. Safe to call concurrently;
+// whichever caller takes the fields does the closing, the other sees an
+// already-closed session.
 func (h *Handlers) Close() {
+	h.sessionMu.Lock()
+	conn, client, launchResult := h.conn, h.client, h.launchResult
+	h.conn, h.client, h.launchResult = nil, nil, nil
+	h.sessionMu.Unlock()
+
 	// Remote mode: end the BiDi session so chromedriver closes Chrome
-	if h.connectURL != "" && h.client != nil {
-		h.client.SendCommand("session.end", map[string]interface{}{})
+	if h.connectURL != "" && client != nil {
+		client.SendCommand("session.end", map[string]interface{}{})
 	}
-	if h.conn != nil {
-		h.conn.Close()
-		h.conn = nil
+	if conn != nil {
+		conn.Close()
 	}
-	if h.launchResult != nil {
-		h.launchResult.Close()
-		h.launchResult = nil
+	if launchResult != nil {
+		launchResult.Close()
 	}
-	h.client = nil
 }
 
 // browserLaunch launches a new browser session or connects to a remote one.
@@ -615,8 +624,10 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to remote browser: %w", err)
 		}
+		h.sessionMu.Lock()
 		h.conn = conn
 		h.client = client
+		h.sessionMu.Unlock()
 
 		return &ToolsCallResult{
 			Content: []Content{{
@@ -650,9 +661,11 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 		}
 	}
 
+	h.sessionMu.Lock()
 	h.launchResult = launchResult
 	h.conn = conn
 	h.client = bidi.NewClient(conn)
+	h.sessionMu.Unlock()
 
 	return &ToolsCallResult{
 		Content: []Content{{

--- a/clicker/internal/agent/handlers_close_test.go
+++ b/clicker/internal/agent/handlers_close_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/vibium/clicker/internal/bidi"
+)
+
+// TestConcurrentClose reproduces the MCP shutdown race: the cleanup goroutine
+// calls Close while browser_quit's Close is in flight on the serve loop.
+// Meaningful under -race, where unsynchronized session-field access fails it.
+func TestConcurrentClose(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	h := NewHandlers("", true, "", nil)
+	conn, err := bidi.Connect("ws" + strings.TrimPrefix(srv.URL, "http"))
+	if err != nil {
+		t.Fatalf("connect to fake server: %v", err)
+	}
+	h.conn = conn
+	h.client = bidi.NewClient(conn)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.Close()
+		}()
+	}
+	wg.Wait()
+
+	if h.conn != nil || h.client != nil || h.launchResult != nil {
+		t.Fatal("session fields not cleared after concurrent Close")
+	}
+}

--- a/clicker/internal/agent/server.go
+++ b/clicker/internal/agent/server.go
@@ -145,10 +145,9 @@ type Server struct {
 	handlers *Handlers
 	version  string
 
-	// busy is held (capacity 1) while a request is being handled. Close
-	// acquires it so shutdown does not tear the browser session down under
-	// an in-flight tool call, with a bounded wait so a wedged call cannot
-	// stall SIGTERM cleanup.
+	// busy is held (capacity 1) while a request is being handled, and by
+	// Close while it tears down the browser session. A channel rather than
+	// a mutex so Close can bound its wait.
 	busy chan struct{}
 }
 
@@ -335,16 +334,21 @@ func (s *Server) writeResponse(resp *Response) error {
 	return err
 }
 
-// Close cleans up the server resources. It waits briefly for an in-flight
-// request so the browser session is not torn down under a tool call, but a
-// wedged call cannot hold up shutdown: cleaning up Chrome promptly matters
-// more than a clean answer to a request that is about to die with the
-// process anyway.
+// closeGraceTimeout bounds how long Close waits for an in-flight request.
+// Cleaning up Chrome promptly matters more than a clean answer to a request
+// that is about to die with the process anyway.
+const closeGraceTimeout = 2 * time.Second
+
+// Close cleans up the server resources. It waits up to closeGraceTimeout for
+// an in-flight request so the browser session is not torn down under a tool
+// call. If the timeout fires, teardown proceeds concurrently with the wedged
+// call: the session fields race is narrowed to that window, and the process
+// exits right after.
 func (s *Server) Close() {
 	select {
 	case s.busy <- struct{}{}:
 		defer func() { <-s.busy }()
-	case <-time.After(2 * time.Second):
+	case <-time.After(closeGraceTimeout):
 	}
 	s.handlers.Close()
 }

--- a/clicker/internal/agent/server.go
+++ b/clicker/internal/agent/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/vibium/clicker/internal/log"
 )
@@ -143,6 +144,12 @@ type Server struct {
 	writer   io.Writer
 	handlers *Handlers
 	version  string
+
+	// busy is held (capacity 1) while a request is being handled. Close
+	// acquires it so shutdown does not tear the browser session down under
+	// an in-flight tool call, with a bounded wait so a wedged call cannot
+	// stall SIGTERM cleanup.
+	busy chan struct{}
 }
 
 // ServerOptions configures the MCP server.
@@ -159,6 +166,7 @@ func NewServer(version string, opts ServerOptions) *Server {
 		writer:   os.Stdout,
 		handlers: NewHandlers(opts.ScreenshotDir, false, opts.ConnectURL, opts.ConnectHeaders),
 		version:  version,
+		busy:     make(chan struct{}, 1),
 	}
 }
 
@@ -178,7 +186,10 @@ func (s *Server) Run() error {
 			continue
 		}
 
+		s.busy <- struct{}{}
 		response := s.handleRequest(line)
+		<-s.busy
+
 		if response != nil {
 			if err := s.writeResponse(response); err != nil {
 				return fmt.Errorf("write error: %w", err)
@@ -324,7 +335,16 @@ func (s *Server) writeResponse(resp *Response) error {
 	return err
 }
 
-// Close cleans up the server resources.
+// Close cleans up the server resources. It waits briefly for an in-flight
+// request so the browser session is not torn down under a tool call, but a
+// wedged call cannot hold up shutdown: cleaning up Chrome promptly matters
+// more than a clean answer to a request that is about to die with the
+// process anyway.
 func (s *Server) Close() {
+	select {
+	case s.busy <- struct{}{}:
+		defer func() { <-s.busy }()
+	case <-time.After(2 * time.Second):
+	}
 	s.handlers.Close()
 }


### PR DESCRIPTION
## Problem

Two goroutines in the MCP server can touch the browser session at the same time: the serve loop handling tool calls, and the SIGTERM handler calling `Server.Close` so Chrome gets cleaned up even when stdin stays open. Under a race-instrumented binary, the MCP test suite reports races between concurrent `Handlers.Close` calls (`browser_quit` vs shutdown) and between shutdown and in-flight tool calls reading the same session fields. The race exists on main. It surfaced while testing the BiDi reader-loop change (#227 ), but does not depend on it.

## Fix

- `Handlers` gets a `sessionMu` guarding `launchResult`, `client`, and `conn`. `Close` takes the fields and nils them under the lock, then closes them outside it, so concurrent `Close` calls are safe. `browserLaunch` assigns the fields under the same lock.
- `Server` serializes shutdown against request handling through a capacity-1 `busy` channel. The serve loop holds it for each request. `Close` acquires it before tearing down the session, bounded at `closeGraceTimeout` (2 seconds) so a stuck tool call cannot delay SIGTERM cleanup. If the timeout fires, teardown proceeds concurrently with the wedged call, so the race in that path is narrowed to the shutdown window rather than eliminated; the process exits immediately after.

## Testing

- Added `TestConcurrentClose`, which runs concurrent `Close` calls against a real websocket connection. On the unfixed code it reports a data race; with this change it passes. Both runs used `-count=5`.
- Ran the MCP suite against a `-race` build. Before the fix, each server process logged 3 to 4 race reports. After, all 47 tests passed and none were reported.
- `go test -race ./...` and `make test` pass locally.