### PR TITLE
fix: attach to remote BiDi sessions instead of creating a second one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,10 +80,8 @@ jobs:
       # xvfb: the Python suite's headed tests need a display.
       # NODE_TEST_TIMEOUT: on Node 20, --test-timeout limits each test file,
       # not each test, and the slowest file needs ~150s.
-      # SUITE_PARALLEL: the desktop default is 2 to keep dev machines
-      # usable; under xvfb there are no visible windows, so run wider.
       - name: Test
-        run: xvfb-run --auto-servernum make test NODE_TEST_TIMEOUT=300000 SUITE_PARALLEL=4
+        run: xvfb-run --auto-servernum make test NODE_TEST_TIMEOUT=300000
 
       # In case the job is interrupted before make test's own cleanup runs.
       - name: Clean up zombie processes

--- a/Makefile
+++ b/Makefile
@@ -171,17 +171,20 @@ serve: build-go
 # caps the peak; the *_PARALLEL defaults are tuned conservatively for the same
 # reason. Bump *_PARALLEL on machines with more cores/memory.
 #
-# SUITE_PARALLEL caps how many suites the middle phase runs at once. The
-# desktop default of 1 runs suites one at a time (peak Chromes = the
-# *_PARALLEL fan-out of a single suite) so a dev machine stays usable;
-# CI overrides to 4 (see .github/workflows/test.yml).
+# SUITE_PARALLEL caps how many suites the middle phase runs at once.
+# Default 4; drop to 1 on a small machine to run suites one at a time
+# (peak Chromes = the *_PARALLEL fan-out of a single suite).
 #
 # test-browser-modes runs in its own serial phase because its tests open
 # visible Chrome windows (headed coverage is intentional — that's what
 # humans use). Inside the parallel fan-out those windows pop up all at
 # once, steal focus, and can beachball the macOS window manager, timing
 # out unrelated suites.
-SUITE_PARALLEL ?= 1
+#
+# test-daemon also runs serially: its tests start and stop the one shared
+# daemon at a fixed socket path, so any suite that auto-starts a daemon
+# alongside them would fight over it.
+SUITE_PARALLEL ?= 4
 test: build install-browser
 	@START_TIME=$$(date +%s); \
 	"$(MAKE)" test-cli test-cleanup && \
@@ -189,6 +192,7 @@ test: build install-browser
 	"$(MAKE)" -j $(SUITE_PARALLEL) test-js-async test-mcp test-python test-java && \
 	"$(MAKE)" test-cleanup && \
 	"$(MAKE)" test-browser-modes test-cleanup && \
+	"$(MAKE)" test-daemon test-cleanup && \
 	"$(MAKE)" test-js-sync; \
 	EXIT=$$?; \
 	"$(MAKE)" test-cleanup; \

--- a/clicker/cmd/clicker/daemon_client.go
+++ b/clicker/cmd/clicker/daemon_client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -83,6 +84,13 @@ func autoStartDaemon() error {
 // isConnectionError returns true if the error indicates the daemon is not running.
 func isConnectionError(err error) bool {
 	if err == nil {
+		return false
+	}
+	// The daemon answered, so it is up whatever the error says. Without this
+	// a remote browser refusing the connection reads as "connection refused"
+	// below and we auto-start a second daemon on top of the live one.
+	var toolErr *daemon.ToolError
+	if errors.As(err, &toolErr) {
 		return false
 	}
 	// Check for common connection-refused patterns

--- a/clicker/cmd/clicker/daemon_cmd.go
+++ b/clicker/cmd/clicker/daemon_cmd.go
@@ -90,23 +90,9 @@ func newDaemonStopCmd() *cobra.Command {
 				return
 			}
 
-			// Read PID before sending shutdown so we can wait for the process to exit
-			pid, _ := daemon.ReadPID()
-
-			if err := daemon.Shutdown(); err != nil {
+			if err := shutdownDaemonAndWait(); err != nil {
 				fmt.Fprintf(os.Stderr, "Error stopping daemon: %v\n", err)
 				os.Exit(1)
-			}
-
-			// Wait for the daemon process to fully exit (including Chrome cleanup)
-			if pid > 0 {
-				deadline := time.Now().Add(10 * time.Second)
-				for time.Now().Before(deadline) {
-					if !daemon.ProcessExists(pid) {
-						break
-					}
-					time.Sleep(100 * time.Millisecond)
-				}
 			}
 
 			fmt.Println("Daemon stopped.")
@@ -153,6 +139,33 @@ func newDaemonStatusCmd() *cobra.Command {
 			fmt.Printf("socket:   %s\n", status.Socket)
 		},
 	}
+}
+
+// shutdownDaemonAndWait asks the daemon to shut down and waits for the process
+// to fully exit (including Chrome cleanup). No-op if it is not running.
+func shutdownDaemonAndWait() error {
+	if !daemon.IsRunning() {
+		return nil
+	}
+
+	// Read PID before sending shutdown so we can wait for the process to exit
+	pid, _ := daemon.ReadPID()
+
+	if err := daemon.Shutdown(); err != nil {
+		return err
+	}
+
+	if pid > 0 {
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			if !daemon.ProcessExists(pid) {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	return nil
 }
 
 // resolveConnect merges CLI flags with env vars. Flags take precedence.

--- a/clicker/cmd/clicker/pipe.go
+++ b/clicker/cmd/clicker/pipe.go
@@ -114,10 +114,15 @@ func runPipe(connectURL string, connectHeaders http.Header) {
 	}
 
 	// Clean up: kill THIS process's chromedriver process tree, remove its
-	// user-data-dir, and sweep any orphaned Chrome processes.
+	// user-data-dir, and sweep any orphaned Chrome processes. Connect mode
+	// launched nothing, so it has no orphans — and the sweep matches on
+	// vibium's Chrome cache dir, which would kill a chromedriver the user
+	// started themselves on this machine and handed us the URL for.
 	router.OnClientDisconnect(client)
 	router.CloseAll()
-	browser.KillOrphanedChromeProcesses()
+	if connectURL == "" {
+		browser.KillOrphanedChromeProcesses()
+	}
 
 	protocolOut.Close()
 }

--- a/clicker/cmd/clicker/start.go
+++ b/clicker/cmd/clicker/start.go
@@ -54,22 +54,9 @@ Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.`,
 			}
 
 			// Remote connect — stop existing daemon and start fresh with --connect
-			if daemon.IsRunning() {
-				pid, _ := daemon.ReadPID()
-				if err := daemon.Shutdown(); err != nil {
-					fmt.Fprintf(os.Stderr, "Error stopping existing daemon: %v\n", err)
-					os.Exit(1)
-				}
-				// Wait for the daemon process to fully exit
-				if pid > 0 {
-					deadline := time.Now().Add(10 * time.Second)
-					for time.Now().Before(deadline) {
-						if !daemon.ProcessExists(pid) {
-							break
-						}
-						time.Sleep(100 * time.Millisecond)
-					}
-				}
+			if err := shutdownDaemonAndWait(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error stopping existing daemon: %v\n", err)
+				os.Exit(1)
 			}
 
 			daemon.CleanStale()

--- a/clicker/cmd/clicker/start.go
+++ b/clicker/cmd/clicker/start.go
@@ -97,6 +97,17 @@ Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.`,
 				os.Exit(1)
 			}
 
+			// Connect now instead of leaving it to the first command that
+			// needs a browser, so a bad URL or a dead endpoint fails here,
+			// where the user typed it. A daemon that cannot reach its
+			// endpoint is no use to the next command either — take it down
+			// rather than leave it to auto-start the same failure.
+			if _, err := daemonCall("browser_start", map[string]interface{}{}); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to connect to %s: %v\n", connectURL, err)
+				shutdownDaemonAndWait()
+				os.Exit(1)
+			}
+
 			fmt.Printf("Connected to %s (daemon pid %d)\n", connectURL, child.Process.Pid)
 		},
 	}

--- a/clicker/cmd/clicker/stop.go
+++ b/clicker/cmd/clicker/stop.go
@@ -17,6 +17,12 @@ func newStopCmd() *cobra.Command {
 				printError(err)
 				return
 			}
+			// Full teardown: a daemon left behind keeps holding the session's
+			// connect settings, so a later command would silently reuse them.
+			if err := shutdownDaemonAndWait(); err != nil {
+				printError(err)
+				return
+			}
 			printResult(result)
 		},
 	}

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -31,6 +31,7 @@ type Handlers struct {
 	headless       bool
 	connectURL     string      // remote BiDi WebSocket URL (empty = local browser)
 	connectHeaders http.Header // headers for remote WebSocket connection
+	ownsRemote     bool        // remote session was created here, so Close() ends it
 	refMap         map[string]string // @e1 -> CSS selector
 	lastMap        string            // last map output (for diff)
 	recorder       *api.Recorder
@@ -592,11 +593,15 @@ func mcpToolToMethod(name string) string {
 func (h *Handlers) Close() {
 	h.sessionMu.Lock()
 	conn, client, launchResult := h.conn, h.client, h.launchResult
+	ownsRemote := h.ownsRemote
 	h.conn, h.client, h.launchResult = nil, nil, nil
+	h.ownsRemote = false
 	h.sessionMu.Unlock()
 
-	// Remote mode: end the BiDi session so chromedriver closes Chrome
-	if h.connectURL != "" && client != nil {
+	// Remote mode: end the BiDi session so chromedriver closes Chrome. Only
+	// when this process created it — an attached session belongs to whoever
+	// handed us the URL, and ending it would close their browser.
+	if ownsRemote && client != nil {
 		client.SendCommand("session.end", map[string]interface{}{})
 	}
 	if conn != nil {
@@ -621,19 +626,24 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 
 	// Remote browser connect mode
 	if h.connectURL != "" {
-		conn, client, sessionID, err := bidi.ConnectRemote(h.connectURL, h.connectHeaders)
+		conn, client, session, err := bidi.ConnectRemote(h.connectURL, h.connectHeaders)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to remote browser: %w", err)
 		}
 		h.sessionMu.Lock()
 		h.conn = conn
 		h.client = client
+		h.ownsRemote = session.Created
 		h.sessionMu.Unlock()
 
+		verb := "Attached to"
+		if session.Created {
+			verb = "Connected to"
+		}
 		return &ToolsCallResult{
 			Content: []Content{{
 				Type: "text",
-				Text: fmt.Sprintf("Connected to remote browser at %s (session %s)", h.connectURL, sessionID),
+				Text: fmt.Sprintf("%s remote browser at %s (session %s)", verb, h.connectURL, session.ID),
 			}},
 		}, nil
 	}

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -22,6 +22,7 @@ type BrowserSession struct {
 	LaunchResult *browser.LaunchResult
 	BidiConn     *bidi.Connection
 	Client       ClientTransport
+	ownsRemote   bool // remote session was created here, so closeSession ends it
 	mu           sync.Mutex
 	closed       bool
 	stopChan     chan struct{}
@@ -96,6 +97,7 @@ func NewRouter(headless bool, connectURL string, connectHeaders http.Header) *Ro
 func (r *Router) OnClientConnect(client ClientTransport) {
 	var launchResult *browser.LaunchResult
 	var bidiConn *bidi.Connection
+	var ownsRemoteSession bool
 	var err error
 
 	if r.connectURL != "" {
@@ -106,8 +108,11 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		// itself in routeBrowserToClient, so no client reader may own it.
 		bidiConn, err = bidi.ConnectWithHeaders(r.connectURL, r.connectHeaders)
 		if err == nil {
-			if _, err = bidi.SessionNewOnConn(bidiConn, map[string]interface{}{}); err != nil {
+			var session *bidi.RemoteSession
+			if session, err = bidi.AttachOrNewSessionOnConn(bidiConn, r.connectURL, map[string]interface{}{}); err != nil {
 				bidiConn.Close()
+			} else {
+				ownsRemoteSession = session.Created
 			}
 		}
 		if err != nil {
@@ -156,6 +161,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		LaunchResult:   launchResult,
 		BidiConn:       bidiConn,
 		Client:         client,
+		ownsRemote:     ownsRemoteSession,
 		stopChan:       make(chan struct{}),
 		internalCmds:   make(map[int]chan json.RawMessage),
 		nextInternalID: 1000000, // Start at high number to avoid collision with client IDs
@@ -928,10 +934,12 @@ func (r *Router) closeSession(session *BrowserSession) {
 		session.recorder.StopScreenshots()
 	}
 
-	// Remote mode: end the BiDi session so chromedriver closes Chrome.
+	// Remote mode: end the BiDi session so chromedriver closes Chrome — but
+	// only one we created. An attached session belongs to whoever handed us
+	// the URL, and ending it would close their browser.
 	// stopChan is already closed, so this sends the command and returns
 	// without waiting for the response; the connection is closed next anyway.
-	if r.connectURL != "" && session.BidiConn != nil {
+	if session.ownsRemote && session.BidiConn != nil {
 		r.sendInternalCommandWithTimeout(session, "session.end", map[string]interface{}{}, 5*time.Second)
 	}
 

--- a/clicker/internal/bidi/connect.go
+++ b/clicker/internal/bidi/connect.go
@@ -4,38 +4,111 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
-// ConnectRemote connects to a remote BiDi endpoint, creates a client,
-// and establishes a session. Returns the connection, client, and session ID.
-// The returned client owns all reads on the connection; callers that need to
-// read the connection themselves must use SessionNewOnConn instead.
-func ConnectRemote(url string, headers http.Header) (*Connection, *Client, string, error) {
+// RemoteSession describes the session a remote connect ended up using.
+type RemoteSession struct {
+	ID string // empty when attached to a session the endpoint does not name
+
+	// Created reports whether this process created the session. Only its
+	// creator may end it — attaching and then sending session.end would
+	// destroy a browser the caller merely borrowed.
+	Created bool
+}
+
+// ConnectRemote connects to a remote BiDi endpoint, creates a client, and
+// establishes a session. The returned client owns all reads on the connection;
+// callers that need to read the connection themselves must use
+// AttachOrNewSessionOnConn instead.
+func ConnectRemote(url string, headers http.Header) (*Connection, *Client, *RemoteSession, error) {
 	conn, err := ConnectWithHeaders(url, headers)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, nil, err
 	}
 
 	client := NewClient(conn)
 
+	// An endpoint that already carries a session rejects session.new with
+	// "session not created" (spec: remote end steps for session.new, step 1).
+	// Attach to that session instead of trying to create a second one.
+	if status, err := client.SessionStatus(); err == nil && !status.Ready {
+		return conn, client, &RemoteSession{ID: SessionIDFromURL(url)}, nil
+	}
+
 	result, err := client.SessionNew(map[string]interface{}{})
 	if err != nil {
 		conn.Close()
-		return nil, nil, "", err
+		return nil, nil, nil, err
 	}
 
-	return conn, client, result.SessionID, nil
+	return conn, client, &RemoteSession{ID: result.SessionID, Created: true}, nil
 }
 
-// SessionNewOnConn performs the session.new handshake with direct reads on a
-// connection that has no Client attached. Callers that will own reads on the
+// AttachOrNewSessionOnConn performs the session handshake with direct reads on
+// a connection that has no Client attached. Callers that will own reads on the
 // connection afterward (like the api router) use this instead of NewClient,
 // whose reader goroutine keeps the socket for the connection's lifetime.
+func AttachOrNewSessionOnConn(conn *Connection, endpoint string, capabilities map[string]interface{}) (*RemoteSession, error) {
+	// See ConnectRemote: an endpoint that already carries a session (a
+	// chromedriver webSocketUrl, a Selenium Grid /se/bidi URL) reports
+	// ready:false and cannot create a second one — attach to it instead.
+	var status SessionStatusResult
+	if raw, err := commandOnConn(conn, "session.status", map[string]interface{}{}); err == nil {
+		if err := json.Unmarshal(raw, &status); err == nil && !status.Ready {
+			return &RemoteSession{ID: SessionIDFromURL(endpoint)}, nil
+		}
+	}
+
+	result, err := SessionNewOnConn(conn, capabilities)
+	if err != nil {
+		return nil, err
+	}
+	return &RemoteSession{ID: result.SessionID, Created: true}, nil
+}
+
+// SessionNewOnConn creates a session with direct reads on a connection that has
+// no Client attached. Only for endpoints known to have no session yet (a
+// freshly launched chromedriver); use AttachOrNewSessionOnConn for user-supplied
+// endpoints, which may already carry one.
 func SessionNewOnConn(conn *Connection, capabilities map[string]interface{}) (*SessionNewResult, error) {
-	cmd := NewCommand("session.new", map[string]interface{}{
+	raw, err := commandOnConn(conn, "session.new", map[string]interface{}{
 		"capabilities": capabilities,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	var result SessionNewResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse session.new result: %w", err)
+	}
+	return &result, nil
+}
+
+// SessionIDFromURL extracts the WebDriver session ID from a BiDi endpoint URL
+// such as ws://host:9515/session/<id> or a Selenium Grid
+// ws://host:4444/session/<id>/se/bidi. Returns "" when the URL names no session.
+func SessionIDFromURL(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for i, p := range parts {
+		if p == "session" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
+}
+
+// commandOnConn sends one command and waits for its response with direct reads
+// on a connection that has no Client attached.
+func commandOnConn(conn *Connection, method string, params map[string]interface{}) (json.RawMessage, error) {
+	cmd := NewCommand(method, params)
 
 	data, err := cmd.Marshal()
 	if err != nil {
@@ -72,12 +145,8 @@ func SessionNewOnConn(conn *Connection, capabilities map[string]interface{}) (*S
 			return nil, err
 		}
 
-		var result SessionNewResult
-		if err := json.Unmarshal(msg.Result, &result); err != nil {
-			return nil, fmt.Errorf("failed to parse session.new result: %w", err)
-		}
-		return &result, nil
+		return msg.Result, nil
 	}
 
-	return nil, fmt.Errorf("timeout waiting for response to session.new after %s", defaultCommandTimeout)
+	return nil, fmt.Errorf("timeout waiting for response to %s after %s", method, defaultCommandTimeout)
 }

--- a/clicker/internal/bidi/connect_test.go
+++ b/clicker/internal/bidi/connect_test.go
@@ -1,0 +1,23 @@
+package bidi
+
+import "testing"
+
+func TestSessionIDFromURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"ws://127.0.0.1:9515/session/6ee2c5b3676daef013c740110218097c", "6ee2c5b3676daef013c740110218097c"},
+		{"ws://localhost:4444/session/04f89ffbe4a92b5178448328f3fa5618/se/bidi", "04f89ffbe4a92b5178448328f3fa5618"},
+		{"wss://cloud.example.com/session/abc123/", "abc123"},
+		{"ws://localhost:9515/session", ""},
+		{"wss://cloud.example.com/bidi", ""},
+		{"://not a url", ""},
+	}
+
+	for _, tt := range tests {
+		if got := SessionIDFromURL(tt.url); got != tt.want {
+			t.Errorf("SessionIDFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}

--- a/clicker/internal/daemon/client.go
+++ b/clicker/internal/daemon/client.go
@@ -15,6 +15,16 @@ const (
 	readTimeout = 60 * time.Second
 )
 
+// ToolError is an error the daemon itself reported. It means the daemon was
+// reached and answered, so callers must not mistake it for the daemon being
+// down — a remote browser refusing a connection produces error text that
+// looks exactly like an unreachable daemon socket.
+type ToolError struct {
+	Msg string
+}
+
+func (e *ToolError) Error() string { return e.Msg }
+
 // Call sends a tools/call request to the daemon and returns the result.
 func Call(toolName string, args map[string]interface{}) (*agent.ToolsCallResult, error) {
 	params := agent.ToolsCallParams{
@@ -33,7 +43,7 @@ func Call(toolName string, args map[string]interface{}) (*agent.ToolsCallResult,
 	}
 
 	if resp.Error != nil {
-		return nil, fmt.Errorf("daemon error: %s", resp.Error.Message)
+		return nil, &ToolError{Msg: fmt.Sprintf("daemon error: %s", resp.Error.Message)}
 	}
 
 	// Parse the result as ToolsCallResult
@@ -49,9 +59,9 @@ func Call(toolName string, args map[string]interface{}) (*agent.ToolsCallResult,
 
 	if result.IsError {
 		if len(result.Content) > 0 {
-			return nil, fmt.Errorf("%s", result.Content[0].Text)
+			return nil, &ToolError{Msg: result.Content[0].Text}
 		}
-		return nil, fmt.Errorf("tool call failed")
+		return nil, &ToolError{Msg: "tool call failed"}
 	}
 
 	return &result, nil

--- a/docs/tutorials/remote-browser.md
+++ b/docs/tutorials/remote-browser.md
@@ -55,6 +55,8 @@ vibium title
 vibium stop
 ```
 
+Both endpoint shapes work: a browser-level URL like `ws://host:9515/session` (vibium creates the session) and a URL for a session that already exists, such as a chromedriver `webSocketUrl` or a Selenium Grid `ws://host:4444/session/<id>/se/bidi` (vibium attaches to it).
+
 ### MCP Server
 
 The MCP server reads the same env vars, so AI agents can use a remote browser:


### PR DESCRIPTION
Fixes #240, fixes #159.

## The bug

`bidi.ConnectRemote` unconditionally sent `session.new`. An endpoint that already carries a session must reject that (BiDi spec, remote end steps for `session.new` step 1). Against a live chromedriver:

| endpoint | `session.status` | `session.new` |
|---|---|---|
| `ws://host:9515/session` | `ready:true` | succeeds |
| `ws://host:9515/session/<id>` | `ready:false`, "already connected" | `session not created` |

The connection works fine without `session.new` — vibium was asking the wrong question. #159 hits the same thing through a Grid `/session/<id>/se/bidi` URL.

It presents as a dead daemon because the connect is lazy: `vibium start <ws-url>` prints `Connected to` after merely spawning the daemon, and the failure lands on the next command as `auto-launch failed`.

## The fix

Probe `session.status`; attach if the endpoint already has a session, create one otherwise. Both connect paths — `bidi.ConnectRemote` (daemon/MCP) and `bidi.AttachOrNewSessionOnConn` (pipe, via `internal/api/router.go`).

Attaching means vibium no longer owns the browser, which exposed two teardown paths that assumed it did:

- **`session.end` on close** — ends a session vibium didn't create. Gated on a new `ownsRemote` flag.
- **`KillOrphanedChromeProcesses` on pipe shutdown** — `pgrep`s for anything running from vibium's Chrome cache dir and kills it, process group first. Connect mode launched nothing, so it has no orphans; but it kills a chromedriver the user started themselves from that same dir, which is what `docs/tutorials/remote-browser.md` tells them to run. Skipped when `--connect` is set. `vibium serve` is always local and still sweeps.

Measured, vibium attaching to a session it didn't create then receiving SIGTERM:

```
before: chromedriver DOWN (ECONNREFUSED) -> session GONE
after:  chromedriver UP                  -> session ALIVE
```

A plain WebSocket doing the same attach-and-close leaves everything up, which is what pinned it on vibium.

## Also here

- **`vibium stop` now stops the daemon**, as its help text already claimed. It previously closed the browser session and left the daemon running — in local mode too. A lingering connect-mode daemon silently routes later commands to the remote browser.
- **`test-daemon` is now part of `make test`**, in the serial phase. It was outside the suite, which is how three failing connect tests went unnoticed. Serial is required: those tests start and stop the one shared daemon at a fixed socket path.
- **`SUITE_PARALLEL` defaults to 4** (was 1); the now-redundant CI override is dropped.

## Eager connect

`vibium start <ws-url>` printed `Connected to` once the daemon socket came up, without connecting to anything — the connect was deferred to the first command that needed a browser, so a dead URL reported success and failed one command later as `auto-launch failed`. It now calls `browser_start` once the socket is up, and on failure reports the error and takes the daemon down rather than leaving one that would auto-start the same failure:

```
$ vibium start ws://127.0.0.1:59999/session --headless
Failed to connect to ws://127.0.0.1:59999/session: ... connect: connection refused
exit=1        daemons left: 0
```

That exposed a second bug. `daemonCall` decides whether to auto-start a daemon by substring-matching the error text for `"connection refused"` — and a remote browser refusing the connection produces exactly that text, so the CLI concluded its own daemon was down and spawned a second one on top of the live one. This fires on any command against an unreachable remote endpoint, not just `start`.

Fixed at the source rather than by tweaking substrings: `daemon.Call` returns a typed `*daemon.ToolError` when the daemon answered and reported an error, and `isConnectionError` returns false for it. Reaching the daemon and getting an error back is not the same as not reaching it.

## Verification

- `make test` green at 18m2s with the daemon suite included (13m13s before adding it).
- `make test-daemon` 48/48; `connect.test.js` 5/5, previously 3 failing.
- New `SessionIDFromURL` unit test covering the chromedriver and Grid URL shapes.
- `vibium pipe --connect` driven end-to-end against both endpoint shapes — browser-level (creates) and per-session (attaches).
- Full CLI path against a real chromedriver session: `start` attaches, `go`/`title` work, `stop` closes the session and daemon, and the user's chromedriver is still up afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
