### PR TITLE
Derive test parallelism from core count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 # only fires when something has gone catastrophically wrong. A healthy
 # sequential test-js phase is ~6-10 minutes because Chrome launch is ~16s
 # per file on macOS (see clients/javascript/src/clicker/process.ts). For
-# faster iteration bump JS_PARALLEL (default 3) to use more cores.
+# faster iteration bump JS_PARALLEL (see DEFAULT_PARALLEL) to use more cores.
 TEST_TIMEOUT ?= 600
 TIMEOUT_CMD := node scripts/timeout.mjs $(TEST_TIMEOUT)
 # Same watchdog for recipes that cd out of the repo root (pytest, gradlew).
@@ -188,6 +188,17 @@ serve: build-go
 # alongside them would fight over it.
 SUITE_PARALLEL ?= 4
 
+# Per-suite browser fan-out, derived from core count: half the cores, floor 3.
+# A 12-core dev box gets 6; CI's 4-vCPU runner stays at the long-standing 3.
+# Measured here at 12 cores: 3 -> 335s, 6 -> 268s, 8 -> 259s. 8 is only 9s
+# better than 6 but runs ~20 concurrent Chromes, near the oversubscription
+# that used to wedge the suite, so the default stops at half.
+ifeq ($(OS),Windows_NT)
+DEFAULT_PARALLEL := 3
+else
+DEFAULT_PARALLEL := $(shell n=$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4); n=$$((n / 2)); [ $$n -lt 3 ] && n=3; echo $$n)
+endif
+
 # macOS VM guests with a dead virtual GPU pay ~15s per Chrome launch.
 # VM_FAST_LAUNCH=1 builds a Metal shim and points vibium at it. Probe first.
 # See docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
@@ -258,8 +269,8 @@ test-cli: build-go
 
 # Run JS library tests
 # Each test file owns its own browser (top-level before/after), so files are
-# independent and safe to run in parallel. JS_PARALLEL controls the fan-out:
-# default 4 gives ~3x speedup vs sequential. (Previously sequential because
+# independent and safe to run in parallel. JS_PARALLEL controls the fan-out.
+# (Previously sequential because
 # we suspected parallel-induced flakes; root cause was a cross-process Chrome
 # temp-dir cleanup race in clicker/internal/browser/launcher.go, now fixed.)
 # Process tests stay sequential because they assert on Chrome process lifecycle.
@@ -269,7 +280,7 @@ test-cli: build-go
 # parallel-safe groups concurrently with test-mcp/test-python/test-java via
 # `$(MAKE) -j 5`. The process group must run alone because it asserts on
 # Chrome PID baselines.
-JS_PARALLEL ?= 3
+JS_PARALLEL ?= $(DEFAULT_PARALLEL)
 
 test-js-async: build-go
 	@echo "--- JS Async Tests (parallel x$(JS_PARALLEL)) ---"
@@ -329,11 +340,11 @@ test-daemon: build-go
 
 # Run Python client tests
 # PY_PARALLEL: pytest-xdist worker count. Each worker spawns its own Chrome,
-# so each adds ~150 MB of memory pressure. Default 4 is conservative; bump
-# for faster CI. Module-scoped browser fixture means xdist's default
+# so each adds ~150 MB of memory pressure. Module-scoped browser fixture means
+# xdist's default
 # loadfile distribution gives each file to a single worker — safe under
 # parallel since each file owns its own browser via conftest.py.
-PY_PARALLEL ?= 3
+PY_PARALLEL ?= $(DEFAULT_PARALLEL)
 
 # Ensure the Python client venv exists with the client + test deps installed.
 python-venv:


### PR DESCRIPTION
## Problem

`JS_PARALLEL` and `PY_PARALLEL` were pinned at 3 — tuned down after the oversubscription freezes, back when a Chrome launch cost ~16s and blocked the whole time. Launches are cheap now, so 3 leaves a 12-core box mostly idle.

But the default can't simply be raised: CI runs bare `make test` with no overrides, so **the Makefile default *is* CI's setting**, and `ubuntu-latest` is a 4-vCPU runner. Hardcoding 6 would oversubscribe CI.

## Change

Derive it: **half the cores, floor 3.**

| Machine | Computes |
| --- | --- |
| CI (4 vCPU) | 3 — unchanged |
| 8-core | 4 |
| 12-core dev box | 6 |
| 16-core | 8 |

Windows keeps a flat 3, since `$(shell)` there doesn't go through a shell. Explicit `JS_PARALLEL=N` overrides still win.

## Why 6 and not 8

Full suite on a 12-core box:

| | Time |
| --- | --- |
| P=3 (today) | 335s |
| **P=6** | **268s** |
| P=8 | 259s |

P=8 buys 9s (3%) for 33% more concurrency, and would run ~20 simultaneous Chromes — back near the oversubscription that used to wedge the suite. The serial phases dominate now, so the middle phase has little left to give. Not worth the headroom.

Standalone measurements scale further (js-async 65s→36s, python 119s→52s from P=3→8), but those don't reflect the real suite, where four suites run concurrently under `SUITE_PARALLEL`.

## Verification

Two full runs at the new default: **270s and 271s, 528 node tests + 381 python passing, 0 failures.** All the intermediate levels (3/4/6/8) were also clean standalone.

## Note

`JAVA_PARALLEL` stays pinned at 3 — each of its workers is a JVM *plus* a Chrome, so it's heavier per worker and warrants its own measurement rather than being swept along with this.