### PR TITLE
Queue client writes so a stalled reader can't freeze the session (#232)

### DIFF
--- a/clicker/internal/api/server.go
+++ b/clicker/internal/api/server.go
@@ -40,13 +40,100 @@ type Server struct {
 	onClose    func(ClientTransport)
 }
 
+// clientWriteDeadline bounds a single socket write. Without it a client that
+// stops reading blocks the writer forever and the queue grows without limit.
+const clientWriteDeadline = 60 * time.Second
+
 // ClientConn represents a connected WebSocket client.
+//
+// Sends are queued and drained by a single writer goroutine, with the socket
+// write performed outside the lock. The browser→client pump calls Send for
+// every forwarded message, so a synchronous write here would let one client
+// that stops reading stall the whole session.
 type ClientConn struct {
 	id     uint64
 	conn   *websocket.Conn
-	mu     sync.Mutex
+	mu     sync.Mutex // guards queue, closed, writeStart
+	cond   *sync.Cond
+	queue  []string
 	closed bool
+	done   chan struct{}
 	server *Server
+
+	writeStart int64 // unix nanos of the in-progress write, 0 when idle
+}
+
+// startWriter begins draining queued messages. Called once per connection.
+func (c *ClientConn) startWriter() {
+	c.cond = sync.NewCond(&c.mu)
+	c.done = make(chan struct{})
+	go c.writeLoop()
+	go c.watchStalledWrite()
+}
+
+// writeLoop drains the queue, writing with the lock released so a stalled
+// client never blocks Send callers.
+func (c *ClientConn) writeLoop() {
+	defer close(c.done)
+	for {
+		c.mu.Lock()
+		for len(c.queue) == 0 && !c.closed {
+			c.cond.Wait()
+		}
+		if len(c.queue) == 0 && c.closed {
+			c.mu.Unlock()
+			return
+		}
+		batch := c.queue
+		c.queue = nil
+		c.writeStart = time.Now().UnixNano()
+		c.mu.Unlock()
+
+		var err error
+		for _, msg := range batch {
+			c.conn.SetWriteDeadline(time.Now().Add(clientWriteDeadline))
+			if err = c.conn.WriteMessage(websocket.TextMessage, []byte(msg)); err != nil {
+				break
+			}
+		}
+
+		c.mu.Lock()
+		c.writeStart = 0
+		if err != nil {
+			// The client is gone or wedged — stop accepting messages so the
+			// queue can't grow unboundedly against a reader that never drains.
+			c.closed = true
+			c.mu.Unlock()
+			fmt.Fprintf(os.Stderr, "[proxy] Client %d write failed, dropping connection: %v\n", c.id, err)
+			c.conn.Close()
+			return
+		}
+		c.mu.Unlock()
+	}
+}
+
+// watchStalledWrite reports a write that is currently blocked — the signature
+// of a client that stopped reading its socket.
+func (c *ClientConn) watchStalledWrite() {
+	t := time.NewTicker(10 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-t.C:
+			c.mu.Lock()
+			start := c.writeStart
+			depth := len(c.queue)
+			c.mu.Unlock()
+			if start != 0 {
+				if blocked := time.Since(time.Unix(0, start)); blocked > 5*time.Second {
+					fmt.Fprintf(os.Stderr, "[proxy] client %d write blocked for %.0fs (%d messages queued) — client not reading\n",
+						c.id, blocked.Seconds(), depth)
+				}
+			}
+		}
+	}
 }
 
 // ID returns the client connection ID.
@@ -168,6 +255,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		conn:   conn,
 		server: s,
 	}
+	client.startWriter()
 
 	s.clients.Store(client.id, client)
 	fmt.Fprintf(os.Stderr, "[proxy] Client %d connected from %s\n", client.id, r.RemoteAddr)
@@ -217,7 +305,7 @@ func (s *Server) handleClient(client *ClientConn) {
 	}
 }
 
-// Send sends a text message to the client.
+// Send queues a message for the client. It never blocks and never drops.
 func (c *ClientConn) Send(msg string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -226,21 +314,26 @@ func (c *ClientConn) Send(msg string) error {
 		return fmt.Errorf("connection closed")
 	}
 
-	return c.conn.WriteMessage(websocket.TextMessage, []byte(msg))
+	c.queue = append(c.queue, msg)
+	c.cond.Signal()
+	return nil
 }
 
-// Close closes the client connection.
+// Close stops accepting messages, waits for the queue to drain, then closes
+// the socket.
 func (c *ClientConn) Close() error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.closed {
+		c.mu.Unlock()
 		return nil
 	}
-
 	c.closed = true
+	c.cond.Signal()
+	c.mu.Unlock()
 
-	// Send close message
+	<-c.done
+
+	c.conn.SetWriteDeadline(time.Now().Add(clientWriteDeadline))
 	c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 
 	return c.conn.Close()

--- a/clicker/internal/api/server_test.go
+++ b/clicker/internal/api/server_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newTestClientConn spins up a real WebSocket pair and returns the server-side
+// ClientConn plus the raw client socket, so tests can stop reading on purpose.
+func newTestClientConn(t *testing.T) (*ClientConn, *websocket.Conn) {
+	t.Helper()
+
+	var (
+		mu     sync.Mutex
+		server *ClientConn
+		ready  = make(chan struct{})
+	)
+
+	upgrader := websocket.Upgrader{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		c := &ClientConn{id: 1, conn: conn}
+		c.startWriter()
+		mu.Lock()
+		server = c
+		mu.Unlock()
+		close(ready)
+		// Hold the handler open for the life of the test.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(ts.Close)
+
+	dialer := websocket.Dialer{}
+	client, _, err := dialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server side never accepted the connection")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	return server, client
+}
+
+// A client that stops reading must not block the caller. The browser→client
+// pump calls Send for every forwarded message, so a synchronous write here
+// froze the whole session once the socket buffers filled (issue #232).
+func TestSendDoesNotBlockOnStalledClient(t *testing.T) {
+	server, _ := newTestClientConn(t)
+
+	// Never read from the client socket. 12MB comfortably exceeds any
+	// kernel/gorilla buffering, so the writer goroutine will be stuck.
+	payload := strings.Repeat("x", 64*1024)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			if err := server.Send(payload); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Send blocked on a client that stopped reading")
+	}
+}
+
+func TestSendDeliversInOrder(t *testing.T) {
+	server, client := newTestClientConn(t)
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		if err := server.Send(string(rune('a'+i%26)) + "-msg"); err != nil {
+			t.Fatalf("Send %d: %v", i, err)
+		}
+	}
+
+	client.SetReadDeadline(time.Now().Add(10 * time.Second))
+	for i := 0; i < n; i++ {
+		_, msg, err := client.ReadMessage()
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		want := string(rune('a'+i%26)) + "-msg"
+		if string(msg) != want {
+			t.Fatalf("message %d = %q, want %q (ordering must be preserved)", i, msg, want)
+		}
+	}
+}
+
+func TestSendAfterCloseFails(t *testing.T) {
+	server, _ := newTestClientConn(t)
+
+	if err := server.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := server.Send("late"); err == nil {
+		t.Error("Send after Close should fail")
+	}
+	// Close must be idempotent — the router calls it on teardown paths that
+	// can overlap.
+	if err := server.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+func TestCloseDrainsQueuedMessages(t *testing.T) {
+	server, client := newTestClientConn(t)
+
+	for i := 0; i < 20; i++ {
+		if err := server.Send("queued"); err != nil {
+			t.Fatalf("Send %d: %v", i, err)
+		}
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- server.Close() }()
+
+	client.SetReadDeadline(time.Now().Add(10 * time.Second))
+	for i := 0; i < 20; i++ {
+		if _, _, err := client.ReadMessage(); err != nil {
+			t.Fatalf("queued message %d was lost: %v", i, err)
+		}
+	}
+
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close did not return after the queue drained")
+	}
+}


### PR DESCRIPTION
`ClientConn.Send` did a synchronous `websocket.WriteMessage` under the connection mutex, and `routeBrowserToClient` calls `Send` for **every** message forwarded from the browser. Once a client stopped draining its socket and the kernel buffers filled, that write blocked the pump — and with it the entire session.

This is the same defect fixed for the pipe transport in #231. It was still live in the WebSocket transport, which is what `vibium serve` and daemon-mode clients use.

## Fix

The `PipeClientConn` design, ported: an unbounded no-drop queue drained by a single writer goroutine, socket writes performed with no lock held, and a watchdog that reports a write blocked longer than 5s.

Two deliberate differences from the pipe version, because a socket can stall where a pipe returns an error:

- each write gets a **60s deadline**, so a wedged peer eventually errors instead of blocking forever
- a failed write marks the connection closed and drops it, so the queue cannot grow without bound against a reader that never returns

`Close` now drains queued messages before closing the socket, so teardown does not discard responses the client has not read yet.

## Verification

The stall test is a real regression test, not a smoke test. Restoring the old synchronous `Send` (and nothing else) makes it fail:

```
--- FAIL: TestSendDoesNotBlockOnStalledClient (10.00s)
    server_test.go:83: Send blocked on a client that stopped reading
```

With the queue it returns immediately. It uses a real WebSocket pair with a client that never reads and pushes 12MB, comfortably past any kernel or gorilla buffering.

Also covered: message ordering is preserved, `Close` drains the queue rather than dropping it, `Send` after `Close` fails, and `Close` is idempotent (the router calls it on teardown paths that can overlap).

Full `make test` passes.

Fixes #232