### PR TITLE
Route every BiDi script result through one decoder (#221, #124)

### DIFF
--- a/clicker/internal/api/handlers_state.go
+++ b/clicker/internal/api/handlers_state.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/vibium/clicker/internal/bidi"
 )
 
 // handleVibiumElText handles vibium:element.text — returns element.textContent.
@@ -554,47 +557,36 @@ func (r *Router) handlePageWaitForFunction(session *BrowserSession, cmd bidiComm
 			"resultOwnership":     "root",
 		})
 		if err == nil {
-			var result struct {
-				Result struct {
-					Type   string `json:"type"`
-					Result struct {
-						Type  string      `json:"type"`
-						Value interface{} `json:"value"`
-					} `json:"result"`
-					ExceptionDetails struct {
-						Text string `json:"text"`
-					} `json:"exceptionDetails"`
-				} `json:"result"`
-			}
-			if err := json.Unmarshal(resp, &result); err == nil {
-				if result.Result.Type == "exception" {
-					// Keep polling — the expression may reference state that does
-					// not exist yet — but remember why for the timeout message.
-					lastErr = result.Result.ExceptionDetails.Text
-				} else {
-					// Truthy check: non-null, non-undefined, non-false, non-zero, non-empty-string
-					res := result.Result.Result
-					truthy := false
-					switch res.Type {
-					case "boolean":
-						truthy = res.Value == true
-					case "number":
-						if v, ok := res.Value.(float64); ok {
-							truthy = v != 0
-						}
-					case "string":
-						if v, ok := res.Value.(string); ok {
-							truthy = v != ""
-						}
-					case "null", "undefined":
-						truthy = false
-					default:
-						truthy = res.Value != nil
+			sr, parseErr := bidi.ParseScriptResponse(resp)
+			var se *bidi.ScriptException
+			switch {
+			case errors.As(parseErr, &se):
+				// Keep polling — the expression may reference state that does
+				// not exist yet — but remember why for the timeout message.
+				lastErr = se.Text
+			case parseErr == nil:
+				// Truthy check: non-null, non-undefined, non-false, non-zero, non-empty-string
+				res := sr.Result
+				truthy := false
+				switch res.Type {
+				case "boolean":
+					truthy = res.Value == true
+				case "number":
+					if v, ok := res.Value.(float64); ok {
+						truthy = v != 0
 					}
-					if truthy {
-						r.sendSuccess(session, cmd.ID, map[string]interface{}{"value": res.Value})
-						return
+				case "string":
+					if v, ok := res.Value.(string); ok {
+						truthy = v != ""
 					}
+				case "null", "undefined":
+					truthy = false
+				default:
+					truthy = res.Value != nil
+				}
+				if truthy {
+					r.sendSuccess(session, cmd.ID, map[string]interface{}{"value": res.Value})
+					return
 				}
 			}
 		}
@@ -1241,57 +1233,12 @@ func (r *Router) handlePageExpose(session *BrowserSession, cmd bidiCommand) {
 }
 
 // deserializeScriptResult extracts a usable value from a BiDi script result.
-// Handles primitives (string, number, boolean, null, undefined) and objects/arrays.
+// Handles primitives (string, number, boolean, null, undefined) and nested
+// objects/arrays. A thrown exception is surfaced as an error rather than null.
 func deserializeScriptResult(resp json.RawMessage) (interface{}, error) {
-	var result struct {
-		Result struct {
-			Result struct {
-				Type   string      `json:"type"`
-				Value  interface{} `json:"value"`
-				Handle string      `json:"handle,omitempty"`
-			} `json:"result"`
-		} `json:"result"`
+	sr, err := bidi.ParseScriptResponse(resp)
+	if err != nil {
+		return nil, err
 	}
-	if err := json.Unmarshal(resp, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse script result: %w", err)
-	}
-
-	r := result.Result.Result
-	switch r.Type {
-	case "null", "undefined":
-		return nil, nil
-	case "string", "number", "boolean":
-		return r.Value, nil
-	case "array":
-		// BiDi returns arrays as {type: "array", value: [{type, value}, ...]}
-		if items, ok := r.Value.([]interface{}); ok {
-			out := make([]interface{}, len(items))
-			for i, item := range items {
-				if m, ok := item.(map[string]interface{}); ok {
-					out[i] = m["value"]
-				} else {
-					out[i] = item
-				}
-			}
-			return out, nil
-		}
-		return r.Value, nil
-	case "object":
-		// BiDi returns objects as {type: "object", value: [[key, {type, value}], ...]}
-		if pairs, ok := r.Value.([]interface{}); ok {
-			out := make(map[string]interface{})
-			for _, pair := range pairs {
-				if kv, ok := pair.([]interface{}); ok && len(kv) == 2 {
-					key, _ := kv[0].(string)
-					if m, ok := kv[1].(map[string]interface{}); ok {
-						out[key] = m["value"]
-					}
-				}
-			}
-			return out, nil
-		}
-		return r.Value, nil
-	default:
-		return r.Value, nil
-	}
+	return bidi.ConvertRemoteValue(sr.Result), nil
 }

--- a/clicker/internal/api/helpers.go
+++ b/clicker/internal/api/helpers.go
@@ -2,8 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
+
+	"github.com/vibium/clicker/internal/bidi"
 )
 
 // resolveContext extracts the "context" param or returns the first context from getTree.
@@ -51,38 +54,33 @@ func checkBidiError(resp json.RawMessage) error {
 // Success structure:   { "result": { "type": "success",   "result": { "type": "string", "value": "..." } } }
 // Exception structure: { "result": { "type": "exception", "exceptionDetails": { "text": "..." } } }
 func parseScriptResult(resp json.RawMessage) (string, error) {
-	var result struct {
-		Result struct {
-			Type   string `json:"type"`
-			Result struct {
-				Type  string `json:"type"`
-				Value string `json:"value,omitempty"`
-			} `json:"result"`
-			ExceptionDetails struct {
-				Text string `json:"text"`
-			} `json:"exceptionDetails"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal(resp, &result); err != nil {
-		return "", fmt.Errorf("failed to parse script result: %w", err)
-	}
-
 	// A thrown exception has no result value — surface it instead of silently
 	// returning an empty string, which previously masked errors such as the
 	// "Illegal invocation" crash when filling a <textarea> (issues #117, #111).
-	if result.Result.Type == "exception" {
-		text := result.Result.ExceptionDetails.Text
-		if text == "" {
-			text = "script threw an exception"
+	sr, err := bidi.ParseScriptResponse(resp)
+	if err != nil {
+		var se *bidi.ScriptException
+		if errors.As(err, &se) {
+			if se.Text == "" {
+				return "", fmt.Errorf("script threw an exception")
+			}
+			return "", fmt.Errorf("%s", se.Text)
 		}
-		return "", fmt.Errorf("%s", text)
+		return "", err
 	}
 
-	if result.Result.Result.Type == "null" || result.Result.Result.Type == "undefined" {
-		return "", fmt.Errorf("script returned %s", result.Result.Result.Type)
+	if sr.Result.Type == "null" || sr.Result.Type == "undefined" {
+		return "", fmt.Errorf("script returned %s", sr.Result.Type)
 	}
 
-	return result.Result.Result.Value, nil
+	// Callers of this helper inject scripts that return a string (typically
+	// JSON.stringify'd); anything else is a bug in the caller's script.
+	value, ok := sr.Result.Value.(string)
+	if !ok {
+		return "", fmt.Errorf("script returned %s, expected string", sr.Result.Type)
+	}
+
+	return value, nil
 }
 
 // resolveElementRef finds an element and returns its BiDi sharedId.

--- a/clicker/internal/api/script_result_test.go
+++ b/clicker/internal/api/script_result_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// page.evaluate returning a nested array previously kept the inner elements as
+// BiDi typed objects, because the array branch unwrapped only one level
+// (issue #124).
+func TestDeserializeScriptResultNestedArray(t *testing.T) {
+	resp := json.RawMessage(`{"result":{"type":"success","result":` +
+		`{"type":"array","value":[` +
+		`{"type":"array","value":[{"type":"string","value":"a"},{"type":"string","value":"b"}]},` +
+		`{"type":"number","value":2}]}}}`)
+
+	got, err := deserializeScriptResult(resp)
+	if err != nil {
+		t.Fatalf("deserializeScriptResult() error = %v", err)
+	}
+
+	want := []interface{}{
+		[]interface{}{"a", "b"},
+		float64(2),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("deserializeScriptResult() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDeserializeScriptResultNestedObject(t *testing.T) {
+	resp := json.RawMessage(`{"result":{"type":"success","result":` +
+		`{"type":"object","value":[` +
+		`["outer",{"type":"object","value":[["inner",{"type":"string","value":"v"}]]}]]}}}`)
+
+	got, err := deserializeScriptResult(resp)
+	if err != nil {
+		t.Fatalf("deserializeScriptResult() error = %v", err)
+	}
+
+	want := map[string]interface{}{
+		"outer": map[string]interface{}{"inner": "v"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("deserializeScriptResult() = %#v, want %#v", got, want)
+	}
+}
+
+// A thrown exception previously fell through to the default branch and returned
+// a nil value with no error, so page.evaluate reported null instead of failing.
+func TestDeserializeScriptResultSurfacesException(t *testing.T) {
+	resp := json.RawMessage(`{"result":{"type":"exception","exceptionDetails":` +
+		`{"text":"ReferenceError: nope is not defined"}}}`)
+
+	got, err := deserializeScriptResult(resp)
+	if err == nil {
+		t.Fatalf("deserializeScriptResult() = %#v, want an error", got)
+	}
+	if !strings.Contains(err.Error(), "ReferenceError: nope is not defined") {
+		t.Errorf("error = %q, want it to carry the exception text", err.Error())
+	}
+}
+
+func TestDeserializeScriptResultPrimitives(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want interface{}
+	}{
+		{"string", `{"type":"string","value":"hi"}`, "hi"},
+		{"number", `{"type":"number","value":3}`, float64(3)},
+		{"boolean", `{"type":"boolean","value":true}`, true},
+		{"null", `{"type":"null"}`, nil},
+		{"undefined", `{"type":"undefined"}`, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := json.RawMessage(`{"result":{"type":"success","result":` + tt.raw + `}}`)
+			got, err := deserializeScriptResult(resp)
+			if err != nil {
+				t.Fatalf("deserializeScriptResult() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("deserializeScriptResult() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// parseScriptResult keeps its string contract and its exception behavior from
+// the #111/#117 fix.
+func TestParseScriptResultStringContract(t *testing.T) {
+	ok := json.RawMessage(`{"result":{"type":"success","result":{"type":"string","value":"payload"}}}`)
+	got, err := parseScriptResult(ok)
+	if err != nil {
+		t.Fatalf("parseScriptResult() error = %v", err)
+	}
+	if got != "payload" {
+		t.Errorf("parseScriptResult() = %q, want %q", got, "payload")
+	}
+
+	exc := json.RawMessage(`{"result":{"type":"exception","exceptionDetails":{"text":"Illegal invocation"}}}`)
+	if _, err = parseScriptResult(exc); err == nil {
+		t.Fatal("parseScriptResult() returned nil error for an exception result")
+	} else if err.Error() != "Illegal invocation" {
+		t.Errorf("error = %q, want %q", err.Error(), "Illegal invocation")
+	}
+
+	null := json.RawMessage(`{"result":{"type":"success","result":{"type":"null"}}}`)
+	if _, err = parseScriptResult(null); err == nil || !strings.Contains(err.Error(), "script returned null") {
+		t.Errorf("parseScriptResult() error = %v, want it to report a null result", err)
+	}
+}

--- a/clicker/internal/bidi/element.go
+++ b/clicker/internal/bidi/element.go
@@ -73,37 +73,24 @@ func (c *Client) FindElement(context, selector string) (*ElementInfo, error) {
 		return nil, err
 	}
 
-	// Parse the result
-	var callResult struct {
-		Type   string          `json:"type"`
-		Result json.RawMessage `json:"result"`
-	}
-	if err := json.Unmarshal(msg.Result, &callResult); err != nil {
-		return nil, fmt.Errorf("failed to parse script.callFunction result: %w", err)
-	}
-
-	if callResult.Type == "exception" {
-		return nil, fmt.Errorf("script exception: %s", string(callResult.Result))
-	}
-
-	// Parse the remote value (string containing JSON)
-	var remoteValue struct {
-		Type  string `json:"type"`
-		Value string `json:"value,omitempty"`
-	}
-
-	if err := json.Unmarshal(callResult.Result, &remoteValue); err != nil {
-		return nil, fmt.Errorf("failed to parse remote value: %w", err)
+	sr, err := ParseScriptResult(msg.Result)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check if element was found
-	if remoteValue.Type == "null" {
+	if sr.Result.Type == "null" {
 		return nil, &errs.ElementNotFoundError{Selector: selector, Context: context}
 	}
 
-	// Parse the JSON string value
+	// The script returns a JSON string to avoid BiDi object serialization
+	payload, ok := sr.Result.Value.(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse remote value: expected string, got %s", sr.Result.Type)
+	}
+
 	var info ElementInfo
-	if err := json.Unmarshal([]byte(remoteValue.Value), &info); err != nil {
+	if err := json.Unmarshal([]byte(payload), &info); err != nil {
 		return nil, fmt.Errorf("failed to parse element info: %w", err)
 	}
 
@@ -169,29 +156,18 @@ func (c *Client) FindAllElements(context, selector string, limit int) ([]Element
 		return nil, err
 	}
 
-	var callResult struct {
-		Type   string          `json:"type"`
-		Result json.RawMessage `json:"result"`
-	}
-	if err := json.Unmarshal(msg.Result, &callResult); err != nil {
-		return nil, fmt.Errorf("failed to parse script.callFunction result: %w", err)
+	sr, err := ParseScriptResult(msg.Result)
+	if err != nil {
+		return nil, err
 	}
 
-	if callResult.Type == "exception" {
-		return nil, fmt.Errorf("script exception: %s", string(callResult.Result))
-	}
-
-	var remoteValue struct {
-		Type  string `json:"type"`
-		Value string `json:"value,omitempty"`
-	}
-
-	if err := json.Unmarshal(callResult.Result, &remoteValue); err != nil {
-		return nil, fmt.Errorf("failed to parse remote value: %w", err)
+	payload, ok := sr.Result.Value.(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse remote value: expected string, got %s", sr.Result.Type)
 	}
 
 	var elements []ElementInfo
-	if err := json.Unmarshal([]byte(remoteValue.Value), &elements); err != nil {
+	if err := json.Unmarshal([]byte(payload), &elements); err != nil {
 		return nil, fmt.Errorf("failed to parse elements: %w", err)
 	}
 

--- a/clicker/internal/bidi/script.go
+++ b/clicker/internal/bidi/script.go
@@ -50,6 +50,78 @@ type RemoteValue struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
+// ExceptionDetails carries the details of a thrown script exception. A BiDi
+// exception response has no "result" member, so this is the only place the
+// failure text exists.
+type ExceptionDetails struct {
+	Text         string       `json:"text"`
+	LineNumber   int          `json:"lineNumber"`
+	ColumnNumber int          `json:"columnNumber"`
+	Exception    *RemoteValue `json:"exception,omitempty"`
+}
+
+// ScriptResult is the payload of a script.evaluate or script.callFunction
+// response: either a success carrying a RemoteValue, or an exception carrying
+// ExceptionDetails.
+type ScriptResult struct {
+	Type             string           `json:"type"`
+	Result           RemoteValue      `json:"result"`
+	ExceptionDetails ExceptionDetails `json:"exceptionDetails"`
+	Realm            string           `json:"realm,omitempty"`
+}
+
+// ScriptException is returned when a script throws. It carries the text from
+// exceptionDetails rather than the absent result member.
+type ScriptException struct {
+	Text       string
+	LineNumber int
+}
+
+func (e *ScriptException) Error() string {
+	if e.Text == "" {
+		return "script threw an exception"
+	}
+	return "script exception: " + e.Text
+}
+
+// ParseScriptResult decodes the payload of a script.evaluate or
+// script.callFunction response — the value of the response's "result" member.
+// A thrown exception is returned as *ScriptException.
+func ParseScriptResult(raw json.RawMessage) (*ScriptResult, error) {
+	var sr ScriptResult
+	if err := json.Unmarshal(raw, &sr); err != nil {
+		return nil, fmt.Errorf("failed to parse script result: %w", err)
+	}
+	if sr.Type == "exception" {
+		return nil, &ScriptException{
+			Text:       sr.ExceptionDetails.Text,
+			LineNumber: sr.ExceptionDetails.LineNumber,
+		}
+	}
+	return &sr, nil
+}
+
+// ParseScriptResponse decodes a full BiDi response envelope, { "result": ... },
+// as returned by the proxy's internal command path. See ParseScriptResult.
+func ParseScriptResponse(raw json.RawMessage) (*ScriptResult, error) {
+	var env struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("failed to parse script result: %w", err)
+	}
+	if len(env.Result) == 0 {
+		return nil, fmt.Errorf("failed to parse script result: no result member")
+	}
+	return ParseScriptResult(env.Result)
+}
+
+// ConvertRemoteValue converts a BiDi RemoteValue into a plain Go value,
+// recursing through arrays and objects.
+func ConvertRemoteValue(rv RemoteValue) interface{} {
+	return convertRemoteValue(rv)
+}
+
 // Evaluate evaluates a JavaScript expression and returns the result.
 // If context is empty, it uses the first available context.
 func (c *Client) Evaluate(context, expression string) (interface{}, error) {
@@ -77,26 +149,12 @@ func (c *Client) Evaluate(context, expression string) (interface{}, error) {
 		return nil, err
 	}
 
-	// Parse the result
-	var evalResult struct {
-		Type   string          `json:"type"`
-		Result json.RawMessage `json:"result"`
-	}
-	if err := json.Unmarshal(msg.Result, &evalResult); err != nil {
-		return nil, fmt.Errorf("failed to parse script.evaluate result: %w", err)
+	sr, err := ParseScriptResult(msg.Result)
+	if err != nil {
+		return nil, err
 	}
 
-	if evalResult.Type == "exception" {
-		return nil, fmt.Errorf("script exception: %s", string(evalResult.Result))
-	}
-
-	// Parse the remote value
-	var remoteValue RemoteValue
-	if err := json.Unmarshal(evalResult.Result, &remoteValue); err != nil {
-		return nil, fmt.Errorf("failed to parse remote value: %w", err)
-	}
-
-	return convertRemoteValue(remoteValue), nil
+	return convertRemoteValue(sr.Result), nil
 }
 
 // CallFunction calls a JavaScript function with arguments.
@@ -133,26 +191,12 @@ func (c *Client) CallFunction(context, functionDeclaration string, args []interf
 		return nil, err
 	}
 
-	// Parse the result
-	var callResult struct {
-		Type   string          `json:"type"`
-		Result json.RawMessage `json:"result"`
-	}
-	if err := json.Unmarshal(msg.Result, &callResult); err != nil {
-		return nil, fmt.Errorf("failed to parse script.callFunction result: %w", err)
+	sr, err := ParseScriptResult(msg.Result)
+	if err != nil {
+		return nil, err
 	}
 
-	if callResult.Type == "exception" {
-		return nil, fmt.Errorf("script exception: %s", string(callResult.Result))
-	}
-
-	// Parse the remote value
-	var remoteValue RemoteValue
-	if err := json.Unmarshal(callResult.Result, &remoteValue); err != nil {
-		return nil, fmt.Errorf("failed to parse remote value: %w", err)
-	}
-
-	return convertRemoteValue(remoteValue), nil
+	return convertRemoteValue(sr.Result), nil
 }
 
 // serializeValue converts a Go value to a BiDi serialized value.

--- a/clicker/internal/bidi/script_result_test.go
+++ b/clicker/internal/bidi/script_result_test.go
@@ -1,0 +1,131 @@
+package bidi
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// A BiDi exception response carries no "result" member, so the failure text is
+// only reachable through exceptionDetails (issue #221).
+func TestParseScriptResultException(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type": "exception",
+		"exceptionDetails": {
+			"text": "ReferenceError: undefinedVariable is not defined",
+			"lineNumber": 4,
+			"columnNumber": 12
+		},
+		"realm": "realm-1"
+	}`)
+
+	_, err := ParseScriptResult(raw)
+	if err == nil {
+		t.Fatal("ParseScriptResult() returned nil error for an exception result")
+	}
+
+	var se *ScriptException
+	if !errors.As(err, &se) {
+		t.Fatalf("error is %T, want *ScriptException", err)
+	}
+	if se.Text != "ReferenceError: undefinedVariable is not defined" {
+		t.Errorf("Text = %q, want the exceptionDetails text", se.Text)
+	}
+	if se.LineNumber != 4 {
+		t.Errorf("LineNumber = %d, want 4", se.LineNumber)
+	}
+	if want := "script exception: ReferenceError: undefinedVariable is not defined"; err.Error() != want {
+		t.Errorf("Error() = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestParseScriptResultExceptionWithoutText(t *testing.T) {
+	raw := json.RawMessage(`{"type":"exception","exceptionDetails":{}}`)
+
+	_, err := ParseScriptResult(raw)
+	if err == nil {
+		t.Fatal("ParseScriptResult() returned nil error for an exception result")
+	}
+	if err.Error() != "script threw an exception" {
+		t.Errorf("Error() = %q, want the fallback message", err.Error())
+	}
+}
+
+func TestParseScriptResultSuccess(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type": "success",
+		"result": {"type": "string", "value": "hello"},
+		"realm": "realm-1"
+	}`)
+
+	sr, err := ParseScriptResult(raw)
+	if err != nil {
+		t.Fatalf("ParseScriptResult() error = %v", err)
+	}
+	if sr.Type != "success" {
+		t.Errorf("Type = %q, want success", sr.Type)
+	}
+	if got := ConvertRemoteValue(sr.Result); got != "hello" {
+		t.Errorf("ConvertRemoteValue() = %#v, want %q", got, "hello")
+	}
+}
+
+func TestParseScriptResponseUnwrapsEnvelope(t *testing.T) {
+	raw := json.RawMessage(`{"result":{"type":"success","result":{"type":"number","value":7}}}`)
+
+	sr, err := ParseScriptResponse(raw)
+	if err != nil {
+		t.Fatalf("ParseScriptResponse() error = %v", err)
+	}
+	if got := ConvertRemoteValue(sr.Result); !reflect.DeepEqual(got, float64(7)) {
+		t.Errorf("ConvertRemoteValue() = %#v, want float64(7)", got)
+	}
+}
+
+// The envelope path must surface exceptions too — this is the JS/Python
+// page.evaluate route, which previously returned null for a thrown error.
+func TestParseScriptResponseSurfacesException(t *testing.T) {
+	raw := json.RawMessage(`{"result":{"type":"exception","exceptionDetails":{"text":"boom"}}}`)
+
+	_, err := ParseScriptResponse(raw)
+	if err == nil {
+		t.Fatal("ParseScriptResponse() returned nil error for an exception result")
+	}
+	var se *ScriptException
+	if !errors.As(err, &se) {
+		t.Fatalf("error is %T, want *ScriptException", err)
+	}
+	if se.Text != "boom" {
+		t.Errorf("Text = %q, want %q", se.Text, "boom")
+	}
+}
+
+func TestParseScriptResponseMissingResult(t *testing.T) {
+	if _, err := ParseScriptResponse(json.RawMessage(`{}`)); err == nil {
+		t.Fatal("ParseScriptResponse() returned nil error for a response with no result member")
+	}
+}
+
+// Nested arrays must survive the round trip — the JS-client page.evaluate path
+// previously unwrapped only one level, leaving inner elements as typed objects
+// (issue #124).
+func TestParseScriptResponseNestedArray(t *testing.T) {
+	raw := json.RawMessage(`{"result":{"type":"success","result":` +
+		`{"type":"array","value":[` +
+		`{"type":"array","value":[{"type":"string","value":"a"},{"type":"string","value":"b"}]},` +
+		`{"type":"array","value":[{"type":"string","value":"c"}]}]}}}`)
+
+	sr, err := ParseScriptResponse(raw)
+	if err != nil {
+		t.Fatalf("ParseScriptResponse() error = %v", err)
+	}
+
+	want := []interface{}{
+		[]interface{}{"a", "b"},
+		[]interface{}{"c"},
+	}
+	if got := ConvertRemoteValue(sr.Result); !reflect.DeepEqual(got, want) {
+		t.Errorf("ConvertRemoteValue() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
Seven call sites decoded `script.evaluate` / `script.callFunction` results independently. This routes all of them through one parser.

## The defect

A BiDi exception response has no `result` member — the failure text lives only in `exceptionDetails`. Four sites built their message from `result` anyway:

```go
return nil, fmt.Errorf("script exception: %s", string(evalResult.Result))
```

so `evalResult.Result` was nil and the user saw `script exception: ` with nothing after it (#221).

A fifth, `deserializeScriptResult` (the JS/Python `page.evaluate` path), unwrapped arrays and objects exactly one level — `out[i] = m["value"]` — leaving nested elements as `{type, value}` objects (#124). It also had no `exception` branch at all, so a thrown error fell through to the default case and returned `null` with no error.

## Why one decoder rather than seven patches

This was fixed once already. `8a0f569` repaired the copy in `api/helpers.go` for #111/#117 and its message claimed it "also makes every other script-backed handler report real errors." It did not — #221 was filed six weeks later against the copy in `bidi/script.go`.

## The change

`bidi.ParseScriptResult` (payload) and `bidi.ParseScriptResponse` (envelope) return a typed `*ScriptException` carrying `exceptionDetails.text`. All seven sites now call them:

| Site | Was |
|---|---|
| `bidi.Evaluate` | empty exception text |
| `bidi.CallFunction` | empty exception text |
| `bidi.FindElement` | empty exception text |
| `bidi.FindAllElements` | empty exception text |
| `api.parseScriptResult` | correct already; now shares the decode |
| `api.deserializeScriptResult` | 1-level unwrap, no exception branch |
| `api` waitForFunction poll loop | correct already; now shares the decode |

`waitForFunction` keeps its keep-polling-on-exception behavior via `errors.As`. `parseScriptResult` keeps its string contract, so its ~14 callers are unaffected.

## Verification

Live browser, before → after:

```
vibium eval "undefinedVariable.foo"
  before: Error: failed to evaluate: script exception:
  after:  Error: failed to evaluate: script exception: ReferenceError: undefinedVariable is not defined
```

`page.eval` over `vibium serve`:

```
nested array (#124)  -> [["a","b"],["c"]]
nested object        -> {"outer":{"inner":"v"}}
array of objects     -> [{"x":1},{"x":2}]
thrown exception     -> ERROR: eval failed: script exception: ReferenceError: undefinedVariable is not defined
```

The new tests are real regression tests: stashing the source changes while keeping them makes all three API-level tests fail with exactly the reported symptoms (inner elements as typed objects, `<nil>` with no error).

`make test` passes — exit 0, zero failures.

Net **-25 lines of source** while adding the exception path and recursion.

Fixes #221
Fixes #124