### PR TITLE
Foreground the target tab before pointer input (#248)

### DIFF
--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -42,6 +42,8 @@ type BrowserSession struct {
 	// Clock support
 	clockPreloadScriptID string // "" if not installed
 
+	activeContext string // last context foregrounded for pointer input; "" = unknown
+
 	// Recording support
 	recorder           *Recorder
 	lastContext        string   // last browsing context resolved by a command
@@ -863,6 +865,38 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 	}
 }
 
+func (s *BrowserSession) activeContextID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.activeContext
+}
+
+func (s *BrowserSession) setActiveContext(ctx string) {
+	s.mu.Lock()
+	s.activeContext = ctx
+	s.mu.Unlock()
+}
+
+// pointerInputContext returns the browsing context a pointer-input command
+// targets, or "" if the command is not pointer input. Keyboard input needs no
+// hit-testing and does not stall, so it is deliberately excluded.
+func pointerInputContext(method string, params map[string]interface{}) string {
+	if method != "input.performActions" {
+		return ""
+	}
+	actions, ok := params["actions"].([]map[string]interface{})
+	if !ok {
+		return ""
+	}
+	for _, a := range actions {
+		if t, _ := a["type"].(string); t == "pointer" {
+			ctx, _ := params["context"].(string)
+			return ctx
+		}
+	}
+	return ""
+}
+
 // sendInternalCommand sends a BiDi command and waits for the response (60s timeout).
 func (r *Router) sendInternalCommand(session *BrowserSession, method string, params map[string]interface{}) (json.RawMessage, error) {
 	return r.sendInternalCommandWithTimeout(session, method, params, 60*time.Second)
@@ -870,6 +904,28 @@ func (r *Router) sendInternalCommand(session *BrowserSession, method string, par
 
 // sendInternalCommandWithTimeout sends a BiDi command and waits for the response with a custom timeout.
 func (r *Router) sendInternalCommandWithTimeout(session *BrowserSession, method string, params map[string]interface{}, timeout time.Duration) (json.RawMessage, error) {
+	// Chrome blocks ~5s dispatching pointer input to a backgrounded tab (#248),
+	// so foreground the target first — but only on a change of context. An
+	// activate round-trip between the two clicks of a dblclick would push them
+	// past the double-click threshold.
+	switch {
+	case method == "browsingContext.create":
+		session.setActiveContext("") // the new tab takes focus
+	case method == "browsingContext.activate":
+		if ctx, _ := params["context"].(string); ctx != "" {
+			session.setActiveContext(ctx)
+		}
+	default:
+		if ctx := pointerInputContext(method, params); ctx != "" && session.activeContextID() != ctx {
+			// Best-effort: a nested context cannot be activated, and the
+			// dispatch below works regardless — so only record on success.
+			if _, err := r.sendInternalCommandWithTimeout(session, "browsingContext.activate",
+				map[string]interface{}{"context": ctx}, timeout); err != nil {
+				session.setActiveContext("")
+			}
+		}
+	}
+
 	// Record BiDi command in recording (opt-in via bidi: true)
 	session.mu.Lock()
 	recorder := session.recorder


### PR DESCRIPTION
Fixes #248.

## Root cause

Chrome blocks ~5s dispatching **pointer** input to a browsing context that isn't the active tab. `browsingContext.create` makes the new tab active, so the page you were working on is backgrounded and its next click/hover/drag stalls.

Timing every internal BiDi call during a 5077ms `hover()` put the entire stall in one command:

```
browsingContext.create      519ms
input.performActions        5.014580708s
```

Not actionability — instrumenting the `WaitForActionable` retry loop printed **zero** iterations, so it succeeded on its first attempt. Not the sync bridge — the async client reproduces it identically.

The BiDi spec sets no activation precondition for `input.performActions` (`docs/reference/WebDriver-Bidi-Spec.md:14270`), so this is Chrome behaviour to defend against rather than misuse of the API. Playwright brings the page to front before pointer actions for the same reason.

## Change

Activate the target context before pointer input, at the `sendInternalCommand` chokepoint so all 17 dispatch sites are covered (mouse, touch, drag, wheel, element click/hover) — and any added later. Nothing bypasses this path.

**Only on a change of context.** My first attempt activated before every dispatch and broke `dblclick selects text`: a ~500ms activate round-trip between the two clicks pushed them past the double-click threshold. A per-session tracker avoids inserting anything mid-gesture:

- `browsingContext.create` clears it — the new tab steals focus (this is the bug scenario, so it must invalidate)
- `browsingContext.activate` records it, covering `page switch`
- pointer input activates only if the target differs

Keyboard input needs no hit-testing and is untouched. Activation is best-effort — a nested (iframe) context can't be activated and the dispatch works regardless — and clears rather than records on failure, so a frame context can't poison the tracker.

## Results

| | Before | After |
| --- | --- | --- |
| `hover()` after `newPage()` | 5077ms | **585ms** |
| repeated actions, one tab | ~60ms | ~60ms (unchanged) |
| alternating between 2 tabs | ~5100ms each | ~570ms each |

Two full suites clean: 528 node + 381 python, 0 failures, 245s/243s (~5s over baseline).

## Note on cost

The residual ~500ms per genuine tab switch is Chrome's activation cost, and it may be inflated on my dev box — `browsingContext.create` also measures ~519ms here, and this machine has a broken virtual GPU, so compositor/window work is abnormally slow. CI on Linux should show the real figure.