### PR TITLE
Share one daemon per file in the daemon tests

### DIFF
--- a/tests/daemon/cli-commands.test.js
+++ b/tests/daemon/cli-commands.test.js
@@ -45,21 +45,19 @@ before(async () => {
       resolve(data.toString().trim());
     });
   });
+  // One daemon for the whole file; each describe re-navigates for a clean page.
+  stopDaemon();
+  clicker('daemon start --headless');
 });
 
 after(() => {
+  stopDaemon();
   if (serverProcess) serverProcess.kill();
 });
 
 describe('Daemon CLI: Navigation commands', () => {
   before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
     clicker(`go ${baseURL}/example`);
-  });
-
-  after(() => {
-    stopDaemon();
   });
 
   test('back navigates back in history', () => {
@@ -83,13 +81,7 @@ describe('Daemon CLI: Navigation commands', () => {
 
 describe('Daemon CLI: Element state commands', () => {
   before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
     clicker(`go ${baseURL}/example`);
-  });
-
-  after(() => {
-    stopDaemon();
   });
 
   test('is visible returns true for visible element', () => {
@@ -113,13 +105,7 @@ describe('Daemon CLI: Element state commands', () => {
 
 describe('Daemon CLI: Accessibility and search commands', () => {
   before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
     clicker(`go ${baseURL}/example`);
-  });
-
-  after(() => {
-    stopDaemon();
   });
 
   test('a11y-tree returns accessibility tree', () => {
@@ -151,13 +137,7 @@ describe('Daemon CLI: Accessibility and search commands', () => {
 
 describe('Daemon CLI: Waiting commands', () => {
   before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
     clicker(`go ${baseURL}/example`);
-  });
-
-  after(() => {
-    stopDaemon();
   });
 
   test('wait load succeeds on loaded page', () => {
@@ -184,15 +164,6 @@ describe('Daemon CLI: Waiting commands', () => {
 });
 
 describe('Daemon CLI: Interaction commands', () => {
-  before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
-  });
-
-  after(() => {
-    stopDaemon();
-  });
-
   test('scroll into-view scrolls element into view', () => {
     clicker(`go ${baseURL}/example`);
     const result = clickerJSON('scroll into-view "a"');
@@ -240,13 +211,10 @@ describe('Daemon CLI: Screenshot --full-page', () => {
   let savedPath = null;
 
   before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
     clicker(`go ${baseURL}/example`);
   });
 
   after(() => {
-    stopDaemon();
     // Clean up screenshot file
     if (savedPath) {
       try { fs.unlinkSync(savedPath); } catch (e) {}
@@ -269,13 +237,7 @@ describe('Daemon CLI: Screenshot --full-page', () => {
 
 describe('Daemon CLI: quit command', () => {
   before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
     clicker(`go ${baseURL}/example`);
-  });
-
-  after(() => {
-    stopDaemon();
   });
 
   test('stop closes browser session', () => {

--- a/tests/daemon/concurrency.test.js
+++ b/tests/daemon/concurrency.test.js
@@ -42,22 +42,17 @@ before(async () => {
       resolve(data.toString().trim());
     });
   });
+  // One daemon for the whole file; each test navigates itself.
+  stopDaemon();
+  clicker('daemon start --headless');
 });
 
 after(() => {
+  stopDaemon();
   if (serverProcess) serverProcess.kill();
 });
 
 describe('Daemon: Rapid sequential commands', () => {
-  before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
-  });
-
-  after(() => {
-    stopDaemon();
-  });
-
   test('multiple go commands in sequence', () => {
     // Navigate to several pages in quick succession
     const r1 = clickerJSON(`go ${baseURL}/example`);
@@ -85,15 +80,6 @@ describe('Daemon: Rapid sequential commands', () => {
 });
 
 describe('Daemon: Error recovery', () => {
-  before(() => {
-    stopDaemon();
-    clicker('daemon start --headless');
-  });
-
-  after(() => {
-    stopDaemon();
-  });
-
   test('find with bad selector returns error', () => {
     // Navigate first
     clickerJSON(`go ${baseURL}/example`);


### PR DESCRIPTION
Follow-up to #245 — this one helps CI too, since it removes real browser launches on every platform.

## Problem

Every `describe` block in the daemon tests did:

```js
before(() => {
  stopDaemon();
  clicker('daemon start --headless');
  clicker(`go ${baseURL}/example`);
});
after(() => { stopDaemon(); });
```

So `test-daemon` paid a full browser launch per suite — **16 launches for 16 suites**. The restart isn't load-bearing: the `go <url>` already there is what resets page state between suites.

## Change

- `cli-commands.test.js` (7 starts) and `concurrency.test.js` (2) now start the daemon once per file; each `describe` keeps its `go` for a clean page.
- `lifecycle.test.js` and `connect.test.js` keep their own daemons — they assert on `daemon start`/`stop` and auto-start, so they need control of it.

**16 launches → 9.**

## Results

| | Before | After |
| --- | --- | --- |
| `test-daemon` | 275s | **149s** |
| tests / suites | 48 / 16 | 48 / 16 (unchanged) |

Verified over 4 repeat `test-daemon` runs, all 48/48 clean at 148-149s — shared-daemon changes are exactly where inter-test coupling hides, so one green run wasn't enough. Full suite also green.