### PR TITLE
Drop the stale #248 comment from the sync-api Multi-page test

### DIFF
--- a/tests/js/sync/sync-api.test.js
+++ b/tests/js/sync/sync-api.test.js
@@ -65,7 +65,6 @@ describe('Sync API: Multi-page', () => {
     assert.ok(page2, 'Should return a new PageSync');
     const allPages = bro.pages();
     assert.ok(allPages.length >= 2, 'Should have at least 2 pages');
-    // Leaving this tab open costs later describes ~5s per mouse action (#248).
     page2.close();
   });
 });


### PR DESCRIPTION
The comment claimed that leaving the tab open costs later describes ~5s per mouse action. #250 fixed that in the browser layer, so it's no longer true.

Verified by removing the `close()` entirely and re-running: `Element interaction` came back at **1898ms** — it was 26s before #250. So the workaround is no longer load-bearing.

The `close()` stays as ordinary cleanup: the test opens a tab, so it closes it. Comment only, no behaviour change. 70/70 passing.