### PR TITLE
Replace the npm-package binary atomically in build-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ build-go: deps
 		target_dir="node_modules/@vibium/$$platform/bin"; \
 		if [ -d "node_modules/@vibium/$$platform" ]; then \
 			mkdir -p "$$target_dir"; \
-			cp clicker/bin/vibium$(EXE) "$$target_dir/vibium$(EXE)"; \
+			cp clicker/bin/vibium$(EXE) "$$target_dir/vibium$(EXE).new" && \
+			mv -f "$$target_dir/vibium$(EXE).new" "$$target_dir/vibium$(EXE)"; \
 		fi; \
 	fi
 


### PR DESCRIPTION
## Problem

`build-go` copies the freshly built binary **over** the existing file in `node_modules/@vibium/<platform>/bin/`. That preserves the inode, and macOS caches code-signature validation per inode, so the copy eventually gets SIGKILLed:

```
clicker/bin/vibium                            → exit 1, prints its error
node_modules/@vibium/darwin-arm64/bin/vibium  → exit 137 (SIGKILL), silent
```

The files are byte-identical (`cmp` clean); only the inode differs.

Users see `npx vibium` dying with `Killed: 9`. The suite sees `tests/cli/wrapper.test.js` fail: `execFileSync` returns `status=null, signal=SIGKILL`, so the wrapper falls past its `process.exit(err.status)` branch and prints `Command failed: …` instead of the binary's own message.

Intermittent — it depends on whether the kernel has cached a validation for that inode, so CI (Linux, fresh checkout) and most local runs never hit it.

## Fix

Copy to a temp name and `mv` into place: new inode, atomic replace, and the old binary survives a failed copy.

## Verification

`cp` over the existing file → exit 137; fresh inode → exit 1. After the change, three consecutive `make build-go` runs each leave a working binary with a distinct inode and no stray `.new`. `wrapper.test.js`, `is-installed.test.js`, `packaging.test.js`: 8/8.