### PR TITLE
Add VM_FAST_LAUNCH to skip the dead-GPU Metal stall in macOS VMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
   endif
 endif
 
-.PHONY: all build build-go build-js build-go-all package package-js package-python install-browser deps clean clean-go clean-js clean-npm-packages clean-python-packages clean-packages clean-cache clean-all serve test test-go test-cli test-js test-js-async test-js-sync test-js-process test-mcp test-daemon test-python python-venv test-browser-modes test-java test-cleanup double-tap get-version set-version build-java package-java publish-java clean-java jshell help
+.PHONY: all build build-go build-js build-go-all package package-js package-python install-browser deps clean clean-go clean-js clean-npm-packages clean-python-packages clean-packages clean-cache clean-all serve test test-go test-cli test-js test-js-async test-js-sync test-js-process test-mcp test-daemon test-python python-venv test-browser-modes test-java test-cleanup mtlshim double-tap get-version set-version build-java package-java publish-java clean-java jshell help
 
 # Version from VERSION file
 # Note: GnuWin32 Make 3.81 runs $(shell) via CreateProcess, not SHELL,
@@ -187,7 +187,24 @@ serve: build-go
 # daemon at a fixed socket path, so any suite that auto-starts a daemon
 # alongside them would fight over it.
 SUITE_PARALLEL ?= 4
-test: build install-browser
+
+# macOS VM guests with a dead virtual GPU pay ~15s per Chrome launch.
+# VM_FAST_LAUNCH=1 builds a Metal shim and points vibium at it. Probe first.
+# See docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
+MTLSHIM := $(CURDIR)/clicker/bin/mtlshim.dylib
+ifeq ($(VM_FAST_LAUNCH),1)
+ifeq ($(UNAME_S),Darwin)
+FAST_LAUNCH_DEP := mtlshim
+export VIBIUM_VM_FAST_LAUNCH := $(MTLSHIM)
+endif
+endif
+
+mtlshim:
+	@mkdir -p $(dir $(MTLSHIM))
+	clang -fno-objc-arc -dynamiclib -framework Metal -framework Foundation \
+		-o $(MTLSHIM) scripts/mtlshim.m
+
+test: build install-browser $(FAST_LAUNCH_DEP)
 	@START_TIME=$$(date +%s); \
 	"$(MAKE)" test-go && \
 	"$(MAKE)" test-cli test-cleanup && \
@@ -506,6 +523,8 @@ help:
 	@echo "  make test-python           - Run Python client tests"
 	@echo "  make test-browser-modes    - Run headed browser-mode tests (JS + Python, serial)"
 	@echo "  make test-java             - Run Java client tests"
+	@echo "  make test VM_FAST_LAUNCH=1 - macOS VM only: skip the ~15s dead-GPU"
+	@echo "                               stall on every Chrome launch"
 	@echo ""
 	@echo "Other:"
 	@echo "  make install-browser       - Install Chrome for Testing"

--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -133,6 +134,10 @@ func Launch(opts LaunchOptions) (*LaunchResult, error) {
 	}
 	cmd := exec.Command(chromedriverPath, cdArgs...)
 	setProcGroup(cmd)
+	// Set here, not around `make`: macOS strips DYLD_* across SIP-protected execs.
+	if shim := vmFastLaunchShim(); shim != "" {
+		cmd.Env = append(os.Environ(), "DYLD_INSERT_LIBRARIES="+shim)
+	}
 	if opts.Verbose {
 		fmt.Println("       ------- chromedriver -------")
 		pw := newPrefixWriter(os.Stdout, "       ")
@@ -262,6 +267,16 @@ func chromeArgs(headless bool) []string {
 		args = append(args, "--headless=new")
 	}
 	return args
+}
+
+// vmFastLaunchShim returns a Metal-interposing dylib path for macOS VM guests
+// whose dead virtual GPU adds ~15s to every Chrome launch. Opt-in, darwin-only.
+// See docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
+func vmFastLaunchShim() string {
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
+	return os.Getenv("VIBIUM_VM_FAST_LAUNCH")
 }
 
 // buildCapabilities returns the capabilities map for BiDi session.new.

--- a/docs/how-to-guides/local-dev-setup-mac.md
+++ b/docs/how-to-guides/local-dev-setup-mac.md
@@ -24,6 +24,10 @@ Before starting, check the [system requirements](../reference/mac-system-require
 
 Assuming macOS VM dev on macOS (via UTM).
 
+If `make test` takes ~18 minutes instead of ~6, see
+[Slow Chrome Launch in a macOS VM](slow-chrome-launch-in-macos-vm.md) — a
+broken virtual GPU adds ~15s to every Chrome launch.
+
 ## Install UTM (on host)
 
 - Install UTM on your host Mac

--- a/docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
+++ b/docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
@@ -1,0 +1,240 @@
+# Slow Chrome Launch in a macOS VM
+
+On a macOS guest whose virtual GPU doesn't work, **every Chrome launch costs an
+extra ~15 seconds**. Since `make test` launches Chrome ~120 times, this is the
+difference between a ~6 minute suite and an ~18 minute one.
+
+This guide explains the cause, how to confirm you're affected, and an opt-in
+workaround. It applies only to VM guests with a broken/absent GPU — on real
+hardware, and on CI, none of this is relevant.
+
+## Symptom
+
+Every browser-owning test file takes a flat ~16–20s regardless of what it
+asserts, while test files that reuse an already-open browser run in 1–5s.
+
+## Confirming it
+
+The stall is not in Chrome, chromedriver, or vibium. It reproduces with a
+four-line Metal program:
+
+```objc
+#import <Metal/Metal.h>
+#import <stdio.h>
+#import <sys/time.h>
+static double now(){struct timeval t;gettimeofday(&t,0);return t.tv_sec+t.tv_usec/1e6;}
+int main(){
+  double s=now();
+  NSArray<id<MTLDevice>> *d = MTLCopyAllDevices();
+  printf("MTLCopyAllDevices: %.2fs (%lu devices)\n", now()-s, (unsigned long)[d count]);
+  return 0;
+}
+```
+
+```bash
+clang -fobjc-arc -framework Metal -framework Foundation -o /tmp/mtl /tmp/mtl.m
+/tmp/mtl
+```
+
+Affected guest:
+
+```
+MTLCopyAllDevices: 15.01s (0 devices)
+```
+
+Healthy machine: well under a second, with at least one device.
+
+## Cause
+
+Chrome — even headless — creates an AppKit `NSWindow`, which makes macOS
+enumerate Metal GPU devices:
+
+```
+NSWindow initWithContentRect:  (AppKit)
+  -> _NXCreateWindow -> NSCGSWindow _createContext
+    -> MTLCopyAllDevices  (Metal)
+      -> MTLIOAccelService initWithAcceleratorPort:
+        -> AppleParavirtGPUMetalIOGPUFamily
+          -> IOGPUDeviceCreateWithOptions -> IOServiceOpen
+            -> mach_msg2_trap            <- blocked ~15s
+```
+
+The guest advertises an `AppleParavirtGPU` IOService that never answers.
+`IOServiceOpen` blocks for a fixed ~15s, then fails with
+`kIOReturnUnsupported` (`0xE00002C7`) and reports zero devices. The kext is
+loaded but matched nothing (`kextstat` shows refcount 0), and
+`system_profiler SPDisplaysDataType` is empty.
+
+Chrome then proceeds correctly with no GPU. **The 15s buys nothing** — it is
+purely the time taken to discover there is no GPU.
+
+### What does not fix it
+
+Checked and ruled out, all still ~16.6s:
+
+- `--disable-gpu`, `--headless=old`, `--use-gl=disabled`, `--in-process-gpu`
+  alone, `--use-angle=swiftshader` (`--use-angle=metal` is worse, ~31s)
+- Switching VM host apps. UTM's Apple backend already *is*
+  Virtualization.framework; `VZMacGraphicsDeviceConfiguration` exposes only
+  display geometry, with no GPU flag for another app to set differently.
+- UTM settings. There is no GPU toggle for macOS guests
+  ([utmapp/UTM#5785](https://github.com/utmapp/UTM/issues/5785)), and the
+  display view is already correctly attached.
+- Unloading the unused kext so Metal fails fast — blocked by SIP.
+
+## Workaround
+
+A `DYLD_INSERT_LIBRARIES` dylib that short-circuits Metal device lookup:
+
+| Configuration | Launch |
+| --- | --- |
+| baseline | 16.6s |
+| shim covering 2 entry points | 15.3s |
+| **shim covering all 3 entry points** | **1.7s** |
+
+Three entry points must be covered, not two. The browser process reaches the
+dead driver through `MTLCopyAllDevices` / `MTLCreateSystemDefaultDevice`, but
+Chrome's **GPU process** uses `MTLCopyAllDevicesWithObserver`. Miss that one
+and the GPU process still stalls ~15s, holding up the browser behind it.
+
+Do **not** reach for Chrome process-model flags to work around a missed entry
+point. `--in-process-gpu` hides the GPU-process stall and appears to work, but
+it collapses the GPU service into the browser process — so any GPU stall wedges
+the browser, and CLI commands start timing out mid-suite. `--single-process`
+is worse still. Cover the entry point instead.
+
+### The shim
+
+```objc
+// Short-circuit Metal device lookup in VMs whose paravirt GPU makes it block
+// ~15s before reporting no GPU anyway. Same result, without the wait.
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+static NSArray *shim_MTLCopyAllDevices(void) {
+  return [[NSArray alloc] init];        // +1, matching the Copy convention
+}
+static id<MTLDevice> shim_MTLCreateSystemDefaultDevice(void) {
+  return nil;                            // what it returns anyway, 15s sooner
+}
+
+#define INTERPOSE(_new, _old)                                                  \
+  __attribute__((used)) static struct { const void *r; const void *o; }        \
+  _interpose_##_old __attribute__((section("__DATA,__interpose"))) = {         \
+    (const void *)(uintptr_t)&_new, (const void *)(uintptr_t)&_old };
+
+INTERPOSE(shim_MTLCopyAllDevices, MTLCopyAllDevices)
+INTERPOSE(shim_MTLCreateSystemDefaultDevice, MTLCreateSystemDefaultDevice)
+```
+
+```bash
+clang -fno-objc-arc -dynamiclib -framework Metal -framework Foundation \
+  -o /tmp/mtlshim.dylib /tmp/mtlshim.m
+```
+
+Both replaced functions return exactly what the real ones return on an
+affected guest — an empty array and `nil`. The shim changes *when* Chrome gets
+that answer, not *what* the answer is. Verify with the probe above before
+trusting it: if `MTLCopyAllDevices` reports any devices, the shim is a lie and
+must not be used.
+
+### What actually happens, in order
+
+The shim launches nothing. It has no `main()` and no process-spawning code —
+it is passive cargo, unrelated to vibium, and not Chrome-specific. vibium still
+does all the launching:
+
+```
+vibium (Go) --spawns--> chromedriver --spawns--> Chrome
+                                                   |
+                                    dyld loads mtlshim.dylib into it
+                                    ONLY IF DYLD_INSERT_LIBRARIES is set
+```
+
+1. Something sets `DYLD_INSERT_LIBRARIES=/tmp/mtlshim.dylib` in the environment.
+2. Chrome gets spawned — by chromedriver, by vibium, or from a shell.
+3. **dyld** (macOS's dynamic linker, not the shim) sees the variable while
+   loading Chrome and maps `mtlshim.dylib` into Chrome's address space.
+4. dyld rewrites two symbol bindings, via the `__DATA,__interpose` section, so
+   Metal calls land on the shim's functions.
+5. Chrome runs normally. When its window setup calls `MTLCopyAllDevices()`, it
+   gets `[]` immediately instead of after 15s.
+6. Chrome exits; the shim goes with it.
+
+The shim's code runs only if something calls those two functions. Otherwise it
+sits inert.
+
+### Using it
+
+Measured on an affected guest, running the process suite directly:
+
+```bash
+DYLD_INSERT_LIBRARIES=/tmp/mtlshim.dylib VIBIUM_VM_FAST_LAUNCH=1 \
+  node --test --test-timeout=30000 --test-force-exit --test-concurrency=1 \
+  tests/js/async/process.test.js tests/js/sync/process.test.js
+```
+
+91s -> 16s, all tests passing. A full vibium launch (`vibium bidi-test`,
+covering chromedriver startup and the BiDi handshake) goes 18.1s -> 3.1s.
+
+**Exporting the variable and running `make` does not work.** macOS strips
+`DYLD_*` when exec'ing a SIP-protected binary, and make runs every recipe
+through `/bin/sh`:
+
+```bash
+# stripped — sh is exec'd with the variable already set
+DYLD_INSERT_LIBRARIES=/tmp/mtlshim.dylib sh -c 'node -e "..."'   # (STRIPPED)
+
+# survives — sh sets it for its child, and node is ad-hoc signed
+sh -c 'DYLD_INSERT_LIBRARIES=/tmp/mtlshim.dylib node -e "..."'   # /tmp/mtlshim.dylib
+```
+
+So it has to be assigned *inline on the command* inside the recipe, the same
+way the Makefile already passes `VIBIUM_BIN_PATH`. Setting it on the Chrome
+`exec.Cmd` in `clicker/internal/browser/launcher.go` avoids the problem
+entirely and is narrower besides.
+
+## Cautions
+
+- **Never enable on real hardware.** Where a GPU exists, the shim doesn't
+  shortcut to the same answer — it hides the GPU, which would break rendering
+  and mask genuine GPU behavior. It is correct *only* because this guest has no
+  working GPU.
+- **Never ship it.** It must not reach published binaries or packages. vibium
+  does nothing unless `VIBIUM_VM_FAST_LAUNCH` points at a dylib, so this is
+  opt-in by construction.
+- **Decide by probe, not by environment.** The criterion is whether
+  `MTLCopyAllDevices` is slow and reports zero devices *on that machine* — not
+  whether it's a laptop or CI. Today's CI is Linux, where the flag is inert and
+  the shim irrelevant. If macOS CI is added later, run the probe on the runner:
+  if it's affected, enabling this is legitimate and buys the same ~3x.
+- **Chrome's process model is unchanged**, so local runs exercise the same
+  topology as CI and as users. Keep it that way: if a stall reappears, extend
+  the shim to cover the entry point rather than reaching for a flag that
+  restructures Chrome's processes.
+- **Environment variables inherit down the whole process tree.** Exporting
+  `DYLD_INSERT_LIBRARIES` before `make test` loads the dylib into node, python,
+  the Go binary, chromedriver, and the JVMs too. Harmless — none of them call
+  Metal — but wider than the problem needs. Setting it on just the Chrome
+  `exec.Cmd` in `clicker/internal/browser/launcher.go` is the surgical option.
+- **Coverage is enumerated, not general.** Three entry points are interposed.
+  If a future Chrome or macOS reaches the driver another way, launches go slow
+  again — sample the stalled process to find the new entry point and add it.
+- **Unsupported territory.** Interposing framework internals isn't a contract
+  Apple maintains. A macOS update could change which entry point is hit first
+  and the shim would silently stop helping. The failure mode is benign — slow
+  launches return, nothing breaks.
+- `DYLD_INSERT_LIBRARIES` works here only because Chrome for Testing is
+  ad-hoc/linker-signed with no hardened runtime (`codesign -dv` shows
+  `flags=0x20002`). A hardened-runtime Chrome would strip it.
+
+## Alternatives that need no hack
+
+- **Run `make test` on the host** instead of in the VM. Lands near CI timings
+  and sidesteps all of the above.
+- **Reduce launch count.** Test files that share a browser are ~10x cheaper.
+  `test-daemon` spends roughly 225s of its 275s launching, because each suite
+  stops and restarts the daemon.
+- **Raise `JS_PARALLEL` / `PY_PARALLEL` / `JAVA_PARALLEL`.** The stall is a
+  blocked `mach_msg` consuming no CPU, so concurrency is cheaper here than the
+  conservative defaults assume.

--- a/scripts/mtlshim.m
+++ b/scripts/mtlshim.m
@@ -1,0 +1,30 @@
+// Returns what Metal already returns on a macOS VM guest with a dead virtual
+// GPU — nothing — without its ~15s wait. Never use where a GPU works.
+// Built by `make mtlshim`. See docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+static NSArray *shim_MTLCopyAllDevices(void) {
+  return [[NSArray alloc] init];        // +1, matching the Copy convention
+}
+
+static id<MTLDevice> shim_MTLCreateSystemDefaultDevice(void) {
+  return nil;                            // what it returns anyway, 15s sooner
+}
+
+// Chrome's GPU process reaches the same dead driver through this one.
+static NSArray *shim_MTLCopyAllDevicesWithObserver(
+    id<NSObject> __strong *observer, MTLDeviceNotificationHandler handler) {
+  if (observer) *observer = nil;
+  return [[NSArray alloc] init];
+}
+
+#define INTERPOSE(_new, _old)                                                  \
+  __attribute__((used)) static struct { const void *r; const void *o; }        \
+  _interpose_##_old __attribute__((section("__DATA,__interpose"))) = {         \
+    (const void *)(uintptr_t)&_new, (const void *)(uintptr_t)&_old };
+
+INTERPOSE(shim_MTLCopyAllDevices, MTLCopyAllDevices)
+INTERPOSE(shim_MTLCreateSystemDefaultDevice, MTLCreateSystemDefaultDevice)
+INTERPOSE(shim_MTLCopyAllDevicesWithObserver, MTLCopyAllDevicesWithObserver)


### PR DESCRIPTION
## Problem

On a macOS VM guest whose virtual GPU never answers, **every Chrome launch costs ~15s**. Chrome — even headless — creates an AppKit `NSWindow`, which makes macOS enumerate Metal devices:

```
NSWindow initWithContentRect:  (AppKit)
  -> MTLCopyAllDevices  (Metal)
    -> MTLIOAccelService initWithAcceleratorPort:
      -> AppleParavirtGPUMetalIOGPUFamily
        -> IOGPUDeviceCreateWithOptions -> IOServiceOpen
          -> mach_msg2_trap            <- blocked ~15s
```

`IOServiceOpen` blocks for a fixed ~15s, then fails `kIOReturnUnsupported` and reports zero devices. The wait buys nothing — it's purely the time taken to discover there is no GPU. Across ~120 launches that's an ~18 minute suite instead of ~6.

Not Chrome, not vibium: a four-line Metal program reproduces it at `MTLCopyAllDevices: 15.01s (0 devices)`.

## Fix

`VM_FAST_LAUNCH=1` builds a Metal-interposing shim and points vibium at it. The shim returns exactly what Metal returns on an affected guest — nothing — without the wait.

Two details that mattered:

- **Three entry points, not two.** The browser process reaches the driver via `MTLCopyAllDevices` / `MTLCreateSystemDefaultDevice`; Chrome's **GPU process** uses `MTLCopyAllDevicesWithObserver`. Covering only the first two leaves the GPU process stalling (15.3s) with the browser waiting behind it.
- **`DYLD_INSERT_LIBRARIES` is set in Go, on chromedriver's own env**, not plumbed through `make`. macOS strips `DYLD_*` when exec'ing SIP-protected binaries, and `/bin/sh`, the venv python, and `gradlew` are all such boundaries. Setting it in the launcher sidesteps every one and makes JS, Python, Java, CLI, MCP, and daemon all benefit uniformly.

Chrome's process model is left alone, so local runs exercise the same topology as CI and as users.

## Results

| | Before | After |
| --- | --- | --- |
| Full suite | 17–20 min | **~5m57s** |
| Python (381 tests) | 357s | 119s |
| `test-cli` | 60s | 29s |
| vibium launch | 18.1s | 3.1s |

Verified across **5 full suites and 5 `test-cli` runs, all green** — 528 node + 381 python + 3 browser-mode, 0 failures, run times within 1s of each other (357/356/357).

## Safety

- **Off by default.** Opt-in by construction: vibium does nothing unless `VIBIUM_VM_FAST_LAUNCH` points at a dylib.
- **Darwin-guarded** in both `launcher.go` (`runtime.GOOS`) and the Makefile (`UNAME_S`), so a stray env var can't affect Linux or Windows.
- **Default path unchanged** and verified — `make test-js-process` still 91s, `make test-go` green.
- **CI is unaffected**: Linux, where the flag is inert and the shim never loads.
- **Never valid where a GPU works** — there it would hide the GPU rather than agree with it. The doc leads with a probe to check before enabling, and frames the criterion as a property of the machine rather than "CI vs not CI", in case macOS CI is added later.

## Docs

`docs/how-to-guides/slow-chrome-launch-in-macos-vm.md` covers the symptom, the probe, the stall path, what doesn't fix it (Chrome flags, other VM host apps, UTM settings, kext unload — all checked and ruled out), the shim and how dyld loads it, the `make`/`sh` stripping gotcha, cautions, and the no-hack alternatives. Linked from the mac dev-setup guide.