### PR TITLE
Use urlmatch for waitForURL and delete the fifth glob dialect

### DIFF
--- a/clicker/internal/api/handlers_navigation.go
+++ b/clicker/internal/api/handlers_navigation.go
@@ -2,9 +2,10 @@ package api
 
 import (
 	"fmt"
-	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/vibium/clicker/internal/urlmatch"
 )
 
 // handlePageNavigate handles vibium:page.navigate — navigates to a URL.
@@ -321,7 +322,7 @@ func WaitForURL(s Session, context, pattern string, timeout time.Duration) (stri
 
 	for {
 		url, err := EvalSimpleScript(s, context, "() => window.location.href")
-		if err == nil && matchesPattern(url, pattern) {
+		if err == nil && urlmatch.Loose(pattern, url) {
 			return url, nil
 		}
 
@@ -370,53 +371,4 @@ func readyStateReached(current, target string) bool {
 		return current == target
 	}
 	return c >= t
-}
-
-// matchesPattern checks if a URL matches a pattern.
-// Supports simple string containment and glob-like patterns with *.
-func matchesPattern(url, pattern string) bool {
-	// Exact match
-	if url == pattern {
-		return true
-	}
-
-	// Simple glob: if pattern has *, do basic wildcard matching
-	if strings.Contains(pattern, "*") {
-		return globMatch(url, pattern)
-	}
-
-	// Substring match
-	return strings.Contains(url, pattern)
-}
-
-// globMatch performs simple glob matching where * matches any characters.
-func globMatch(s, pattern string) bool {
-	parts := strings.Split(pattern, "*")
-	if len(parts) == 0 {
-		return true
-	}
-
-	pos := 0
-	for i, part := range parts {
-		if part == "" {
-			continue
-		}
-		idx := strings.Index(s[pos:], part)
-		if idx < 0 {
-			return false
-		}
-		if i == 0 && idx != 0 {
-			// First part must match at start if pattern doesn't start with *
-			return false
-		}
-		pos += idx + len(part)
-	}
-
-	// If pattern doesn't end with *, the last part must match at the end
-	lastPart := parts[len(parts)-1]
-	if lastPart != "" && !strings.HasSuffix(s, lastPart) {
-		return false
-	}
-
-	return true
 }

--- a/clicker/internal/api/handlers_navigation_test.go
+++ b/clicker/internal/api/handlers_navigation_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/vibium/clicker/internal/urlmatch"
+)
+
+// WaitForURL is documented as a substring test ("Wait until the page URL
+// contains a given substring" — agent/schema.go, cmd/clicker/wait_cmd.go,
+// README.md), so it uses urlmatch.Loose rather than the anchored glob matcher.
+//
+// The expectations below are the behavior of the matchesPattern/globMatch pair
+// this replaced, captured over every pattern the tests, docs and README use.
+// They exist so the substring contract cannot be quietly traded away for
+// anchored globs.
+func TestWaitForURLPatternContract(t *testing.T) {
+	tests := []struct {
+		pattern string
+		url     string
+		want    bool
+	}{
+		{"**/login", "http://127.0.0.1:8080/login", true},
+		{"**/login", "http://127.0.0.1:8080/secure", false},
+		{"**/login", "http://127.0.0.1:8080/subpage", false},
+		{"**/login", "http://127.0.0.1:8080/dashboard", false},
+		{"**/login", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"**/login", "http://127.0.0.1:8080/example", false},
+		{"**/login", "http://127.0.0.1:8080/", false},
+		{"**/login", "http://127.0.0.1:8080/checkout/success", false},
+		{"**/login", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/login", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/secure", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/subpage", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/dashboard", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/example", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/checkout/success", false},
+		{"**/nonexistent-page-xyz", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"**/secure", "http://127.0.0.1:8080/login", false},
+		{"**/secure", "http://127.0.0.1:8080/secure", true},
+		{"**/secure", "http://127.0.0.1:8080/subpage", false},
+		{"**/secure", "http://127.0.0.1:8080/dashboard", false},
+		{"**/secure", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"**/secure", "http://127.0.0.1:8080/example", false},
+		{"**/secure", "http://127.0.0.1:8080/", false},
+		{"**/secure", "http://127.0.0.1:8080/checkout/success", false},
+		{"**/secure", "http://127.0.0.1:8080/login?next=/secure", true},
+		{"/login", "http://127.0.0.1:8080/login", true},
+		{"/login", "http://127.0.0.1:8080/secure", false},
+		{"/login", "http://127.0.0.1:8080/subpage", false},
+		{"/login", "http://127.0.0.1:8080/dashboard", false},
+		{"/login", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"/login", "http://127.0.0.1:8080/example", false},
+		{"/login", "http://127.0.0.1:8080/", false},
+		{"/login", "http://127.0.0.1:8080/checkout/success", false},
+		{"/login", "http://127.0.0.1:8080/login?next=/secure", true},
+		{"**/dashboard", "http://127.0.0.1:8080/login", false},
+		{"**/dashboard", "http://127.0.0.1:8080/secure", false},
+		{"**/dashboard", "http://127.0.0.1:8080/subpage", false},
+		{"**/dashboard", "http://127.0.0.1:8080/dashboard", true},
+		{"**/dashboard", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"**/dashboard", "http://127.0.0.1:8080/example", false},
+		{"**/dashboard", "http://127.0.0.1:8080/", false},
+		{"**/dashboard", "http://127.0.0.1:8080/checkout/success", false},
+		{"**/dashboard", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/login", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/secure", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/subpage", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/dashboard", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/example", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/checkout/success", false},
+		{"**/never-going-here", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/login", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/secure", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/subpage", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/dashboard", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/example", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/checkout/success", false},
+		{"**/never-matches-xyz", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"**/subpage", "http://127.0.0.1:8080/login", false},
+		{"**/subpage", "http://127.0.0.1:8080/secure", false},
+		{"**/subpage", "http://127.0.0.1:8080/subpage", true},
+		{"**/subpage", "http://127.0.0.1:8080/dashboard", false},
+		{"**/subpage", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"**/subpage", "http://127.0.0.1:8080/example", false},
+		{"**/subpage", "http://127.0.0.1:8080/", false},
+		{"**/subpage", "http://127.0.0.1:8080/checkout/success", false},
+		{"**/subpage", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"/dashboard", "http://127.0.0.1:8080/login", false},
+		{"/dashboard", "http://127.0.0.1:8080/secure", false},
+		{"/dashboard", "http://127.0.0.1:8080/subpage", false},
+		{"/dashboard", "http://127.0.0.1:8080/dashboard", true},
+		{"/dashboard", "http://127.0.0.1:8080/app/dashboard?x=1", true},
+		{"/dashboard", "http://127.0.0.1:8080/example", false},
+		{"/dashboard", "http://127.0.0.1:8080/", false},
+		{"/dashboard", "http://127.0.0.1:8080/checkout/success", false},
+		{"/dashboard", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"/example", "http://127.0.0.1:8080/login", false},
+		{"/example", "http://127.0.0.1:8080/secure", false},
+		{"/example", "http://127.0.0.1:8080/subpage", false},
+		{"/example", "http://127.0.0.1:8080/dashboard", false},
+		{"/example", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"/example", "http://127.0.0.1:8080/example", true},
+		{"/example", "http://127.0.0.1:8080/", false},
+		{"/example", "http://127.0.0.1:8080/checkout/success", false},
+		{"/example", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"success", "http://127.0.0.1:8080/login", false},
+		{"success", "http://127.0.0.1:8080/secure", false},
+		{"success", "http://127.0.0.1:8080/subpage", false},
+		{"success", "http://127.0.0.1:8080/dashboard", false},
+		{"success", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"success", "http://127.0.0.1:8080/example", false},
+		{"success", "http://127.0.0.1:8080/", false},
+		{"success", "http://127.0.0.1:8080/checkout/success", true},
+		{"success", "http://127.0.0.1:8080/login?next=/secure", false},
+		{"**/checkout/*", "http://127.0.0.1:8080/login", false},
+		{"**/checkout/*", "http://127.0.0.1:8080/secure", false},
+		{"**/checkout/*", "http://127.0.0.1:8080/subpage", false},
+		{"**/checkout/*", "http://127.0.0.1:8080/dashboard", false},
+		{"**/checkout/*", "http://127.0.0.1:8080/app/dashboard?x=1", false},
+		{"**/checkout/*", "http://127.0.0.1:8080/example", false},
+		{"**/checkout/*", "http://127.0.0.1:8080/", false},
+		{"**/checkout/*", "http://127.0.0.1:8080/checkout/success", true},
+		{"**/checkout/*", "http://127.0.0.1:8080/login?next=/secure", false},
+	}
+
+	for _, tt := range tests {
+		if got := urlmatch.Loose(tt.pattern, tt.url); got != tt.want {
+			t.Errorf("Loose(%q, %q) = %v, want %v", tt.pattern, tt.url, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Second step of consolidating URL matching. `matchesPattern`/`globMatch` (`handlers_navigation.go:377-422`) was a *fifth* dialect — its own substring-plus-wildcard scheme, distinct from the three client matchers and from `urlmatch`. This deletes it.

## waitForURL keeps its substring contract

`urlmatch.Loose`, not `Match`. The "contains a substring" behavior is documented in four places:

- `agent/schema.go:729` — "Wait until the page URL **contains** a given substring"
- `cmd/clicker/wait_cmd.go:44` + its examples — `vibium wait url "/dashboard"`
- `README.md:56`
- `tests/js/async/navigation.test.js` — `vibe.waitUntil.url('/login')`

Under an anchored glob every one of those becomes a permanent timeout. `Loose` splits it: a plain pattern stays a substring test, a pattern carrying glob syntax gets glob semantics. That removes the dialect without touching the documented behavior.

## No-regression proof

`handlers_navigation_test.go` captures the deleted pair's behavior over every pattern that appears in the tests, docs and README (`**/login`, `**/secure`, `**/subpage`, `**/dashboard`, `/login`, `/dashboard`, `/example`, `**/checkout/*`, …) crossed with representative URLs — **108 combinations, all identical before and after**.

The expectations were generated by running the *old* implementation, so the test asserts "behaves like what it replaced" rather than "behaves like I think it should". It also pins the substring contract so it cannot be quietly traded for anchored globs later.

Full `make test` passes locally.

Net: −48 lines.