### PR TITLE
Fix SPA history navigation tracking

### DIFF
--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -181,6 +181,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 			"browsingContext.downloadEnd",
 			"browsingContext.load",
 			"browsingContext.fragmentNavigated",
+			"browsingContext.historyUpdated",
 		},
 	})
 	if err != nil {
@@ -829,7 +830,7 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 			} `json:"params"`
 		}
 		if json.Unmarshal([]byte(msg), &bidiEvent) == nil {
-			if bidiEvent.Params.URL != "" && (bidiEvent.Method == "browsingContext.load" || bidiEvent.Method == "browsingContext.fragmentNavigated") {
+			if bidiEvent.Params.URL != "" && (bidiEvent.Method == "browsingContext.load" || bidiEvent.Method == "browsingContext.fragmentNavigated" || bidiEvent.Method == "browsingContext.historyUpdated") {
 				session.mu.Lock()
 				session.lastURL = bidiEvent.Params.URL
 				session.mu.Unlock()

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -288,14 +288,11 @@ export class Page {
         const logContext = source?.context;
         if (logContext && logContext !== this.contextId) return;
         this.handleLogEntryAdded(params);
-      } else if (event.method === 'browsingContext.load') {
-        const url = params.url as string | undefined;
-        if (url) {
-          for (const cb of this.navigationCallbacks) {
-            cb(url);
-          }
-        }
-      } else if (event.method === 'browsingContext.fragmentNavigated') {
+      } else if (
+        event.method === 'browsingContext.load' ||
+        event.method === 'browsingContext.fragmentNavigated' ||
+        event.method === 'browsingContext.historyUpdated'
+      ) {
         const url = params.url as string | undefined;
         if (url) {
           for (const cb of this.navigationCallbacks) {

--- a/tests/js/async/navigation.test.js
+++ b/tests/js/async/navigation.test.js
@@ -62,6 +62,22 @@ describe('JS Navigation', () => {
     assert.ok(url.includes('/login'), 'URL should contain /login');
   });
 
+  test('SPA history navigation updates capture.navigation() and page.url()', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/');
+    const expectedURL = new URL('/simulated-spa-route', baseURL).href;
+
+    const capturedURL = await vibe.capture.navigation(
+      async () => {
+        await vibe.evaluate('history.pushState({}, "", "/simulated-spa-route")');
+      },
+      { timeout: 2000 }
+    );
+
+    assert.strictEqual(capturedURL, expectedURL);
+    assert.strictEqual(await vibe.url(), expectedURL);
+  });
+
   test('page.title() returns page title', async () => {
     const vibe = await bro.page();
     await vibe.go(baseURL + '/');


### PR DESCRIPTION
## Summary

- subscribe API sessions to `browsingContext.historyUpdated`
- update the cached page URL for history API navigation
- resolve JavaScript navigation capture callbacks for the same event
- cover `history.pushState()` through the local browser integration test

## Testing

- `make build-go build-js`
- `node --test --test-timeout=30000 --test-force-exit --test-concurrency=1 tests/js/async/navigation.test.js`
- `go -C clicker test ./...`
- `make test-js-async JS_PARALLEL=3`
- `make test-js-sync JS_PARALLEL=3`

Closes https://github.com/VibiumDev/vibium/issues/126