### PR TITLE
Fix Java client params the engine never reads (#174)

### DIFF
--- a/clients/java/src/main/java/com/vibium/Download.java
+++ b/clients/java/src/main/java/com/vibium/Download.java
@@ -1,6 +1,7 @@
 package com.vibium;
 
 import com.google.gson.JsonObject;
+import com.vibium.errors.VibiumException;
 import com.vibium.internal.BiDiClient;
 
 import java.util.concurrent.CompletableFuture;
@@ -34,9 +35,13 @@ public class Download {
 
     /** Save the download to a path. */
     public void saveAs(String path) {
+        String sourcePath = path();
+        if (sourcePath == null) {
+            throw new VibiumException("download did not complete; cannot save");
+        }
         JsonObject params = new JsonObject();
-        params.addProperty("path", path);
-        params.addProperty("url", url);
+        params.addProperty("sourcePath", sourcePath);
+        params.addProperty("destPath", path);
         client.send("vibium:download.saveAs", params);
     }
 

--- a/clients/java/src/main/java/com/vibium/Element.java
+++ b/clients/java/src/main/java/com/vibium/Element.java
@@ -267,18 +267,18 @@ public class Element {
 
     /** Find a child element by CSS selector with options. */
     public Element find(String childSelector, FindOptions options) {
-        JsonObject params = elementParams();
-        params.addProperty("childSelector", childSelector);
+        JsonObject params = scopedParams();
+        params.addProperty("selector", childSelector);
         if (options != null && options.timeout() != null) {
             params.addProperty("timeout", options.timeout());
         }
         JsonObject result = client.send("vibium:element.find", params);
-        return elementFromResult(result);
+        return elementFromResult(result, childSelector);
     }
 
     /** Find a child element by semantic selector. */
     public Element find(SelectorOptions childOptions) {
-        JsonObject params = elementParams();
+        JsonObject params = scopedParams();
         for (Map.Entry<String, Object> entry : childOptions.toParams().entrySet()) {
             params.add(entry.getKey(), GSON.toJsonTree(entry.getValue()));
         }
@@ -293,18 +293,18 @@ public class Element {
 
     /** Find all child elements by CSS selector with options. */
     public List<Element> findAll(String childSelector, FindOptions options) {
-        JsonObject params = elementParams();
-        params.addProperty("childSelector", childSelector);
+        JsonObject params = scopedParams();
+        params.addProperty("selector", childSelector);
         if (options != null && options.timeout() != null) {
             params.addProperty("timeout", options.timeout());
         }
         JsonObject result = client.send("vibium:element.findAll", params);
-        return elementsFromResult(result);
+        return elementsFromResult(result, childSelector);
     }
 
     /** Find all child elements by semantic selector. */
     public List<Element> findAll(SelectorOptions childOptions) {
-        JsonObject params = elementParams();
+        JsonObject params = scopedParams();
         for (Map.Entry<String, Object> entry : childOptions.toParams().entrySet()) {
             params.add(entry.getKey(), GSON.toJsonTree(entry.getValue()));
         }
@@ -324,15 +324,37 @@ public class Element {
         return params;
     }
 
+    /** Params for a child lookup: this element becomes the scope, the child supplies the selector. */
+    private JsonObject scopedParams() {
+        JsonObject params = new JsonObject();
+        params.addProperty("context", contextId);
+        params.addProperty("scope", selector);
+        return params;
+    }
+
     private void sendAction(String method) {
         client.send(method, elementParams());
     }
 
     private Element elementFromResult(JsonObject result) {
-        String sel = result.has("selector") ? result.get("selector").getAsString() : "";
+        return elementFromResult(result, "");
+    }
+
+    // The find response carries only tag/text/box, so the child's selector has to
+    // come from the caller or the returned element cannot be re-resolved.
+    private Element elementFromResult(JsonObject result, String selector) {
         int idx = result.has("index") ? result.get("index").getAsInt() : 0;
         ElementInfo eInfo = parseElementInfo(result);
-        return new Element(client, contextId, sel, idx, eInfo);
+        return new Element(client, contextId, selector, idx, eInfo);
+    }
+
+    private List<Element> elementsFromResult(JsonObject result, String selector) {
+        List<Element> elements = new ArrayList<>();
+        com.google.gson.JsonArray arr = result.has("elements") ? result.getAsJsonArray("elements") : new com.google.gson.JsonArray();
+        for (int i = 0; i < arr.size(); i++) {
+            elements.add(new Element(client, contextId, selector, i, parseElementInfo(arr.get(i).getAsJsonObject())));
+        }
+        return elements;
     }
 
     private List<Element> elementsFromResult(JsonObject result) {

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -310,7 +310,7 @@ public class Page {
     /** Wait for a JS function to return truthy with options. */
     public Object waitForFunction(String fn, WaitOptions options) {
         JsonObject params = contextParams();
-        params.addProperty("expression", fn);
+        params.addProperty("fn", fn);
         if (options != null && options.timeout() != null) {
             params.addProperty("timeout", options.timeout());
         }

--- a/clients/java/src/main/java/com/vibium/types/A11yOptions.java
+++ b/clients/java/src/main/java/com/vibium/types/A11yOptions.java
@@ -7,15 +7,16 @@ import java.util.Map;
  * Options for getting the accessibility tree.
  */
 public class A11yOptions {
-    private Boolean interestingOnly;
+    private Boolean everything;
     private String root;
 
-    public A11yOptions interestingOnly(boolean interestingOnly) { this.interestingOnly = interestingOnly; return this; }
+    /** Include every node, not just the interesting ones. Defaults to false. */
+    public A11yOptions everything(boolean everything) { this.everything = everything; return this; }
     public A11yOptions root(String root) { this.root = root; return this; }
 
     public Map<String, Object> toParams() {
         Map<String, Object> params = new LinkedHashMap<>();
-        if (interestingOnly != null) params.put("interestingOnly", interestingOnly);
+        if (everything != null) params.put("everything", everything);
         if (root != null) params.put("root", root);
         return params;
     }

--- a/clients/java/src/test/java/com/vibium/TestServer.java
+++ b/clients/java/src/test/java/com/vibium/TestServer.java
@@ -108,6 +108,8 @@ class TestServer {
         + "<input type=\"checkbox\" id=\"cb\" checked />"
         + "<button disabled>Disabled Button</button>"
         + "</main>"
+        // Generic containers carry no role, so they appear only when everything=true.
+        + "<div><div><span>plain wrapper text</span></div></div>"
         + "</body></html>";
 
     private static final String DOWNLOAD_HTML = "<html><head><title>Download</title></head><body>"

--- a/clients/java/src/test/java/com/vibium/WireContractTest.java
+++ b/clients/java/src/test/java/com/vibium/WireContractTest.java
@@ -1,0 +1,118 @@
+package com.vibium;
+
+import com.vibium.types.A11yNode;
+import com.vibium.types.A11yOptions;
+import com.vibium.types.StartOptions;
+import com.vibium.types.WaitOptions;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Covers commands where the Java client sent a param name the engine does not read.
+ * Each of these silently no-opped or failed before, because the engine reads params
+ * out of an untyped map and a key it does not recognise simply becomes a zero value.
+ */
+class WireContractTest {
+
+    static Browser browser;
+    static TestServer server;
+    Page page;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        server = new TestServer();
+        server.start();
+        browser = Vibium.start(new StartOptions().headless(true));
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (browser != null) browser.stop();
+        if (server != null) server.stop();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        page = browser.page();
+    }
+
+    /**
+     * The client sent "expression"; the engine reads "fn". fn was therefore "",
+     * and the engine's `const __vibiumPred = (%s)` became `()` — the
+     * "SyntaxError: Unexpected token ')'" in issue #174.
+     */
+    @Test
+    void waitForFunctionEvaluatesTheExpression() {
+        page.go(server.baseUrl());
+        Object result = page.waitForFunction(
+            "() => document.querySelector('h1') !== null",
+            new WaitOptions().timeout(5000));
+        assertNotNull(result, "waitForFunction should resolve with the truthy value");
+    }
+
+    @Test
+    void waitForFunctionAcceptsABareExpression() {
+        page.go(server.baseUrl());
+        Object result = page.waitForFunction(
+            "document.readyState === 'complete'",
+            new WaitOptions().timeout(5000));
+        assertNotNull(result, "a bare expression should be wrapped and evaluated");
+    }
+
+    /**
+     * The client sent the parent under "selector" plus a "childSelector" the engine
+     * never reads, so the lookup was never scoped to this element.
+     */
+    @Test
+    void findIsScopedToTheParentElement() {
+        page.go(server.baseUrl() + "/links");
+        Element nested = page.find("#nested");
+
+        // info() is what the engine resolved under the scope, so this asserts the
+        // scoping itself rather than a second, unscoped lookup.
+        Element inner = nested.find("span");
+        assertEquals("span", inner.info().tag());
+        assertEquals("Nested span", inner.info().text());
+    }
+
+    @Test
+    void findAllIsScopedToTheParentElement() {
+        page.go(server.baseUrl() + "/links");
+
+        List<Element> allLinks = page.findAll("a");
+        assertEquals(4, allLinks.size(), "page has four links in total");
+
+        List<Element> nestedSpans = page.find("#nested").findAll("span");
+        assertEquals(2, nestedSpans.size(), "only the two spans inside #nested are in scope");
+    }
+
+    /**
+     * The client sent "interestingOnly"; the engine reads "everything" and inverts it,
+     * so the option never had any effect.
+     */
+    @Test
+    void a11yEverythingReturnsMoreNodesThanTheDefault() {
+        page.go(server.baseUrl() + "/a11y");
+
+        int interesting = countNodes(page.a11yTree());
+        int everything = countNodes(page.a11yTree(new A11yOptions().everything(true)));
+
+        assertTrue(everything > interesting,
+            "everything(true) should include uninteresting nodes: "
+                + everything + " vs " + interesting);
+    }
+
+    private static int countNodes(A11yNode node) {
+        if (node == null) return 0;
+        int total = 1;
+        if (node.children() != null) {
+            for (A11yNode child : node.children()) {
+                total += countNodes(child);
+            }
+        }
+        return total;
+    }
+}


### PR DESCRIPTION
The engine reads request params out of an untyped `map[string]interface{}`, so a key a client names differently does not error — it becomes a zero value and the command silently no-ops or reports a misleading `"X is required"`. Four Java commands were sending keys no handler reads.

| Command | Java sent | Engine reads | Result |
|---|---|---|---|
| `waitForFunction` | `expression` | `fn` (`handlers_state.go:521`) | **#174** |
| `Element.find/findAll` | `selector` + `childSelector` | `scope` + `selector` (`handlers_elements.go:101-113`) | child lookups never scoped |
| `Download.saveAs` | `path` + `url` | `sourcePath` + `destPath` (`handlers_download.go:36-40`) | always failed |
| `A11yOptions` | `interestingOnly` | `everything`, inverted (`handlers_a11y.go:113-115`) | option had no effect |

## #174's filed root cause is wrong

The issue says the Java client double-wraps every expression. It does not — `grep -rn "() =>" clients/java/src/main/` returns **zero** hits. The real cause is the key: with `fn` empty, the handler's `const __vibiumPred = (%s)` renders as `const __vibiumPred = ()`, which is precisely the reported `SyntaxError: Unexpected token ')'`.

Worth noting how the wrong key got there: `vibium:page.eval` genuinely does take `expression`, while its siblings `page.waitForFunction` and `page.expose` take `fn`. The engine uses four different names for "a piece of JavaScript" — `fn`, `content`, `script`, `expression`.

## Also fixed

`Element.find/findAll` built child elements from a response that carries only `tag`/`text`/`box`, so the child had an empty selector and could not be re-resolved. Now carries the child selector, matching `Page.find` and `element.ts:340`.

## Verification

New `WireContractTest` (5 tests) — all pass; all fail against the pre-fix client. The scoping tests were confirmed failing by reverting `Element.java` alone and re-running. The a11y assertion needed a discriminating fixture: the existing `/a11y` page is entirely interesting nodes (8 vs 8 either way), so a generic wrapper `div` was added; cross-checked against the JS client, which shows 18 vs 20 on the shared fixture.

Full `make test-java` passes.

## Deliberately not in this PR

Two adjacent defects of a *different* class — the client listening for `vibium:` event names the engine never emits:

- `Page.java:733` dispatches routes on `vibium:network.intercepted`; the engine forwards raw `network.beforeRequestSent`. That is #128, and it is entangled with moving URL pattern matching server-side.
- `Page.java:727-731` listens for `vibium:download.started`/`completed`; the engine forwards raw `browsingContext.downloadWillBegin`/`downloadEnd` (`router.go:188-189`), and the payload field is `navigation`, not `navigationId`. So `onDownload` can never fire — filing separately.

That second one is why `saveAs` has no runtime test here: you cannot obtain a `Download` object until the event wiring is fixed. The param fix is verified against the handler and against `download.ts:55-58`.

Fixes #174