### PR TITLE
Close the extra tab in the sync-api Multi-page test

### DIFF
--- a/tests/js/sync/sync-api.test.js
+++ b/tests/js/sync/sync-api.test.js
@@ -65,6 +65,8 @@ describe('Sync API: Multi-page', () => {
     assert.ok(page2, 'Should return a new PageSync');
     const allPages = bro.pages();
     assert.ok(allPages.length >= 2, 'Should have at least 2 pages');
+    // Leaving this tab open costs later describes ~5s per mouse action (#248).
+    page2.close();
   });
 });
 


### PR DESCRIPTION
`Sync API: Multi-page` opened a second tab via `bro.newPage()` and never closed it. That made every later mouse-dispatching action cost ~5s, so the `Element interaction` describe took **26s instead of 1.4s**.

Bisected — `Element interaction` alone runs in 2.6s; preceded by `Multi-page` it takes 26s. `fill()` and `selectOption()` stayed fast throughout because they don't dispatch pointer events.

## Results

| | Before | After |
| --- | --- | --- |
| `Element interaction` describe | 26.0s | **1.4s** |
| `sync-api.test.js` | 74.7s | **43.5s** |
| `test-js-sync` phase | 75.5s | **46s** |

70/70 passing.

## Note

The 5s stall itself is a product bug, filed as #248 — mouse actions stall for ~5s after a second tab is opened, reproducible in both the sync and async clients with no test framework involved. This PR only stops the test suite from paying for it; it does not fix the underlying issue.