### PR TITLE
tests: never hit live external sites

### DIFF
--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -123,7 +123,11 @@ func Launch(opts LaunchOptions) (*LaunchResult, error) {
 	log.Debug("using port", "port", port)
 
 	// Start chromedriver as a process group leader so we can kill all children
-	cmd := exec.Command(chromedriverPath, fmt.Sprintf("--port=%d", port))
+	cdArgs := []string{fmt.Sprintf("--port=%d", port)}
+	if dir := os.Getenv("VIBIUM_CHROMEDRIVER_LOG_DIR"); dir != "" {
+		cdArgs = append(cdArgs, "--verbose", fmt.Sprintf("--log-path=%s/chromedriver-%d.log", dir, port))
+	}
+	cmd := exec.Command(chromedriverPath, cdArgs...)
 	setProcGroup(cmd)
 	if opts.Verbose {
 		fmt.Println("       ------- chromedriver -------")

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -225,32 +225,32 @@ export class Page {
     this.capture = {
       response(pattern: string, fn?: () => Promise<void>, options?: { timeout?: number }): Promise<Response> {
         const promise = self._captureResponse(pattern, options);
-        if (fn) return fn().then(() => promise);
+        if (fn) return Promise.all([promise, fn()]).then(([v]) => v);
         return promise;
       },
       request(pattern: string, fn?: () => Promise<void>, options?: { timeout?: number }): Promise<Request> {
         const promise = self._captureRequest(pattern, options);
-        if (fn) return fn().then(() => promise);
+        if (fn) return Promise.all([promise, fn()]).then(([v]) => v);
         return promise;
       },
       navigation(fn?: () => Promise<void>, options?: { timeout?: number }): Promise<string> {
         const promise = self._captureNavigation(options);
-        if (fn) return fn().then(() => promise);
+        if (fn) return Promise.all([promise, fn()]).then(([v]) => v);
         return promise;
       },
       download(fn?: () => Promise<void>, options?: { timeout?: number }): Promise<Download> {
         const promise = self._captureDownload(options);
-        if (fn) return fn().then(() => promise);
+        if (fn) return Promise.all([promise, fn()]).then(([v]) => v);
         return promise;
       },
       dialog(fn?: () => Promise<void>, options?: { timeout?: number }): Promise<Dialog> {
         const promise = self._captureDialog(options);
-        if (fn) return fn().then(() => promise);
+        if (fn) return Promise.all([promise, fn()]).then(([v]) => v);
         return promise;
       },
       event(name: string, fn?: () => Promise<void>, options?: { timeout?: number }): Promise<unknown> {
         const promise = self._captureEvent(name, options);
-        if (fn) return fn().then(() => promise);
+        if (fn) return Promise.all([promise, fn()]).then(([v]) => v);
         return promise;
       },
     };

--- a/clients/python/tests/test_basic.py
+++ b/clients/python/tests/test_basic.py
@@ -1,14 +1,45 @@
 """Basic tests for the Vibium Python client."""
 
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
 from vibium import browser
+
+EXAMPLE_HTML = b"""<html><head><title>Example Domain</title></head><body>
+  <div>
+    <h1>Example Domain</h1>
+    <p>This domain is for use in illustrative examples in documents.</p>
+    <p><a href="/more-information">More information...</a></p>
+  </div>
+</body></html>"""
+
+MORE_INFORMATION_HTML = b"""<html><head><title>More information</title></head><body>
+  <h1>More information</h1>
+</body></html>"""
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = MORE_INFORMATION_HTML if self.path == "/more-information" else EXAMPLE_HTML
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
 
 
 def test_sync_api():
     """Test the synchronous API with new object model."""
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    base_url = f"http://127.0.0.1:{server.server_port}"
+
     bro = browser.start(headless=True)
     try:
         vibe = bro.new_page()
-        vibe.go("https://example.com")
+        vibe.go(f"{base_url}/example")
 
         # Test title
         title = vibe.title()
@@ -16,7 +47,7 @@ def test_sync_api():
 
         # Test url
         url = vibe.url()
-        assert "example.com" in url, f"Expected URL with 'example.com', got: {url}"
+        assert "/example" in url, f"Expected URL with '/example', got: {url}"
 
         # Test find (CSS) and text
         h1 = vibe.find("h1")
@@ -49,6 +80,7 @@ def test_sync_api():
 
     finally:
         bro.stop()
+        server.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -5,7 +5,6 @@ Tests are functional but could be improved:
 ## Coverage Gaps
 - [ ] `element.getAttribute()` not tested
 - [ ] `element.boundingBox()` not tested
-- [ ] CLI tests still use example.com (should use the-internet.herokuapp.com)
 
 ## Auto-Wait Tests
 - [ ] "click waits for actionable" should test element that starts hidden and becomes visible

--- a/tests/cli/actionability.test.js
+++ b/tests/cli/actionability.test.js
@@ -3,17 +3,34 @@
  * Tests auto-wait and actionability behavior
  */
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
+
 describe('CLI: Actionability', () => {
   test('is actionable reports visibility status', () => {
-    const result = execSync(`${VIBIUM} is actionable https://example.com "a"`, {
+    const result = execSync(`${VIBIUM} is actionable ${baseURL}/example "a"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -26,7 +43,7 @@ describe('CLI: Actionability', () => {
   test('click with short timeout fails on non-existent element', () => {
     assert.throws(
       () => {
-        execSync(`${VIBIUM} click https://example.com "#does-not-exist" --timeout 1s`, {
+        execSync(`${VIBIUM} click ${baseURL}/example "#does-not-exist" --timeout 1s`, {
           encoding: 'utf-8',
           timeout: 10000,
           stdio: 'pipe', // capture the expected failure instead of leaking it to the console

--- a/tests/cli/elements.test.js
+++ b/tests/cli/elements.test.js
@@ -28,7 +28,7 @@ after(() => {
 
 describe('CLI: Elements', () => {
   test('find command locates element and returns @ref', () => {
-    const result = execSync(`${VIBIUM} find https://example.com "a"`, {
+    const result = execSync(`${VIBIUM} find ${baseURL}/example "a"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -49,7 +49,7 @@ describe('CLI: Elements', () => {
   });
 
   test('click command navigates via link', () => {
-    const result = execSync(`${VIBIUM} click https://example.com "a"`, {
+    const result = execSync(`${VIBIUM} click ${baseURL}/example "a"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });

--- a/tests/cli/find-refs.test.js
+++ b/tests/cli/find-refs.test.js
@@ -3,14 +3,32 @@
  * Tests that find, find --all return @refs in oneshot mode
  */
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
+const path = require('path');
 const { VIBIUM } = require('../helpers');
+
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
 
 describe('CLI: Find @refs', () => {
   test('find CSS selector returns @ref', () => {
-    const result = execSync(`${VIBIUM} find https://example.com "a"`, {
+    const result = execSync(`${VIBIUM} find ${baseURL}/example "a"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -19,7 +37,7 @@ describe('CLI: Find @refs', () => {
   });
 
   test('find --all returns multiple @refs', () => {
-    const result = execSync(`${VIBIUM} find https://example.com "p" --all`, {
+    const result = execSync(`${VIBIUM} find ${baseURL}/example "p" --all`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -28,7 +46,7 @@ describe('CLI: Find @refs', () => {
   });
 
   test('find --all --limit 1 returns single @ref', () => {
-    const result = execSync(`${VIBIUM} find https://example.com "p" --all --limit 1`, {
+    const result = execSync(`${VIBIUM} find ${baseURL}/example "p" --all --limit 1`, {
       encoding: 'utf-8',
       timeout: 30000,
     });

--- a/tests/cli/input-tools.test.js
+++ b/tests/cli/input-tools.test.js
@@ -4,14 +4,32 @@
  * Note: scroll, keys, select require daemon mode and are tested via MCP
  */
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
+const path = require('path');
 const { VIBIUM } = require('../helpers');
+
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
 
 describe('CLI: Input Tools', () => {
   test('hover command hovers over element', () => {
-    const result = execSync(`${VIBIUM} hover https://example.com "a"`, {
+    const result = execSync(`${VIBIUM} hover ${baseURL}/example "a"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });

--- a/tests/cli/navigation.test.js
+++ b/tests/cli/navigation.test.js
@@ -3,7 +3,7 @@
  * Tests the vibium binary directly
  */
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const { execSync, spawn } = require('node:child_process');
 const fs = require('node:fs');
@@ -11,20 +11,37 @@ const os = require('node:os');
 const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
+
 describe('CLI: Navigation', () => {
   test('navigate command loads page and prints title', () => {
-    const result = execSync(`${VIBIUM} go https://example.com`, {
+    const result = execSync(`${VIBIUM} go ${baseURL}/example`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
-    assert.match(result, /example/i, 'Should show example.com content');
+    assert.match(result, /example/i, 'Should show example page content');
   });
 
   test('screenshot command creates valid PNG', () => {
     const filename = `vibium-test-${Date.now()}.png`;
     let savedPath;
     try {
-      const result = execSync(`${VIBIUM} screenshot https://example.com -o ${filename}`, {
+      const result = execSync(`${VIBIUM} screenshot ${baseURL}/example -o ${filename}`, {
         encoding: 'utf-8',
         timeout: 30000,
       });
@@ -53,14 +70,14 @@ describe('CLI: Navigation', () => {
   });
 
   test('eval command executes JavaScript', () => {
-    const result = execSync(`${VIBIUM} eval https://example.com "document.title"`, {
+    const result = execSync(`${VIBIUM} eval ${baseURL}/example "document.title"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
     assert.match(result, /Example Domain/i, 'Should return page title');
   });
   test('eval returns valid JSON for objects', () => {
-    const result = execSync(`${VIBIUM} eval https://example.com "({title: document.title, url: location.href})"`, {
+    const result = execSync(`${VIBIUM} eval ${baseURL}/example "({title: document.title, url: location.href})"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -69,7 +86,7 @@ describe('CLI: Navigation', () => {
     assert.ok(parsed.url, 'Should have url key');
   });
   test('eval returns valid JSON for arrays', () => {
-    const result = execSync(`${VIBIUM} eval https://example.com "[1, 2, 3]"`, {
+    const result = execSync(`${VIBIUM} eval ${baseURL}/example "[1, 2, 3]"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });

--- a/tests/cli/page-reading.test.js
+++ b/tests/cli/page-reading.test.js
@@ -3,14 +3,32 @@
  * Tests text, html, find --all commands
  */
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
+const path = require('path');
 const { VIBIUM } = require('../helpers');
+
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
 
 describe('CLI: Page Reading', () => {
   test('text command returns page text', () => {
-    const result = execSync(`${VIBIUM} text https://example.com`, {
+    const result = execSync(`${VIBIUM} text ${baseURL}/example`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -18,7 +36,7 @@ describe('CLI: Page Reading', () => {
   });
 
   test('text command with selector returns element text', () => {
-    const result = execSync(`${VIBIUM} text https://example.com "h1"`, {
+    const result = execSync(`${VIBIUM} text ${baseURL}/example "h1"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -26,7 +44,7 @@ describe('CLI: Page Reading', () => {
   });
 
   test('html command returns page HTML', () => {
-    const result = execSync(`${VIBIUM} html https://example.com "h1"`, {
+    const result = execSync(`${VIBIUM} html ${baseURL}/example "h1"`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -34,7 +52,7 @@ describe('CLI: Page Reading', () => {
   });
 
   test('html command with --outer returns outer HTML', () => {
-    const result = execSync(`${VIBIUM} html https://example.com "h1" --outer`, {
+    const result = execSync(`${VIBIUM} html ${baseURL}/example "h1" --outer`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -43,7 +61,7 @@ describe('CLI: Page Reading', () => {
   });
 
   test('find --all returns multiple @refs', () => {
-    const result = execSync(`${VIBIUM} find https://example.com "p" --all`, {
+    const result = execSync(`${VIBIUM} find ${baseURL}/example "p" --all`, {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -52,7 +70,7 @@ describe('CLI: Page Reading', () => {
   });
 
   test('find --all with --limit', () => {
-    const result = execSync(`${VIBIUM} find https://example.com "p" --all --limit 1`, {
+    const result = execSync(`${VIBIUM} find ${baseURL}/example "p" --all --limit 1`, {
       encoding: 'utf-8',
       timeout: 30000,
     });

--- a/tests/cli/process.test.js
+++ b/tests/cli/process.test.js
@@ -3,13 +3,30 @@
  * Tests that Chrome processes are cleaned up properly
  */
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const { execSync, execFileSync, spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { VIBIUM } = require('../helpers');
+
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
 
 /**
  * Get PIDs of Chrome for Testing processes spawned by clicker
@@ -82,7 +99,7 @@ describe('CLI: Process Cleanup', () => {
     execSync(`${VIBIUM} daemon start --headless`, { encoding: 'utf-8', timeout: 30000 });
 
     // Navigate to launch the browser
-    execSync(`${VIBIUM} go https://example.com`, {
+    execSync(`${VIBIUM} go ${baseURL}/example`, {
       encoding: 'utf-8',
       timeout: 30000,
     });

--- a/tests/daemon/cli-commands.test.js
+++ b/tests/daemon/cli-commands.test.js
@@ -5,7 +5,7 @@
 
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const { VIBIUM } = require('../helpers');
@@ -21,7 +21,7 @@ function clicker(args, opts = {}) {
 }
 
 function clickerJSON(args, opts = {}) {
-  const result = clicker(`${args} --json`, opts);
+  const result = clicker(`--json ${args}`, opts);
   return JSON.parse(result);
 }
 
@@ -34,11 +34,28 @@ function stopDaemon() {
   }
 }
 
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
+
 describe('Daemon CLI: Navigation commands', () => {
   before(() => {
     stopDaemon();
     clicker('daemon start --headless');
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
@@ -47,7 +64,7 @@ describe('Daemon CLI: Navigation commands', () => {
 
   test('back navigates back in history', () => {
     // Navigate to a second page
-    clickerJSON('go https://example.com/');
+    clickerJSON(`go ${baseURL}/more-information`);
     const result = clickerJSON('back');
     assert.strictEqual(result.ok, true, 'back should succeed');
   });
@@ -68,7 +85,7 @@ describe('Daemon CLI: Element state commands', () => {
   before(() => {
     stopDaemon();
     clicker('daemon start --headless');
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
@@ -90,7 +107,7 @@ describe('Daemon CLI: Element state commands', () => {
   test('attr gets element attribute', () => {
     const result = clickerJSON('attr "a" "href"');
     assert.strictEqual(result.ok, true);
-    assert.ok(result.result.includes('iana.org'), 'Should return href value');
+    assert.ok(result.result.includes('/more-information'), 'Should return href value');
   });
 });
 
@@ -98,7 +115,7 @@ describe('Daemon CLI: Accessibility and search commands', () => {
   before(() => {
     stopDaemon();
     clicker('daemon start --headless');
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
@@ -125,7 +142,7 @@ describe('Daemon CLI: Accessibility and search commands', () => {
   });
 
   test('find role finds element by role and name', () => {
-    const result = clickerJSON('find role link --name "Learn more"');
+    const result = clickerJSON('find role link --name "More information"');
     assert.strictEqual(result.ok, true);
     assert.ok(result.result.includes('@e1'), 'Should return @e1 ref');
     assert.ok(result.result.includes('[a]'), 'Should find link element');
@@ -136,7 +153,7 @@ describe('Daemon CLI: Waiting commands', () => {
   before(() => {
     stopDaemon();
     clicker('daemon start --headless');
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
@@ -150,16 +167,18 @@ describe('Daemon CLI: Waiting commands', () => {
   });
 
   test('wait url matches current URL', () => {
-    const result = clickerJSON('wait url "example.com"');
+    const result = clickerJSON('wait url "/example"');
     assert.strictEqual(result.ok, true);
-    assert.ok(result.result.includes('example.com'), 'Should match URL pattern');
+    assert.ok(result.result.includes('/example'), 'Should match URL pattern');
   });
 
   test('sleep pauses execution', () => {
     const start = Date.now();
-    const result = clickerJSON('sleep 200');
+    // sleep sets DisableFlagParsing (so negative values work), which also
+    // rejects --json — call it without JSON output
+    const result = clicker('sleep 200');
     const elapsed = Date.now() - start;
-    assert.strictEqual(result.ok, true);
+    assert.ok(result.includes('Slept') || result.includes('200'), 'Should confirm sleep');
     assert.ok(elapsed >= 150, `Should have waited ~200ms (actual: ${elapsed}ms)`);
   });
 });
@@ -175,14 +194,14 @@ describe('Daemon CLI: Interaction commands', () => {
   });
 
   test('scroll into-view scrolls element into view', () => {
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     const result = clickerJSON('scroll into-view "a"');
     assert.strictEqual(result.ok, true);
     assert.ok(result.result.includes('Scrolled'), 'Should confirm scroll');
   });
 
   test('press sends key to focused element', () => {
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     const result = clickerJSON('press Tab');
     assert.strictEqual(result.ok, true);
     assert.ok(result.result.includes('Pressed'), 'Should confirm key press');
@@ -190,7 +209,7 @@ describe('Daemon CLI: Interaction commands', () => {
 
   test('fill and value work together on input', () => {
     // Navigate to a page with an input via eval
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     clicker('eval "document.body.innerHTML = \'<input id=test type=text>\';"');
 
     // Fill the input
@@ -204,7 +223,7 @@ describe('Daemon CLI: Interaction commands', () => {
   });
 
   test('check and uncheck toggle checkbox', () => {
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     clicker('eval "document.body.innerHTML = \'<input id=cb type=checkbox>\';"');
 
     // Check
@@ -223,7 +242,7 @@ describe('Daemon CLI: Screenshot --full-page', () => {
   before(() => {
     stopDaemon();
     clicker('daemon start --headless');
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
@@ -252,15 +271,15 @@ describe('Daemon CLI: quit command', () => {
   before(() => {
     stopDaemon();
     clicker('daemon start --headless');
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
     stopDaemon();
   });
 
-  test('quit closes browser session', () => {
-    const result = clickerJSON('quit');
+  test('stop closes browser session', () => {
+    const result = clickerJSON('stop');
     assert.strictEqual(result.ok, true);
     assert.ok(result.result.includes('closed'), 'Should confirm browser closed');
   });

--- a/tests/daemon/concurrency.test.js
+++ b/tests/daemon/concurrency.test.js
@@ -5,7 +5,8 @@
 
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
+const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
 function clicker(args, opts = {}) {
@@ -18,7 +19,7 @@ function clicker(args, opts = {}) {
 }
 
 function clickerJSON(args, opts = {}) {
-  const result = clicker(`${args} --json`, opts);
+  const result = clicker(`--json ${args}`, opts);
   return JSON.parse(result);
 }
 
@@ -29,6 +30,23 @@ function stopDaemon() {
     // Daemon may not be running
   }
 }
+
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
 
 describe('Daemon: Rapid sequential commands', () => {
   before(() => {
@@ -42,25 +60,25 @@ describe('Daemon: Rapid sequential commands', () => {
 
   test('multiple go commands in sequence', () => {
     // Navigate to several pages in quick succession
-    const r1 = clickerJSON('go https://example.com');
+    const r1 = clickerJSON(`go ${baseURL}/example`);
     assert.strictEqual(r1.ok, true, 'First go should succeed');
 
-    const r2 = clickerJSON('go https://example.com');
+    const r2 = clickerJSON(`go ${baseURL}/example`);
     assert.strictEqual(r2.ok, true, 'Second go should succeed');
 
-    const r3 = clickerJSON('go https://example.com');
+    const r3 = clickerJSON(`go ${baseURL}/example`);
     assert.strictEqual(r3.ok, true, 'Third go should succeed');
   });
 
   test('go then eval then find', () => {
-    const nav = clickerJSON('go https://example.com');
+    const nav = clickerJSON(`go ${baseURL}/example`);
     assert.strictEqual(nav.ok, true);
 
-    const evalResult = clickerJSON('eval https://example.com "document.title"');
+    const evalResult = clickerJSON(`eval ${baseURL}/example "document.title"`);
     assert.strictEqual(evalResult.ok, true);
     assert.ok(evalResult.result.includes('Example Domain'));
 
-    const find = clickerJSON('find https://example.com "h1"');
+    const find = clickerJSON(`find ${baseURL}/example "h1"`);
     assert.strictEqual(find.ok, true);
     assert.ok(find.result.includes('h1'));
   });
@@ -78,11 +96,11 @@ describe('Daemon: Error recovery', () => {
 
   test('find with bad selector returns error', () => {
     // Navigate first
-    clickerJSON('go https://example.com');
+    clickerJSON(`go ${baseURL}/example`);
 
     // Find with nonexistent selector
     try {
-      clickerJSON('find https://example.com ".nonexistent-element-xyz"');
+      clickerJSON(`find ${baseURL}/example ".nonexistent-element-xyz"`);
       assert.fail('Should have thrown');
     } catch (e) {
       // Expected — command exits non-zero on error in --json mode
@@ -93,7 +111,7 @@ describe('Daemon: Error recovery', () => {
 
   test('commands still work after error', () => {
     // After a failed command, the daemon should still work
-    const result = clickerJSON('go https://example.com');
+    const result = clickerJSON(`go ${baseURL}/example`);
     assert.strictEqual(result.ok, true, 'Navigate should succeed after error');
   });
 });

--- a/tests/daemon/connect.test.js
+++ b/tests/daemon/connect.test.js
@@ -9,6 +9,7 @@ const assert = require('node:assert');
 const { execSync, spawn } = require('node:child_process');
 const http = require('node:http');
 const net = require('node:net');
+const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
 // Helper to run vibium and return trimmed output
@@ -22,7 +23,7 @@ function clicker(args, opts = {}) {
 }
 
 function clickerJSON(args, opts = {}) {
-  const result = clicker(`${args} --json`, opts);
+  const result = clicker(`--json ${args}`, opts);
   return JSON.parse(result);
 }
 
@@ -150,6 +151,23 @@ function getBrowserPaths() {
   };
 }
 
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
+
 describe('Daemon: Remote browser connect', () => {
   let chromedriverProc;
   let chromedriverPort;
@@ -191,9 +209,9 @@ describe('Daemon: Remote browser connect', () => {
   });
 
   test('navigation works through remote connection', () => {
-    const result = clickerJSON('go https://example.com');
+    const result = clickerJSON(`go ${baseURL}/example`);
     assert.strictEqual(result.ok, true, 'Navigate should succeed');
-    assert.ok(result.result.includes('example.com'), 'Should confirm navigation');
+    assert.ok(result.result.includes('/example'), 'Should confirm navigation');
   });
 
   test('window set returns error for remote browsers', () => {
@@ -250,7 +268,7 @@ describe('Daemon: VIBIUM_CONNECT_URL env var', () => {
 
   test('VIBIUM_CONNECT_URL auto-starts daemon in connect mode', () => {
     // With no daemon running, set env var and run a command
-    const result = clickerJSON('go https://example.com --headless', {
+    const result = clickerJSON(`go ${baseURL}/example --headless`, {
       env: { VIBIUM_CONNECT_URL: bidiWsUrl },
     });
     assert.strictEqual(result.ok, true, 'Navigate should succeed via env var auto-start');

--- a/tests/daemon/find-refs.test.js
+++ b/tests/daemon/find-refs.test.js
@@ -5,7 +5,8 @@
 
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
+const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
 function clicker(args, opts = {}) {
@@ -18,7 +19,7 @@ function clicker(args, opts = {}) {
 }
 
 function clickerJSON(args, opts = {}) {
-  const result = clicker(`${args} --json`, opts);
+  const result = clicker(`--json ${args}`, opts);
   return JSON.parse(result);
 }
 
@@ -30,11 +31,28 @@ function stopDaemon() {
   }
 }
 
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
+
 describe('Daemon: Find @refs workflow', () => {
   before(() => {
     stopDaemon();
     clicker('daemon start --headless');
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
@@ -42,7 +60,7 @@ describe('Daemon: Find @refs workflow', () => {
   });
 
   test('find text returns @ref', () => {
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     const findResult = clickerJSON('find text "Example Domain"');
     assert.strictEqual(findResult.ok, true);
     assert.ok(findResult.result.includes('@e1'), 'find should return @e1');
@@ -50,7 +68,7 @@ describe('Daemon: Find @refs workflow', () => {
   });
 
   test('find CSS selector returns @ref and click @e1 navigates', () => {
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     const findResult = clickerJSON('find "a"');
     assert.strictEqual(findResult.ok, true);
     assert.ok(findResult.result.includes('@e1'), 'find should return @e1');
@@ -59,11 +77,11 @@ describe('Daemon: Find @refs workflow', () => {
     clickerJSON('click @e1');
     clickerJSON('wait load');
     const urlResult = clickerJSON('url');
-    assert.ok(urlResult.result.includes('iana.org'), 'Should navigate to IANA after clicking');
+    assert.ok(urlResult.result.includes('/more-information'), 'Should navigate to linked page after clicking');
   });
 
   test('find role returns @ref and click @e1 navigates', () => {
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     const findResult = clickerJSON('find role link');
     assert.strictEqual(findResult.ok, true);
     assert.ok(findResult.result.includes('@e1'), 'find role should return @e1');
@@ -72,11 +90,11 @@ describe('Daemon: Find @refs workflow', () => {
     clickerJSON('click @e1');
     clickerJSON('wait load');
     const urlResult = clickerJSON('url');
-    assert.ok(urlResult.result.includes('iana.org'), 'Should navigate to IANA after clicking');
+    assert.ok(urlResult.result.includes('/more-information'), 'Should navigate to linked page after clicking');
   });
 
   test('find --all returns multiple @refs', () => {
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     const findResult = clickerJSON('find --all "p"');
     assert.strictEqual(findResult.ok, true);
     assert.ok(findResult.result.includes('@e1'), 'find --all should return @e1');
@@ -84,7 +102,7 @@ describe('Daemon: Find @refs workflow', () => {
   });
 
   test('find resets refMap from previous map', () => {
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
     // First map to get refs
     const mapResult = clickerJSON('map');
     assert.strictEqual(mapResult.ok, true);
@@ -99,6 +117,6 @@ describe('Daemon: Find @refs workflow', () => {
     // Clicking @e1 (h1) should not navigate away
     clickerJSON('click @e1');
     const urlResult = clickerJSON('url');
-    assert.ok(urlResult.result.includes('example.com'), 'Should still be on example.com');
+    assert.ok(urlResult.result.includes('/example'), 'Should still be on /example');
   });
 });

--- a/tests/daemon/lifecycle.test.js
+++ b/tests/daemon/lifecycle.test.js
@@ -6,6 +6,7 @@
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const { execSync, spawn } = require('node:child_process');
+const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
 // Helper to run clicker with --json and parse output
@@ -19,7 +20,7 @@ function clicker(args, opts = {}) {
 }
 
 function clickerJSON(args, opts = {}) {
-  const result = clicker(`${args} --json`, opts);
+  const result = clicker(`--json ${args}`, opts);
   return JSON.parse(result);
 }
 
@@ -31,6 +32,23 @@ function stopDaemon() {
     // Daemon may not be running
   }
 }
+
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
 
 describe('Daemon: Lifecycle', () => {
   before(() => {
@@ -81,15 +99,15 @@ describe('Daemon: Multi-step workflow', () => {
 
   test('go then find reuses browser session', () => {
     // Navigate
-    const navResult = clickerJSON('go https://example.com');
+    const navResult = clickerJSON(`go ${baseURL}/example`);
     assert.strictEqual(navResult.ok, true, 'Navigate should succeed');
     assert.ok(
-      navResult.result.includes('example.com'),
+      navResult.result.includes('/example'),
       'Should confirm navigation'
     );
 
     // Find element on same page (no URL needed — session persists)
-    const findResult = clickerJSON('find https://example.com "h1"');
+    const findResult = clickerJSON(`find ${baseURL}/example "h1"`);
     assert.strictEqual(findResult.ok, true, 'Find should succeed');
     assert.ok(
       findResult.result.includes('h1'),
@@ -98,7 +116,7 @@ describe('Daemon: Multi-step workflow', () => {
   });
 
   test('eval on current page works', () => {
-    const result = clickerJSON('eval https://example.com "document.title"');
+    const result = clickerJSON(`eval ${baseURL}/example "document.title"`);
     assert.strictEqual(result.ok, true, 'Eval should succeed');
     assert.ok(
       result.result.includes('Example Domain'),
@@ -118,7 +136,7 @@ describe('Daemon: Auto-start', () => {
 
   test('CLI command auto-starts daemon when not running', () => {
     // No daemon running — this should auto-start one
-    const result = clickerJSON('go https://example.com --headless');
+    const result = clickerJSON(`go ${baseURL}/example --headless`);
     assert.strictEqual(result.ok, true, 'Navigate should succeed via auto-start');
 
     // Verify daemon is now running

--- a/tests/daemon/recording.test.js
+++ b/tests/daemon/recording.test.js
@@ -5,7 +5,7 @@
 
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('node:child_process');
+const { execSync, spawn } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
@@ -23,7 +23,7 @@ function clicker(args, opts = {}) {
 }
 
 function clickerJSON(args, opts = {}) {
-  const result = clicker(`${args} --json`, opts);
+  const result = clicker(`--json ${args}`, opts);
   return JSON.parse(result);
 }
 
@@ -73,6 +73,23 @@ function readRecordingEvents(extractedDir) {
   return events;
 }
 
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
+
 describe('Daemon CLI: Recording', () => {
   const tmpFiles = [];
   const tmpDirs = [];
@@ -86,7 +103,7 @@ describe('Daemon CLI: Recording', () => {
   before(() => {
     stopDaemon();
     clicker('daemon start --headless');
-    clicker('go https://example.com');
+    clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
@@ -123,7 +140,7 @@ describe('Daemon CLI: Recording', () => {
 
   test('record stop saves valid Playwright-compatible zip', () => {
     clickerJSON('record start');
-    clickerJSON('go https://example.com');
+    clickerJSON(`go ${baseURL}/example`);
 
     const zipPath = tmpPath('valid-zip.zip');
     const result = clickerJSON(`record stop -o "${zipPath}"`);
@@ -169,7 +186,7 @@ describe('Daemon CLI: Recording', () => {
 
   test('record start --screenshots captures per-action screenshots', () => {
     clickerJSON('record start --screenshots');
-    clickerJSON('go https://example.com');
+    clickerJSON(`go ${baseURL}/example`);
     clickerJSON('click "a"');
 
     const zipPath = tmpPath('screenshots.zip');
@@ -196,7 +213,7 @@ describe('Daemon CLI: Recording', () => {
   test('record group start / group stop adds group markers', () => {
     clickerJSON('record start');
     clickerJSON('record group start "Login"');
-    clickerJSON('go https://example.com');
+    clickerJSON(`go ${baseURL}/example`);
     clickerJSON('record group stop');
 
     const zipPath = tmpPath('groups.zip');
@@ -218,7 +235,7 @@ describe('Daemon CLI: Recording', () => {
 
   test('record chunk start / chunk stop saves chunk zip', () => {
     clickerJSON('record start');
-    clickerJSON('go https://example.com');
+    clickerJSON(`go ${baseURL}/example`);
 
     // Stop first chunk
     const chunkPath1 = tmpPath('chunk1.zip');
@@ -227,7 +244,7 @@ describe('Daemon CLI: Recording', () => {
 
     // Start second chunk
     clickerJSON('record chunk start');
-    clickerJSON('go https://example.com');
+    clickerJSON(`go ${baseURL}/example`);
 
     // Stop second chunk
     const chunkPath2 = tmpPath('chunk2.zip');
@@ -253,7 +270,7 @@ describe('Daemon CLI: Recording', () => {
 
   test('record start --title sets trace viewer title', () => {
     clickerJSON('record start --title "CLI Title"');
-    clickerJSON('go https://example.com');
+    clickerJSON(`go ${baseURL}/example`);
 
     const zipPath = tmpPath('title.zip');
     clickerJSON(`record stop -o "${zipPath}"`);
@@ -266,7 +283,7 @@ describe('Daemon CLI: Recording', () => {
 
   test('recording with multiple actions captures multiple screenshots', () => {
     clickerJSON('record start --screenshots');
-    clickerJSON('go https://example.com');
+    clickerJSON(`go ${baseURL}/example`);
 
     // Inject interactive elements
     clicker('eval "document.body.innerHTML = \'<input id=inp type=text><button id=btn1>A</button><button id=btn2>B</button>\';"');

--- a/tests/helpers/test-server.js
+++ b/tests/helpers/test-server.js
@@ -120,6 +120,20 @@ const ADD_REMOVE_HTML = `<html><head><title>The Internet - Add/Remove</title></h
   </script>
 </body></html>`;
 
+const EXAMPLE_HTML = `<html><head><title>Example Domain</title></head><body>
+  <div>
+    <h1>Example Domain</h1>
+    <p>This domain is for use in illustrative examples in documents. You may use this
+    domain in literature without prior coordination or asking for permission.</p>
+    <p><a href="/more-information">More information...</a></p>
+  </div>
+</body></html>`;
+
+const MORE_INFORMATION_HTML = `<html><head><title>More information</title></head><body>
+  <h1>More information</h1>
+  <p>You followed the example link. This page is served locally.</p>
+</body></html>`;
+
 const SELECTORS_HTML = `<html><head><title>Selectors</title></head><body>
   <h1>Selector Strategies Test</h1>
   <input type="text" id="search" placeholder="Search..." data-testid="search-input" title="Search field" />
@@ -140,6 +154,8 @@ const routes = {
   '/inputs': INPUTS_HTML,
   '/dynamic_loading/1': DYNAMIC_LOADING_HTML,
   '/add_remove_elements/': ADD_REMOVE_HTML,
+  '/example': EXAMPLE_HTML,
+  '/more-information': MORE_INFORMATION_HTML,
   '/selectors': SELECTORS_HTML,
 };
 

--- a/tests/js/async/a11y.test.js
+++ b/tests/js/async/a11y.test.js
@@ -7,30 +7,33 @@ const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 
 const { browser } = require('../../../clients/javascript/dist');
+const { createTestServer } = require('../../helpers/test-server');
 
-let bro, vibe;
+let server, baseURL, bro, vibe;
 
 before(async () => {
+  ({ server, baseURL } = await createTestServer());
   bro = await browser.start({ headless: true });
   vibe = await bro.page();
 });
 
 after(async () => {
   if (bro) await bro.stop();
+  if (server) server.close();
 });
 
 // --- el.role() ---
 
 describe('Element Accessibility: role()', () => {
   test('role() returns "link" for <a> element', async () => {
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
     const link = await vibe.find('a');
     const role = await link.role();
     assert.strictEqual(role, 'link');
   });
 
   test('role() returns "heading" for <h1> element', async () => {
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
     const h1 = await vibe.find('h1');
     const role = await h1.role();
     assert.strictEqual(role, 'heading');
@@ -44,7 +47,7 @@ describe('Element Accessibility: role()', () => {
   });
 
   test('fluent: find().role() chains', async () => {
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
     const role = await vibe.find('a').role();
     assert.strictEqual(role, 'link');
   });
@@ -54,7 +57,7 @@ describe('Element Accessibility: role()', () => {
 
 describe('Element Accessibility: label()', () => {
   test('label() returns accessible name for a link', async () => {
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
     const link = await vibe.find('a');
     const label = await link.label();
     assert.ok(label.length > 0, `label should not be empty, got: "${label}"`);
@@ -98,15 +101,15 @@ describe('Element Accessibility: label()', () => {
 
 describe('Page Accessibility: a11yTree()', () => {
   test('returns tree with WebArea root and document title', async () => {
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
     const tree = await vibe.a11yTree();
     assert.strictEqual(tree.role, 'WebArea');
     assert.strictEqual(tree.name, 'Example Domain');
     assert.ok(Array.isArray(tree.children), 'tree should have children');
   });
 
-  test('tree contains heading and link roles on example.com', async () => {
-    await vibe.go('https://example.com');
+  test('tree contains heading and link roles on the example page', async () => {
+    await vibe.go(`${baseURL}/example`);
     const tree = await vibe.a11yTree();
 
     function findRoles(node) {

--- a/tests/js/async/input-eval.test.js
+++ b/tests/js/async/input-eval.test.js
@@ -141,7 +141,7 @@ describe('Mouse: page-level input', () => {
 describe('Screenshots: options', () => {
   test('screenshot() returns a PNG buffer', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const buf = await vibe.screenshot();
     assert.ok(Buffer.isBuffer(buf), 'screenshot() should return a Buffer');
@@ -156,7 +156,7 @@ describe('Screenshots: options', () => {
 
   test('screenshot({ fullPage: true }) captures full page', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const viewportShot = await vibe.screenshot();
     const fullShot = await vibe.screenshot({ fullPage: true });
@@ -167,7 +167,7 @@ describe('Screenshots: options', () => {
 
   test('screenshot({ clip }) captures a specific region', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const clipShot = await vibe.screenshot({
       clip: { x: 0, y: 0, width: 100, height: 100 },
@@ -179,7 +179,7 @@ describe('Screenshots: options', () => {
 
   test('pdf() returns a PDF buffer', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const buf = await vibe.pdf();
     assert.ok(Buffer.isBuffer(buf), 'pdf() should return a Buffer');
@@ -196,7 +196,7 @@ describe('Screenshots: options', () => {
 describe('Evaluation: page-level', () => {
   test('eval() evaluates an expression', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const result = await vibe.evaluate('1 + 1');
     assert.strictEqual(result, 2);
@@ -204,7 +204,7 @@ describe('Evaluation: page-level', () => {
 
   test('eval() returns strings', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const result = await vibe.evaluate('document.title');
     assert.strictEqual(result, 'Example Domain');
@@ -212,7 +212,7 @@ describe('Evaluation: page-level', () => {
 
   test('eval() returns null for undefined', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const result = await vibe.evaluate('undefined');
     assert.strictEqual(result, null);
@@ -220,7 +220,7 @@ describe('Evaluation: page-level', () => {
 
   test('addScript() injects inline JS', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     await vibe.addScript('window.__testVar = 42;');
 
@@ -230,7 +230,7 @@ describe('Evaluation: page-level', () => {
 
   test('addStyle() injects inline CSS', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     await vibe.addStyle('body { background-color: rgb(255, 0, 0) !important; }');
 
@@ -240,7 +240,7 @@ describe('Evaluation: page-level', () => {
 
   test('expose() injects a named function on window', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     await vibe.expose('myAdd', '(a, b) => a + b');
 

--- a/tests/js/async/interaction.test.js
+++ b/tests/js/async/interaction.test.js
@@ -101,7 +101,7 @@ describe('Interaction: Click variants', () => {
 
   test('dblclick selects text', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(baseURL + '/example');
 
     const h1 = await vibe.find('h1');
     await h1.dblclick();
@@ -258,7 +258,7 @@ describe('Interaction: findAll index bug fix', () => {
 describe('Interaction: dispatchEvent', () => {
   test('dispatchEvent fires custom event', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(baseURL + '/example');
 
     // Set up an event listener
     await vibe.evaluate(`

--- a/tests/js/async/state.test.js
+++ b/tests/js/async/state.test.js
@@ -28,7 +28,7 @@ after(async () => {
 describe('Element State: text and content', () => {
   test('text() returns textContent', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     const text = await h1.text();
@@ -37,7 +37,7 @@ describe('Element State: text and content', () => {
 
   test('innerText() returns rendered text', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     const text = await h1.innerText();
@@ -46,7 +46,7 @@ describe('Element State: text and content', () => {
 
   test('html() returns innerHTML', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     const html = await h1.html();
@@ -67,16 +67,16 @@ describe('Element State: text and content', () => {
 describe('Element State: attributes', () => {
   test('attr() returns attribute value', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const link = await vibe.find('a');
     const href = await link.attr('href');
-    assert.ok(href.includes('iana.org'), `href should contain iana.org, got: ${href}`);
+    assert.ok(href.includes('/more-information'), `href should contain /more-information, got: ${href}`);
   });
 
   test('attr() returns null for missing attribute', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     const val = await h1.attr('data-nonexistent');
@@ -85,7 +85,7 @@ describe('Element State: attributes', () => {
 
   test('getAttribute() is an alias for attr()', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const link = await vibe.find('a');
     const attr = await link.attr('href');
@@ -97,7 +97,7 @@ describe('Element State: attributes', () => {
 describe('Element State: bounds', () => {
   test('bounds() returns bounding box', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     const box = await h1.bounds();
@@ -109,7 +109,7 @@ describe('Element State: bounds', () => {
 
   test('boundingBox() is an alias for bounds()', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     const bounds = await h1.bounds();
@@ -121,7 +121,7 @@ describe('Element State: bounds', () => {
 describe('Element State: visibility', () => {
   test('isVisible() returns true for visible element', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     const visible = await h1.isVisible();
@@ -130,7 +130,7 @@ describe('Element State: visibility', () => {
 
   test('isHidden() returns false for visible element', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     const hidden = await h1.isHidden();
@@ -173,7 +173,7 @@ describe('Element State: enabled/checked/editable', () => {
 describe('Element State: screenshot', () => {
   test('screenshot() returns a PNG buffer', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const link = await vibe.find('a');
     const buf = await link.screenshot();
@@ -189,7 +189,7 @@ describe('Element State: screenshot', () => {
 describe('Page Waiting', () => {
   test('find(selector) auto-waits for element', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const h1 = await vibe.find('h1');
     assert.ok(h1, 'find should return an element (auto-waits)');
@@ -199,7 +199,7 @@ describe('Page Waiting', () => {
 
   test('wait(ms) delays execution', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const start = Date.now();
     await vibe.wait(200);
@@ -209,7 +209,7 @@ describe('Page Waiting', () => {
 
   test('waitUntil(fn) resolves when function returns truthy', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const result = await vibe.waitUntil('() => document.querySelector("h1") !== null');
     assert.ok(result, 'waitUntil should return truthy value');
@@ -230,7 +230,7 @@ describe('Page Waiting', () => {
 describe('Fluent chaining: state methods', () => {
   test('find().text() chains fluently', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const text = await vibe.find('h1').text();
     assert.strictEqual(text, 'Example Domain');
@@ -238,15 +238,15 @@ describe('Fluent chaining: state methods', () => {
 
   test('find().attr() chains fluently', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const href = await vibe.find('a').attr('href');
-    assert.ok(href.includes('iana.org'));
+    assert.ok(href.includes('/more-information'));
   });
 
   test('find().isVisible() chains fluently', async () => {
     const vibe = await bro.page();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const visible = await vibe.find('h1').isVisible();
     assert.strictEqual(visible, true);
@@ -258,7 +258,7 @@ describe('Fluent chaining: state methods', () => {
 describe('Element State Checkpoint', () => {
   test('full checkpoint: state queries + waiting + screenshot', async () => {
     const vibe = await bro.newPage();
-    await vibe.go('https://example.com');
+    await vibe.go(`${baseURL}/example`);
 
     const link = await vibe.find('a');
     const linkText = await link.text();
@@ -266,7 +266,7 @@ describe('Element State Checkpoint', () => {
     assert.ok(linkText.length > 0, 'link text should not be empty');
 
     console.log('attr:', await link.attr('href'));
-    assert.ok((await link.attr('href')).includes('iana.org'));
+    assert.ok((await link.attr('href')).includes('/more-information'));
 
     console.log('isVisible:', await link.isVisible());
     assert.strictEqual(await link.isVisible(), true);

--- a/tests/mcp/server.test.js
+++ b/tests/mcp/server.test.js
@@ -114,6 +114,23 @@ class MCPClient {
   }
 }
 
+let serverProcess, baseURL;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
+
 describe('MCP Server: Protocol', () => {
   let client;
 
@@ -222,13 +239,13 @@ describe('MCP Server: Browser Tools', () => {
   test('browser_navigate auto-launches browser (lazy launch)', async () => {
     const response = await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
 
     assert.ok(response.result, 'Should have result');
     assert.ok(!response.result.isError, 'Should not be an error');
     assert.ok(
-      response.result.content[0].text.includes('example.com'),
+      response.result.content[0].text.includes('/example'),
       'Should confirm navigation'
     );
   });
@@ -251,13 +268,13 @@ describe('MCP Server: Browser Tools', () => {
   test('browser_navigate goes to URL', async () => {
     const response = await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
 
     assert.ok(response.result, 'Should have result');
     assert.ok(!response.result.isError, 'Should not be an error');
     assert.ok(
-      response.result.content[0].text.includes('example.com'),
+      response.result.content[0].text.includes('/example'),
       'Should confirm navigation'
     );
   });
@@ -321,6 +338,22 @@ describe('MCP Server: Browser Tools', () => {
       response.result.content[0].text.includes('Clicked'),
       'Should confirm click'
     );
+
+    // Navigation commits asynchronously after the click — poll briefly
+    let urlText;
+    for (let i = 0; i < 50; i++) {
+      const urlResponse = await client.call('tools/call', {
+        name: 'browser_get_url',
+        arguments: {},
+      });
+      urlText = urlResponse.result.content[0].text;
+      if (urlText.includes('/more-information')) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.ok(
+      urlText.includes('/more-information'),
+      `Should land on /more-information after clicking the link, got: ${urlText}`
+    );
   });
 
   test('browser_stop closes session', async () => {
@@ -356,10 +389,10 @@ describe('MCP Server: New Tools', () => {
     await client.start();
     await client.call('initialize', { capabilities: {} });
 
-    // Navigate to example.com for testing
+    // Navigate to the local example page for testing
     await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
   });
 
@@ -405,8 +438,8 @@ describe('MCP Server: New Tools', () => {
     assert.ok(response.result, 'Should have result');
     assert.ok(!response.result.isError, 'Should not be an error');
     assert.ok(
-      response.result.content[0].text.includes('example.com'),
-      'Should contain example.com URL'
+      response.result.content[0].text.includes('/example'),
+      'Should contain /example URL'
     );
   });
 
@@ -706,10 +739,10 @@ describe('MCP Server: Recording', { timeout: 120000 }, () => {
     await client.start();
     await client.call('initialize', { capabilities: {} });
 
-    // Navigate to example.com so browser is launched
+    // Navigate to the local example page so browser is launched
     await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
   });
 
@@ -780,7 +813,7 @@ describe('MCP Server: Recording', { timeout: 120000 }, () => {
     // Navigate to generate events
     await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
 
     // Stop and save
@@ -861,7 +894,7 @@ describe('MCP Server: Recording', { timeout: 120000 }, () => {
     // Perform actions to trigger screenshots
     await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
     await client.call('tools/call', {
       name: 'browser_click',
@@ -931,7 +964,7 @@ describe('MCP Server: Recording', { timeout: 120000 }, () => {
     // Perform action inside group
     await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
 
     // Stop group
@@ -974,7 +1007,7 @@ describe('MCP Server: Recording', { timeout: 120000 }, () => {
     // First chunk: navigate
     await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
 
     // Stop first chunk
@@ -995,7 +1028,7 @@ describe('MCP Server: Recording', { timeout: 120000 }, () => {
     // Navigate again
     await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
 
     // Stop second chunk
@@ -1037,7 +1070,7 @@ describe('MCP Server: Recording', { timeout: 120000 }, () => {
 
     await client.call('tools/call', {
       name: 'browser_navigate',
-      arguments: { url: 'https://example.com' },
+      arguments: { url: `${baseURL}/example` },
     });
 
     const zipPath = tmpPath('title.zip');
@@ -1063,7 +1096,7 @@ describe('MCP Server: regression fixes', () => {
     client = new MCPClient();
     await client.start();
     await client.call('initialize', { capabilities: {} });
-    await client.call('tools/call', { name: 'browser_navigate', arguments: { url: 'https://example.com' } });
+    await client.call('tools/call', { name: 'browser_navigate', arguments: { url: `${baseURL}/example` } });
   });
 
   after(() => {
@@ -1102,7 +1135,7 @@ describe('MCP Server: regression fixes', () => {
     const r = await tool('browser_get_text', { selector: '#e' });
     assert.ok(!r.result.isError, `empty text should not error: ${JSON.stringify(r.result)}`);
     assert.strictEqual(r.result.content[0].text, '');
-    await tool('browser_navigate', { url: 'https://example.com' });
+    await tool('browser_navigate', { url: `${baseURL}/example` });
   });
 
   test('browser_set_cookie derives domain from the page when omitted (#152)', async () => {


### PR DESCRIPTION
## Summary

A stalled external navigation could wedge the entire test suite: the MCP `browser_click` test clicked the link on live example.com, navigating to iana.org. If that navigation stalled, chromedriver's BiDi mapper would refuse to run `script.callFunction` until the navigation settled, and the run sat frozen until the 600s timeout SIGKILLed everything (#151 family). Tests should never depend on the public internet.

## Changes

- **Local example.com replica** — `tests/helpers/test-server.js` now serves an `/example` page replicating example.com (same title/h1, so existing assertions hold), with its "More information..." link pointing at a local `/more-information` page. A click physically cannot leave localhost.
- **Migrated all automated suites** off live example.com/iana.org (~128 references across 19 files): js/async, CLI, daemon, and MCP tests, plus the Python client smoke test. The MCP click test now polls for the post-click URL instead of racing the navigation.
- **`fix(js)`: capture timeouts fire even when the action callback wedges** — capture.response/request/navigation/download/dialog/event ran `fn().then(() => promise)`, so a never-settling action blocked the capture timeout; now uses `Promise.all`.
- **Opt-in chromedriver verbose logging** via `VIBIUM_CHROMEDRIVER_LOG_DIR` (debugging aid from the freeze investigation).
- **Daemon suite drift repairs** (suite is not part of `make test`): fixed `--json` flag placement after positionals, renamed `quit` → `stop`. Remaining 3 failures there are a pre-existing product bug in `vibium start <ws-url>` remote-connect mode (issue to be filed separately).

Note: `tests/manual/webdriver-bidi-raw.js` (manual debugging script, not part of `make test`) intentionally still uses live example.com.

## Testing

Full `make test` green end-to-end three times (6m39s, 18m21s under load, plus a fresh run today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)