### PR TITLE
Add urlmatch: one URL glob implementation for the engine

### DIFF
--- a/clicker/internal/urlmatch/testdata/url-patterns.json
+++ b/clicker/internal/urlmatch/testdata/url-patterns.json
@@ -1,0 +1,239 @@
+{
+ "_comment": "Generated from Playwright's globToRegexPattern (reference/playwright/packages/isomorphic/urlMatch.ts). Shared conformance fixture: every vibium client and the Go engine must agree with these.",
+ "cases": [
+  {
+   "pattern": "**/api/data",
+   "url": "http://h/api/data",
+   "match": true
+  },
+  {
+   "pattern": "**/api/data",
+   "url": "http://h/api/data?x=1",
+   "match": false
+  },
+  {
+   "pattern": "**/api/data",
+   "url": "http://h/xapi/datay",
+   "match": false
+  },
+  {
+   "pattern": "**/api/data",
+   "url": "http://h/v1/api/data",
+   "match": true
+  },
+  {
+   "pattern": "**/api/*",
+   "url": "http://h/api/v1/data",
+   "match": false
+  },
+  {
+   "pattern": "**/api/*",
+   "url": "http://h/api/data",
+   "match": true
+  },
+  {
+   "pattern": "*/api",
+   "url": "http://h/v1/api",
+   "match": false
+  },
+  {
+   "pattern": "*/api",
+   "url": "h/api",
+   "match": true
+  },
+  {
+   "pattern": "**/*.{png,jpg}",
+   "url": "http://h/c.jpg",
+   "match": true
+  },
+  {
+   "pattern": "**/*.{png,jpg}",
+   "url": "http://h/c.png",
+   "match": true
+  },
+  {
+   "pattern": "**/*.{png,jpg}",
+   "url": "http://h/c.gif",
+   "match": false
+  },
+  {
+   "pattern": "**/*.{png,jpg}",
+   "url": "http://h/a/b/c.jpg",
+   "match": true
+  },
+  {
+   "pattern": "/api/data",
+   "url": "http://h/v2/api/data?q=1",
+   "match": false
+  },
+  {
+   "pattern": "/api/data",
+   "url": "/api/data",
+   "match": true
+  },
+  {
+   "pattern": "*.js",
+   "url": "https://h/a/b/foo.js",
+   "match": false
+  },
+  {
+   "pattern": "*.js",
+   "url": "foo.js",
+   "match": true
+  },
+  {
+   "pattern": "https://foo/**/bar.js",
+   "url": "https://foo/bar.js",
+   "match": true
+  },
+  {
+   "pattern": "https://foo/**/bar.js",
+   "url": "https://foo/a/bar.js",
+   "match": true
+  },
+  {
+   "pattern": "https://foo/**/bar.js",
+   "url": "https://foo/a/b/bar.js",
+   "match": true
+  },
+  {
+   "pattern": "**/get?test=1",
+   "url": "http://h/getXtest=1",
+   "match": false
+  },
+  {
+   "pattern": "**/get?test=1",
+   "url": "http://h/get?test=1",
+   "match": true
+  },
+  {
+   "pattern": "**/v[0-9]",
+   "url": "http://h/v1",
+   "match": false
+  },
+  {
+   "pattern": "**/v[0-9]",
+   "url": "http://h/v[0-9]",
+   "match": true
+  },
+  {
+   "pattern": "**/json",
+   "url": "http://h/json",
+   "match": true
+  },
+  {
+   "pattern": "**/json",
+   "url": "http://h/json/extra",
+   "match": false
+  },
+  {
+   "pattern": "**/json",
+   "url": "http://h/a/json",
+   "match": true
+  },
+  {
+   "pattern": "{*.png,*.jpg}",
+   "url": "logo.png",
+   "match": true
+  },
+  {
+   "pattern": "{*.png,*.jpg}",
+   "url": "logo.jpg",
+   "match": true
+  },
+  {
+   "pattern": "{*.png,*.jpg}",
+   "url": "logo.gif",
+   "match": false
+  },
+  {
+   "pattern": "**",
+   "url": "http://h/anything",
+   "match": true
+  },
+  {
+   "pattern": "**",
+   "url": "",
+   "match": true
+  },
+  {
+   "pattern": "**/*.png",
+   "url": "http://h/a/b.png",
+   "match": true
+  },
+  {
+   "pattern": "**/*.png",
+   "url": "http://h/b.png",
+   "match": true
+  },
+  {
+   "pattern": "**/text",
+   "url": "http://127.0.0.1:1/text",
+   "match": true
+  },
+  {
+   "pattern": "**/api/echo",
+   "url": "http://127.0.0.1:1/api/echo",
+   "match": true
+  },
+  {
+   "pattern": "**/subpage",
+   "url": "http://127.0.0.1:1/subpage",
+   "match": true
+  },
+  {
+   "pattern": "a,b",
+   "url": "a,b",
+   "match": true
+  },
+  {
+   "pattern": "**/*.{png,jpg,jpeg,gif,svg,webp,ico}",
+   "url": "http://h/x.webp",
+   "match": true
+  },
+  {
+   "pattern": "**/*.{png,jpg,jpeg,gif,svg,webp,ico}",
+   "url": "http://h/x.txt",
+   "match": false
+  },
+  {
+   "pattern": "**/get*",
+   "url": "http://h/getfoo",
+   "match": true
+  },
+  {
+   "pattern": "**/get*",
+   "url": "http://h/get",
+   "match": true
+  },
+  {
+   "pattern": "{a,{b,c}}",
+   "url": "http://h/x",
+   "error": true
+  },
+  {
+   "pattern": "}bad",
+   "url": "http://h/x",
+   "error": true
+  },
+  {
+   "pattern": "{unclosed",
+   "url": "http://h/x",
+   "error": true
+  }
+ ],
+ "vibiumDeviations": [
+  {
+   "pattern": "http://a.com",
+   "url": "http://a.com/",
+   "match": true,
+   "why": "A pattern with no glob syntax that parses as an absolute URL is normalized (lowercase scheme+host, empty path becomes \"/\") so it matches the URL shape browsers actually report. Raw Playwright glob would say false."
+  },
+  {
+   "pattern": "http://a.com",
+   "url": "http://a.com",
+   "match": false,
+   "why": "Same normalization: the pattern becomes http://a.com/, so the path-less form no longer matches."
+  }
+ ]
+}

--- a/clicker/internal/urlmatch/urlmatch.go
+++ b/clicker/internal/urlmatch/urlmatch.go
@@ -1,0 +1,204 @@
+// Package urlmatch implements URL glob matching for route interception and
+// request/response observers.
+//
+// The dialect is Playwright's, so patterns written for Playwright behave the
+// same here. Before this package the matching lived in each client and had
+// drifted: the JS client supported {a,b} groups, the Python client used fnmatch
+// (where * crosses "/"), and the Java client matched substrings.
+package urlmatch
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// escapedChars are the characters that must be escaped to appear literally in a
+// regular expression. Note "?" is here: in this dialect it is a literal, not a
+// single-character wildcard.
+var escapedChars = map[byte]bool{
+	'$': true, '^': true, '+': true, '.': true, '*': true, '(': true, ')': true,
+	'|': true, '\\': true, '?': true, '{': true, '}': true, '[': true, ']': true,
+}
+
+// Matcher is a compiled pattern.
+type Matcher struct {
+	pattern string
+	re      *regexp.Regexp
+}
+
+// Pattern returns the glob the matcher was compiled from.
+func (m *Matcher) Match(u string) bool { return m.re.MatchString(u) }
+
+// String returns the original glob.
+func (m *Matcher) String() string { return m.pattern }
+
+var cache sync.Map // pattern -> *cacheEntry
+
+type cacheEntry struct {
+	m   *Matcher
+	err error
+}
+
+// Compile builds a Matcher, memoizing the result per pattern.
+func Compile(pattern string) (*Matcher, error) {
+	if v, ok := cache.Load(pattern); ok {
+		e := v.(*cacheEntry)
+		return e.m, e.err
+	}
+
+	e := &cacheEntry{}
+	expr, err := globToRegex(pattern)
+	if err != nil {
+		e.err = err
+	} else if re, cerr := regexp.Compile(expr); cerr != nil {
+		e.err = fmt.Errorf("invalid glob pattern %q: %w", pattern, cerr)
+	} else {
+		e.m = &Matcher{pattern: pattern, re: re}
+	}
+
+	cache.Store(pattern, e)
+	return e.m, e.err
+}
+
+// Match reports whether url matches pattern. An empty pattern matches anything.
+func Match(pattern, u string) (bool, error) {
+	if pattern == "" {
+		return true, nil
+	}
+	m, err := Compile(normalizePattern(pattern))
+	if err != nil {
+		return false, err
+	}
+	return m.Match(u), nil
+}
+
+// Loose is the predicate for the "wait until the URL contains ..." family,
+// which is documented as a substring test. A pattern carrying glob syntax is
+// matched as a glob; anything else is a plain substring test, so
+// `vibium wait url "/dashboard"` keeps working.
+func Loose(pattern, u string) bool {
+	if pattern == "" {
+		return true
+	}
+	if !strings.ContainsAny(pattern, "*{\\") {
+		return strings.Contains(u, pattern)
+	}
+	ok, err := Match(pattern, u)
+	if err != nil {
+		// An unparseable glob falls back to the substring behavior rather than
+		// failing a navigation wait.
+		return strings.Contains(u, pattern)
+	}
+	return ok
+}
+
+// normalizePattern gives a plain absolute URL the same shape the browser
+// reports, so route("http://example.com") matches "http://example.com/".
+// Patterns containing glob syntax are left alone.
+func normalizePattern(pattern string) string {
+	if strings.ContainsAny(pattern, "*{}\\") {
+		return pattern
+	}
+	u, err := url.Parse(pattern)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return pattern
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	if u.Path == "" {
+		u.Path = "/"
+	}
+	return u.String()
+}
+
+// globToRegex is a transliteration of Playwright's globToRegexPattern
+// (reference/playwright/packages/isomorphic/urlMatch.ts).
+func globToRegex(glob string) (string, error) {
+	var b strings.Builder
+	b.WriteByte('^')
+
+	inGroup := false
+	for i := 0; i < len(glob); i++ {
+		c := glob[i]
+
+		if c == '\\' && i+1 < len(glob) {
+			i++
+			writeLiteral(&b, glob[i])
+			continue
+		}
+
+		if c == '*' {
+			charBefore := byte(0)
+			if i > 0 {
+				charBefore = glob[i-1]
+			}
+			starCount := 1
+			for i+1 < len(glob) && glob[i+1] == '*' {
+				starCount++
+				i++
+			}
+			if starCount > 1 {
+				charAfter := byte(0)
+				if i+1 < len(glob) {
+					charAfter = glob[i+1]
+				}
+				if charAfter == '/' {
+					// "/**/" collapses so that https://a/**/b.js also matches https://a/b.js
+					if charBefore == '/' {
+						b.WriteString("((.+/)|)")
+					} else {
+						b.WriteString("(.*/)")
+					}
+					i++
+				} else {
+					b.WriteString("(.*)")
+				}
+			} else {
+				b.WriteString("([^/]*)")
+			}
+			continue
+		}
+
+		switch c {
+		case '{':
+			if inGroup {
+				return "", fmt.Errorf("invalid glob pattern %q: nested '{' is not supported", glob)
+			}
+			inGroup = true
+			b.WriteByte('(')
+		case '}':
+			if !inGroup {
+				return "", fmt.Errorf("invalid glob pattern %q: unmatched '}'", glob)
+			}
+			inGroup = false
+			b.WriteByte(')')
+		case ',':
+			if inGroup {
+				b.WriteByte('|')
+			} else {
+				// Playwright emits "\," here, which JS accepts as an identity
+				// escape but RE2 rejects. A comma is not a metacharacter.
+				b.WriteByte(',')
+			}
+		default:
+			writeLiteral(&b, c)
+		}
+	}
+
+	if inGroup {
+		return "", fmt.Errorf("invalid glob pattern %q: unmatched '{'", glob)
+	}
+
+	b.WriteByte('$')
+	return b.String(), nil
+}
+
+func writeLiteral(b *strings.Builder, c byte) {
+	if escapedChars[c] {
+		b.WriteByte('\\')
+	}
+	b.WriteByte(c)
+}

--- a/clicker/internal/urlmatch/urlmatch_test.go
+++ b/clicker/internal/urlmatch/urlmatch_test.go
@@ -1,0 +1,143 @@
+package urlmatch
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+type fixtureCase struct {
+	Pattern string `json:"pattern"`
+	URL     string `json:"url"`
+	Match   bool   `json:"match"`
+	Error   bool   `json:"error"`
+	Why     string `json:"why"`
+}
+
+type fixture struct {
+	Cases      []fixtureCase `json:"cases"`
+	Deviations []fixtureCase `json:"vibiumDeviations"`
+}
+
+func loadFixture(t *testing.T) fixture {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/url-patterns.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var f fixture
+	if err := json.Unmarshal(raw, &f); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if len(f.Cases) == 0 {
+		t.Fatal("fixture has no cases")
+	}
+	return f
+}
+
+// The expectations in testdata were produced by running Playwright's own
+// globToRegexPattern, so this asserts dialect compatibility rather than
+// agreement with a second reading of the algorithm.
+func TestMatchesPlaywrightDialect(t *testing.T) {
+	f := loadFixture(t)
+	for _, c := range f.Cases {
+		t.Run(c.Pattern+" vs "+c.URL, func(t *testing.T) {
+			got, err := Match(c.Pattern, c.URL)
+			if c.Error {
+				if err == nil {
+					t.Fatalf("Match(%q, %q) = %v, want an error", c.Pattern, c.URL, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Match(%q, %q) error = %v", c.Pattern, c.URL, err)
+			}
+			if got != c.Match {
+				t.Errorf("Match(%q, %q) = %v, want %v", c.Pattern, c.URL, got, c.Match)
+			}
+		})
+	}
+}
+
+func TestDocumentedDeviations(t *testing.T) {
+	f := loadFixture(t)
+	for _, c := range f.Deviations {
+		t.Run(c.Pattern+" vs "+c.URL, func(t *testing.T) {
+			got, err := Match(c.Pattern, c.URL)
+			if err != nil {
+				t.Fatalf("Match(%q, %q) error = %v", c.Pattern, c.URL, err)
+			}
+			if got != c.Match {
+				t.Errorf("Match(%q, %q) = %v, want %v — %s", c.Pattern, c.URL, got, c.Match, c.Why)
+			}
+		})
+	}
+}
+
+func TestEmptyPatternMatchesEverything(t *testing.T) {
+	got, err := Match("", "http://example.com/anything")
+	if err != nil {
+		t.Fatalf("Match error = %v", err)
+	}
+	if !got {
+		t.Error("an empty pattern should match everything")
+	}
+}
+
+// Loose backs the documented "wait until the URL contains ..." behavior, which
+// several commands and the README rely on.
+func TestLoose(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		url     string
+		want    bool
+	}{
+		{"plain substring", "/dashboard", "http://h/app/dashboard?x=1", true},
+		{"plain substring absent", "/admin", "http://h/app/dashboard", false},
+		{"bare word", "success", "http://h/checkout/success", true},
+		{"glob pattern uses glob rules", "**/subpage", "http://h/subpage", true},
+		{"glob pattern anchored", "**/subpage", "http://h/subpage/extra", false},
+		{"glob with braces", "**/*.{png,jpg}", "http://h/a/b.png", true},
+		{"empty matches", "", "http://h/x", true},
+		{"unparseable glob falls back to substring", "{unclosed", "http://h/{unclosed/x", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Loose(tt.pattern, tt.url); got != tt.want {
+				t.Errorf("Loose(%q, %q) = %v, want %v", tt.pattern, tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompileErrors(t *testing.T) {
+	for _, pattern := range []string{"{a,{b,c}}", "}bad", "{unclosed"} {
+		if _, err := Compile(pattern); err == nil {
+			t.Errorf("Compile(%q) = nil error, want a syntax error", pattern)
+		}
+	}
+}
+
+// A comma outside a group must stay literal. Playwright emits "\," here, which
+// JavaScript accepts as an identity escape but RE2 rejects outright.
+func TestLiteralCommaCompiles(t *testing.T) {
+	got, err := Match("a,b", "a,b")
+	if err != nil {
+		t.Fatalf("Match error = %v", err)
+	}
+	if !got {
+		t.Error(`Match("a,b", "a,b") = false, want true`)
+	}
+}
+
+func TestCompileIsCached(t *testing.T) {
+	a, err := Compile("**/cached")
+	if err != nil {
+		t.Fatalf("Compile error = %v", err)
+	}
+	b, _ := Compile("**/cached")
+	if a != b {
+		t.Error("Compile should return the memoized matcher for the same pattern")
+	}
+}


### PR DESCRIPTION
Groundwork for moving URL pattern matching out of the clients and into the Go binary. **No callers yet** — this PR is just the implementation and its semantics, so the dialect argument happens in isolation.

## Why

Pattern matching for `page.route` and the request/response observers lives in each client, and the three have already drifted:

| client | dialect |
|---|---|
| `clients/javascript/src/utils/match.ts` | `{a,b}` groups, `*` stops at `/` |
| `clients/python/.../page.py:27` | `fnmatch` — `*` **crosses** `/`, no groups |
| `clients/java/.../Page.java:830` | no groups, **substring** match |

Running all three over a shared table, **19 of 26 cases disagreed**. `page.route("*.jpg")` means three different things depending on which client you use, and `match.ts` throws outright on `{*.png,*.jpg}` (`SyntaxError: Nothing to repeat`), escaping through an unguarded handler loop.

Nothing caught this because every pattern in the automated suite happens to fall in the subset where all three agree. The two non-trivial patterns in the repo live in `tests/manual/`, which `make test` does not run.

## Dialect

Playwright's, transliterated from `reference/playwright/packages/isomorphic/urlMatch.ts`. Patterns written for Playwright behave the same here.

| | |
|---|---|
| anchoring | full-URL, `^…$` |
| `*` | `[^/]*` — does not cross `/` |
| `**` | `.*`; `/**/` collapses so `https://foo/**/bar.js` matches `https://foo/bar.js` |
| `?` | **literal**, not a wildcard |
| `{a,b}` | alternation; nested or unmatched braces are a hard error |
| `[a-z]` | literal characters, not a class |

One deliberate change from Playwright: it emits `\,` for a comma outside a group, which JS accepts as an identity escape but **RE2 rejects**. The comma is written literally instead — same behavior, valid Go.

## Two predicates, not one

`Match` is anchored and glob-only — for routes and observers.

`Loose` backs the separate, documented *"wait until the URL contains …"* family. That contract is explicit in four places (`schema.go:729` "Substring to match in the URL", `wait_cmd.go:44`, `README.md:56`, `tests/js/async/navigation.test.js:85`) and anchored globs would turn every `vibium wait url "/dashboard"` into a permanent timeout. So a plain pattern stays a substring test; a pattern carrying glob syntax is matched as a glob. That kills the fifth dialect without breaking the documented one.

## Testing

The expectations in `testdata/url-patterns.json` were produced by **executing Playwright's own `globToRegexPattern`**, not by a second reading of the algorithm — 44 conformance cases across 20 patterns, plus 3 error cases. 54 subtests, all passing.

The two places vibium deliberately differs are in a separate `vibiumDeviations` block with a stated reason, so a divergence can never be silent: a glob-free pattern that parses as an absolute URL is normalized (lowercase scheme+host, empty path → `/`) so `route("http://a.com")` matches the `http://a.com/` browsers actually report.

The fixture is structured to become the shared cross-client conformance table once the clients stop matching locally.