### PR TITLE
Fix make test overload and the intermittent pipe-transport session wedge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,10 @@ jobs:
       # xvfb: the Python suite's headed tests need a display.
       # NODE_TEST_TIMEOUT: on Node 20, --test-timeout limits each test file,
       # not each test, and the slowest file needs ~150s.
+      # SUITE_PARALLEL: the desktop default is 2 to keep dev machines
+      # usable; under xvfb there are no visible windows, so run wider.
       - name: Test
-        run: xvfb-run --auto-servernum make test NODE_TEST_TIMEOUT=300000
+        run: xvfb-run --auto-servernum make test NODE_TEST_TIMEOUT=300000 SUITE_PARALLEL=4
 
       # In case the job is interrupted before make test's own cleanup runs.
       - name: Clean up zombie processes

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
   endif
 endif
 
-.PHONY: all build build-go build-js build-go-all package package-js package-python install-browser deps clean clean-go clean-js clean-npm-packages clean-python-packages clean-packages clean-cache clean-all serve test test-cli test-js test-js-async test-js-sync test-js-process test-mcp test-daemon test-python test-java test-cleanup double-tap get-version set-version build-java package-java publish-java clean-java jshell help
+.PHONY: all build build-go build-js build-go-all package package-js package-python install-browser deps clean clean-go clean-js clean-npm-packages clean-python-packages clean-packages clean-cache clean-all serve test test-cli test-js test-js-async test-js-sync test-js-process test-mcp test-daemon test-python python-venv test-browser-modes test-java test-cleanup double-tap get-version set-version build-java package-java publish-java clean-java jshell help
 
 # Version from VERSION file
 # Note: GnuWin32 Make 3.81 runs $(shell) via CreateProcess, not SHELL,
@@ -170,12 +170,25 @@ serve: build-go
 # ready timeout and cascading into cancellations. Keeping test-js-sync separate
 # caps the peak; the *_PARALLEL defaults are tuned conservatively for the same
 # reason. Bump *_PARALLEL on machines with more cores/memory.
+#
+# SUITE_PARALLEL caps how many suites the middle phase runs at once. The
+# desktop default of 1 runs suites one at a time (peak Chromes = the
+# *_PARALLEL fan-out of a single suite) so a dev machine stays usable;
+# CI overrides to 4 (see .github/workflows/test.yml).
+#
+# test-browser-modes runs in its own serial phase because its tests open
+# visible Chrome windows (headed coverage is intentional — that's what
+# humans use). Inside the parallel fan-out those windows pop up all at
+# once, steal focus, and can beachball the macOS window manager, timing
+# out unrelated suites.
+SUITE_PARALLEL ?= 1
 test: build install-browser
 	@START_TIME=$$(date +%s); \
 	"$(MAKE)" test-cli test-cleanup && \
 	"$(MAKE)" test-js-process test-cleanup && \
-	"$(MAKE)" -j 4 test-js-async test-mcp test-python test-java && \
+	"$(MAKE)" -j $(SUITE_PARALLEL) test-js-async test-mcp test-python test-java && \
 	"$(MAKE)" test-cleanup && \
+	"$(MAKE)" test-browser-modes test-cleanup && \
 	"$(MAKE)" test-js-sync; \
 	EXIT=$$?; \
 	"$(MAKE)" test-cleanup; \
@@ -234,7 +247,6 @@ test-js-async: build-go
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
 		tests/js/async/async-api.test.js \
 		tests/js/async/auto-wait.test.js \
-		tests/js/async/browser-modes.test.js \
 		tests/js/async/elements.test.js \
 		tests/js/async/interaction.test.js \
 		tests/js/async/state.test.js \
@@ -293,17 +305,35 @@ test-daemon: build-go
 # loadfile distribution gives each file to a single worker — safe under
 # parallel since each file owns its own browser via conftest.py.
 PY_PARALLEL ?= 3
-test-python: build-go install-browser
-	@echo "--- Python Client Tests (parallel x$(PY_PARALLEL)) ---"
+
+# Ensure the Python client venv exists with the client + test deps installed.
+python-venv:
 	@cd clients/python && \
 		if [ ! -d ".venv" ]; then $(PYTHON) -m venv .venv; fi && \
 		. $(VENV_ACTIVATE) && \
 		if ! python -c "import vibium, xdist" 2>/dev/null; then \
 			python -m pip install --quiet --upgrade pip && \
 			pip install -e ../../packages/python/$(PYTHON_PLATFORM_PKG) -e ".[test]"; \
-		fi && \
+		fi
+
+# test_browser_modes.py is excluded here and run headed + serial by
+# test-browser-modes (see the `test` target comment).
+test-python: build-go install-browser python-venv
+	@echo "--- Python Client Tests (parallel x$(PY_PARALLEL)) ---"
+	@cd clients/python && \
+		. $(VENV_ACTIVATE) && \
 		VIBIUM_BIN_PATH=$(CURDIR)/clicker/bin/vibium$(EXE) \
-		$(TIMEOUT_CMD_ABS) python -m pytest ../../tests/py/ -v --tb=short -x -n $(PY_PARALLEL) --dist=loadfile
+		$(TIMEOUT_CMD_ABS) python -m pytest ../../tests/py/ -v --tb=short -x -n $(PY_PARALLEL) --dist=loadfile \
+			--ignore=../../tests/py/test_browser_modes.py
+
+# Headed browser-mode tests, one visible Chrome window at a time.
+test-browser-modes: build-go install-browser python-venv
+	@echo "--- Browser Mode Tests (headed, serial) ---"
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/js/async/browser-modes.test.js
+	@cd clients/python && \
+		. $(VENV_ACTIVATE) && \
+		VIBIUM_BIN_PATH=$(CURDIR)/clicker/bin/vibium$(EXE) \
+		$(TIMEOUT_CMD_ABS) python -m pytest ../../tests/py/test_browser_modes.py -v --tb=short -x
 
 # Build Java client JAR (dev — no native binaries, fast)
 build-java: build-go
@@ -462,6 +492,7 @@ help:
 	@echo "  make test-mcp              - Run MCP server tests only"
 	@echo "  make test-daemon           - Run daemon lifecycle tests"
 	@echo "  make test-python           - Run Python client tests"
+	@echo "  make test-browser-modes    - Run headed browser-mode tests (JS + Python, serial)"
 	@echo "  make test-java             - Run Java client tests"
 	@echo ""
 	@echo "Other:"

--- a/clicker/cmd/clicker/mcp_cmd.go
+++ b/clicker/cmd/clicker/mcp_cmd.go
@@ -47,6 +47,9 @@ The server provides browser automation tools:
 		Example: `  # Run directly (for testing)
   vibium mcp
 
+  # Launch browsers with no visible window (servers, CI)
+  vibium mcp --headless
+
   # Configure in Claude Code
   claude mcp add vibium -- vibium mcp
 
@@ -100,9 +103,11 @@ The server provides browser automation tools:
 				}
 
 				connectURL, connectHeaders := connectFromEnv()
+				headless, _ := cmd.Flags().GetBool("headless")
 
 				server := agent.NewServer(version, agent.ServerOptions{
 					ScreenshotDir:  screenshotDir,
+					Headless:       headless,
 					ConnectURL:     connectURL,
 					ConnectHeaders: connectHeaders,
 				})
@@ -125,5 +130,6 @@ The server provides browser automation tools:
 		},
 	}
 	cmd.Flags().String("screenshot-dir", "", "Directory for saving screenshots (default: ~/Pictures/Vibium, use \"\" to disable)")
+	cmd.Flags().Bool("headless", false, "Launch browsers in headless mode (no visible window)")
 	return cmd
 }

--- a/clicker/internal/agent/server.go
+++ b/clicker/internal/agent/server.go
@@ -148,6 +148,7 @@ type Server struct {
 // ServerOptions configures the MCP server.
 type ServerOptions struct {
 	ScreenshotDir  string      // Directory for saving screenshots (empty = disabled)
+	Headless       bool        // Launch browsers without a visible window
 	ConnectURL     string      // Remote BiDi WebSocket URL (empty = local browser)
 	ConnectHeaders http.Header // Headers for remote WebSocket connection
 }
@@ -157,7 +158,7 @@ func NewServer(version string, opts ServerOptions) *Server {
 	return &Server{
 		reader:   bufio.NewReader(os.Stdin),
 		writer:   os.Stdout,
-		handlers: NewHandlers(opts.ScreenshotDir, false, opts.ConnectURL, opts.ConnectHeaders),
+		handlers: NewHandlers(opts.ScreenshotDir, opts.Headless, opts.ConnectURL, opts.ConnectHeaders),
 		version:  version,
 	}
 }

--- a/clicker/internal/api/pipe.go
+++ b/clicker/internal/api/pipe.go
@@ -4,77 +4,127 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"sync"
+	"time"
 )
 
-// pipeWriteQueueSize is the buffer size for outgoing messages.
-// This prevents the browser-to-client routing goroutine from blocking
-// on slow pipe writes (e.g., when the Python client is busy processing
-// events), which would also block delivery of internal command responses
-// and cause navigation timeouts.
-const pipeWriteQueueSize = 4096
-
 // PipeClientConn implements ClientTransport over stdin/stdout pipes.
+//
+// Writes are decoupled from the callers through an unbounded queue drained
+// by a single writer goroutine that flushes with no lock held. Send never
+// blocks and never drops: a blocking Send would stall the browser-to-client
+// routing goroutine (freezing command responses and event delivery for the
+// whole session), and a dropped response or event permanently hangs the
+// client command or paused request waiting on it.
 type PipeClientConn struct {
 	writer *bufio.Writer
-	mu     sync.Mutex
+	mu     sync.Mutex // guards queue, closed
+	cond   *sync.Cond
+	queue  []string
 	closed bool
-	msgCh  chan string
 	done   chan struct{}
+
+	flushStart int64 // unix nanos of in-progress flush, 0 = idle (guarded by mu)
 }
 
 // NewPipeClientConn creates a PipeClientConn that writes protocol messages to w.
 func NewPipeClientConn(w io.Writer) *PipeClientConn {
 	c := &PipeClientConn{
 		writer: bufio.NewWriter(w),
-		msgCh:  make(chan string, pipeWriteQueueSize),
 		done:   make(chan struct{}),
 	}
+	c.cond = sync.NewCond(&c.mu)
 	go c.writeLoop()
+	go c.watchStalledFlush()
 	return c
 }
 
-// writeLoop drains the message channel and writes to the pipe.
+// writeLoop drains the queue and writes to the pipe. Flushing happens with
+// the lock released so a stalled reader never blocks Send callers.
 func (c *PipeClientConn) writeLoop() {
 	defer close(c.done)
-	for msg := range c.msgCh {
+	for {
 		c.mu.Lock()
-		if c.closed {
+		for len(c.queue) == 0 && !c.closed {
+			c.cond.Wait()
+		}
+		if len(c.queue) == 0 && c.closed {
 			c.mu.Unlock()
 			return
 		}
-		c.writer.WriteString(msg)
-		c.writer.WriteByte('\n')
-		c.writer.Flush()
+		batch := c.queue
+		c.queue = nil
+		c.flushStart = time.Now().UnixNano()
 		c.mu.Unlock()
+
+		var err error
+		for _, msg := range batch {
+			if _, err = c.writer.WriteString(msg); err != nil {
+				break
+			}
+			if err = c.writer.WriteByte('\n'); err != nil {
+				break
+			}
+		}
+		if err == nil {
+			err = c.writer.Flush()
+		}
+
+		c.mu.Lock()
+		c.flushStart = 0
+		if err != nil {
+			// The pipe is gone (client exited) — stop accepting messages so
+			// the queue can't grow unboundedly against a dead reader.
+			c.closed = true
+			c.mu.Unlock()
+			return
+		}
+		c.mu.Unlock()
+	}
+}
+
+// watchStalledFlush periodically reports a flush that is currently blocked —
+// the signature of a client that stopped reading its end of the pipe.
+func (c *PipeClientConn) watchStalledFlush() {
+	t := time.NewTicker(10 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-t.C:
+			c.mu.Lock()
+			start := c.flushStart
+			depth := len(c.queue)
+			c.mu.Unlock()
+			if start != 0 {
+				if blocked := time.Since(time.Unix(0, start)); blocked > 5*time.Second {
+					fmt.Fprintf(os.Stderr, "[pipe] write blocked for %.0fs (%d messages queued) — client not reading\n",
+						blocked.Seconds(), depth)
+				}
+			}
+		}
 	}
 }
 
 // ID returns a fixed client ID (pipe mode supports exactly one client).
 func (c *PipeClientConn) ID() uint64 { return 1 }
 
-// Send queues a JSON message for writing to the pipe.
-// This is non-blocking as long as the write queue is not full.
+// Send queues a JSON message for writing to the pipe. It never blocks and
+// never drops messages.
 func (c *PipeClientConn) Send(msg string) error {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.closed {
-		c.mu.Unlock()
 		return fmt.Errorf("pipe closed")
 	}
-	c.mu.Unlock()
-
-	select {
-	case c.msgCh <- msg:
-		return nil
-	default:
-		// Queue is full — drop the message to avoid blocking.
-		// This can happen under extreme event pressure but is better
-		// than blocking the browser message routing goroutine.
-		return nil
-	}
+	c.queue = append(c.queue, msg)
+	c.cond.Signal()
+	return nil
 }
 
-// Close marks the pipe as closed and drains the write queue.
+// Close marks the pipe as closed and waits for queued messages to be written.
 func (c *PipeClientConn) Close() error {
 	c.mu.Lock()
 	if c.closed {
@@ -82,8 +132,8 @@ func (c *PipeClientConn) Close() error {
 		return nil
 	}
 	c.closed = true
+	c.cond.Signal()
 	c.mu.Unlock()
-	close(c.msgCh)
 	<-c.done
 	return nil
 }

--- a/clients/javascript/src/clicker/process.ts
+++ b/clients/javascript/src/clicker/process.ts
@@ -57,6 +57,12 @@ export class VibiumProcess {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
+      // Always drain stderr: an unread pipe blocks vibium once the OS buffer
+      // fills. Forward diagnostics to our stderr when VIBIUM_STDERR is set.
+      proc.stderr?.on('data', (chunk: Buffer) => {
+        if (process.env.VIBIUM_STDERR) process.stderr.write(chunk);
+      });
+
       // If the ready-wait throws — timeout, the caller's await being interrupted
       // by a test-runner timeout, an unhandled rejection — we must SIGKILL the
       // spawned child. Otherwise its pipes stay open, keep Node's event loop

--- a/clients/python/src/vibium/binary.py
+++ b/clients/python/src/vibium/binary.py
@@ -19,6 +19,27 @@ from .errors import VibiumNotFoundError, BrowserCrashedError
 _STREAM_LIMIT = 256 * 1024 * 1024  # 256 MiB
 
 
+async def _drain_stderr(process) -> None:
+    """Continuously read the subprocess's stderr so the pipe never fills.
+
+    An unread stderr pipe blocks vibium once the OS buffer (~64 KiB) fills.
+    Forward diagnostics to our stderr when VIBIUM_STDERR is set.
+    """
+    if not process.stderr:
+        return
+    forward = bool(os.environ.get("VIBIUM_STDERR"))
+    try:
+        while True:
+            chunk = await process.stderr.read(65536)
+            if not chunk:
+                return
+            if forward:
+                sys.stderr.write(chunk.decode(errors="replace"))
+                sys.stderr.flush()
+    except (asyncio.CancelledError, OSError):
+        pass
+
+
 def get_platform_package_name() -> str:
     """Get the platform-specific package name."""
     system = sys.platform
@@ -252,6 +273,9 @@ class VibiumProcess:
 
             instance = cls(process)
             instance._pre_ready_lines = pre_ready_lines
+            # Always drain stderr: an unread pipe blocks vibium once the OS
+            # buffer fills. Forward diagnostics when VIBIUM_STDERR is set.
+            instance._stderr_task = asyncio.create_task(_drain_stderr(process))
             return instance
 
         # Unreachable: the final attempt either returns or raises above.

--- a/tests/mcp/server.test.js
+++ b/tests/mcp/server.test.js
@@ -24,7 +24,9 @@ class MCPClient {
 
   start() {
     return new Promise((resolve, reject) => {
-      this.proc = spawn(VIBIUM, ['mcp'], {
+      // --headless: without it every suite's lazy browser launch opens a
+      // visible, focus-stealing Chrome window during the parallel test phase.
+      this.proc = spawn(VIBIUM, ['mcp', '--headless'], {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 


### PR DESCRIPTION
## Summary

Two related reliability fixes for `make test` and the client transport, validated together.

**Commit 1 — Tame make test parallelism and isolate headed browser tests** (fixes #230)
- `SUITE_PARALLEL ?= 1` gates the middle test phase: serial by default on dev machines, CI overrides to 4 under xvfb
- The intentionally-headed browser-modes tests (JS + Python) move to a dedicated serial `make test-browser-modes` phase — headed coverage kept, at most one visible window at a time
- New `vibium mcp --headless` flag (previously `agent.NewServer` hardcoded headed); MCP tests use it

**Commit 2 — Fix intermittent session wedge: never block or drop pipe messages** (fixes #231)
- `PipeClientConn` held its mutex across `Flush`, so a client that briefly stalled reading its pipe blocked every `Send` — including the browser→client event pump — freezing the whole session; its queue-full fallback silently dropped messages, permanently hanging whatever awaited the dropped response or event
- Replaced with an unbounded no-drop queue drained by a writer that flushes with no lock held; `Send` never blocks and never drops; writer exits when the pipe dies; a watchdog logs `write blocked Ns — client not reading`
- JS and Python clients now continuously drain vibium's stderr (previously piped and never read — 64KB of accumulated output would block the daemon forever); `VIBIUM_STDERR=1` forwards it for debugging

Follow-up filed separately: #232 (daemon WebSocket transport shares the synchronous-write hazard).

## Validation

- Raw-NDJSON stall harness: old code froze the event pump during a 5s reader stall; fixed code delivered 39/39 command responses and 7,803 events through the same stall
- Two consecutive full `make test` runs green (18m20s / 18m17s) after a day with a ~50% mid-suite wedge rate
- 60+ isolated runs of the previously-wedging files, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)