### PR TITLE
Harden browser launch: sweep orphaned temp dirs, bound two unbounded waits

### DIFF
--- a/clicker/cmd/clicker/daemon_cmd.go
+++ b/clicker/cmd/clicker/daemon_cmd.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/vibium/clicker/internal/browser"
 	"github.com/vibium/clicker/internal/daemon"
 	"github.com/vibium/clicker/internal/paths"
 )
@@ -203,6 +204,10 @@ func resolveConnect(connectFlag string, headerFlags []string) (string, http.Head
 func runDaemonForeground(idleTimeout time.Duration, connectFlag string, headerFlags []string) {
 	// Clean stale files from a previous crash
 	daemon.CleanStale()
+
+	// Reclaim Chrome profile dirs orphaned by earlier crashed/killed sessions
+	// (parallel-safe: the minAge filter skips any live sibling's dir).
+	browser.CleanupOrphanedChromeTempDirs(time.Minute)
 
 	if daemon.IsRunning() {
 		fmt.Fprintln(os.Stderr, "Daemon is already running.")

--- a/clicker/cmd/clicker/pipe.go
+++ b/clicker/cmd/clicker/pipe.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/vibium/clicker/internal/api"
@@ -64,6 +65,12 @@ func runPipe(connectURL string, connectHeaders http.Header) {
 	// Redirect os.Stdout to stderr so any stray fmt.Print / log output
 	// doesn't corrupt the protocol stream.
 	os.Stdout = os.Stderr
+
+	// Reclaim Chrome profile dirs orphaned by earlier crashed/killed sessions.
+	// A clean shutdown removes a session's own dir, but any hard kill (crash,
+	// test timeout, `make test`'s pkill -9) leaks it, and nothing swept them.
+	// Parallel-safe: the minAge filter never touches a live sibling's dir.
+	browser.CleanupOrphanedChromeTempDirs(time.Minute)
 
 	router := api.NewRouter(headless, connectURL, connectHeaders)
 	client := api.NewPipeClientConn(protocolOut)

--- a/clicker/cmd/clicker/serve.go
+++ b/clicker/cmd/clicker/serve.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/vibium/clicker/internal/browser"
 	"github.com/vibium/clicker/internal/api"
+	"github.com/vibium/clicker/internal/browser"
 )
 
 func newServeCmd() *cobra.Command {
@@ -29,6 +29,10 @@ func newServeCmd() *cobra.Command {
 			port, _ := cmd.Flags().GetInt("port")
 
 			fmt.Printf("Starting Vibium proxy server on port %d...\n", port)
+
+			// Reclaim Chrome profile dirs orphaned by earlier crashed/killed
+			// sessions (parallel-safe: the minAge filter skips live siblings).
+			browser.CleanupOrphanedChromeTempDirs(time.Minute)
 
 			// Create router to manage browser sessions
 			router := api.NewRouter(headless, "", nil)

--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -19,6 +19,10 @@ import (
 	"github.com/vibium/clicker/internal/process"
 )
 
+// sessionCreateTimeout bounds the HTTP POST /session fallback (Chrome cold
+// launch ~16s) so a wedged chromedriver can't hang it indefinitely.
+const sessionCreateTimeout = 30 * time.Second
+
 // prefixWriter wraps an io.Writer and prepends a prefix to each line.
 type prefixWriter struct {
 	w      io.Writer
@@ -274,9 +278,9 @@ func buildCapabilities(chromePath string, headless bool) map[string]interface{} 
 				"args":            chromeArgs(headless),
 				"excludeSwitches": []string{"enable-automation", "enable-logging"},
 				"prefs": map[string]interface{}{
-					"credentials_enable_service":                          false,
-					"profile.password_manager_enabled":                    false,
-					"profile.password_manager_leak_detection":             false,
+					"credentials_enable_service":                           false,
+					"profile.password_manager_enabled":                     false,
+					"profile.password_manager_leak_detection":              false,
 					"profile.default_content_setting_values.notifications": 2,
 				},
 			},
@@ -300,7 +304,10 @@ func createSession(baseURL, chromePath string, headless, verbose bool) (string, 
 		fmt.Printf("       --> %s\n", string(jsonBody))
 	}
 
-	resp, err := http.Post(baseURL+"/session", "application/json", bytes.NewReader(jsonBody))
+	// Bounded so a wedged chromedriver can't hang the HTTP fallback forever.
+	// session.new + Chrome cold-launch fit comfortably within this.
+	httpClient := &http.Client{Timeout: sessionCreateTimeout}
+	resp, err := httpClient.Post(baseURL+"/session", "application/json", bytes.NewReader(jsonBody))
 	if err != nil {
 		return "", "", "", err
 	}
@@ -477,4 +484,3 @@ func CleanupOrphanedChromeTempDirs(minAge time.Duration) {
 		log.Debug("cleaned up orphaned Chrome temp dirs", "count", count, "minAge", minAge)
 	}
 }
-

--- a/clients/python/src/vibium/binary.py
+++ b/clients/python/src/vibium/binary.py
@@ -18,6 +18,11 @@ from .errors import VibiumNotFoundError, BrowserCrashedError
 # past, raising LimitOverrunError and killing the receiver loop (issue #110).
 _STREAM_LIMIT = 256 * 1024 * 1024  # 256 MiB
 
+# Overall wall-clock budget (seconds) for one launch attempt's ready signal.
+# The per-read timeout alone can be reset forever by dribbled pre-ready output,
+# so a stuck launch could hang far past it; this bounds the whole attempt.
+_READY_TIMEOUT = 60
+
 
 async def _drain_stderr(process) -> None:
     """Continuously read the subprocess's stderr so the pipe never fills.
@@ -235,12 +240,19 @@ class VibiumProcess:
             )
 
             # Events (e.g. browsingContext.contextCreated) may arrive first.
+            # Bound the whole wait with a wall-clock deadline, not just per-read:
+            # vibium forwards pre-ready events, so a per-read timeout can be
+            # reset indefinitely by dribbled output while `ready` never arrives.
             pre_ready_lines = []
+            deadline = asyncio.get_running_loop().time() + _READY_TIMEOUT
             try:
                 while True:
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        raise asyncio.TimeoutError
                     line_bytes = await asyncio.wait_for(
                         process.stdout.readline(),  # type: ignore[union-attr]
-                        timeout=30,
+                        timeout=remaining,
                     )
                     if not line_bytes:
                         # EOF — process died


### PR DESCRIPTION
Three small, independent bug fixes for "could hang / leak forever" issues on the browser-launch path. Each is its own commit.

### 1. Sweep orphaned Chrome temp dirs at startup
`CleanupOrphanedChromeTempDirs` existed but was **never called**, so Chrome profile dirs leaked whenever a session was hard-killed (crash, test timeout, `make test`'s own `pkill -9`) instead of shut down cleanly. Wired into the `pipe`, `serve`, and `daemon` entry points at startup. Parallel-safe: the `minAge` filter never removes a live sibling's dir.

### 2. Bound the HTTP `POST /session` fallback
`createSession` used `http.Post` with **no timeout**, so a wedged chromedriver could hang the fallback indefinitely. Now uses an `http.Client{Timeout: 30s}`. Only affects the rare HTTP fallback path; the normal BiDi launch is untouched.

### 3. Bound the Python client's ready-signal wait
The startup loop had only a per-readline 30s timeout and **no overall bound**, so `browser.start()` could hang far past 30s if vibium dribbled pre-ready output. Adds a 60s wall-clock deadline across the whole wait.

### Verification
- Go build clean, gofmt-clean, Python syntax OK.
- Real headless `start → navigate → title → stop` works; the sweep removes a stale dir and preserves a live one.

### Note
These are correctness/hardening fixes surfaced while investigating the intermittent `make test` launch wedge. They do **not** cure that wedge — evidence points to a chromedriver/Chrome-for-Testing stall under sustained load (reducing launch count didn't help), which is a separate follow-up.