### PR TITLE
Serialize dispatched commands only while recording

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ test-js-async: build-go
 		tests/js/async/storage.test.js \
 		tests/js/async/frames.test.js \
 		tests/js/async/object-model.test.js \
+		tests/js/async/dispatch-concurrency.test.js \
 		tests/js/async/navigation.test.js \
 		tests/js/async/lifecycle.test.js
 

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -221,14 +221,39 @@ func handlerCapturesBefore(method string) bool {
 }
 
 // dispatch wraps a vibium handler with automatic action recording.
+// unblocksAnotherCommand reports whether a method exists to release a browser
+// state that is blocking some other in-flight command. Such a method must never
+// wait on dispatchMu: the command it would wait for is the one it is meant to
+// unblock, which is a deadlock with a 60s fuse.
+//
+// Chrome is launched with unhandledPromptBehavior "ignore", so a dialog opened
+// by a click stays open and Chrome answers nothing else for that context until
+// browsingContext.handleUserPrompt arrives.
+func unblocksAnotherCommand(method string) bool {
+	switch method {
+	case "vibium:dialog.accept", "vibium:dialog.dismiss":
+		return true
+	}
+	return false
+}
+
 func (r *Router) dispatch(session *BrowserSession, cmd bidiCommand, handler vibiumHandler) {
 	go func() {
-		session.dispatchMu.Lock()
-		defer session.dispatchMu.Unlock()
-
 		session.mu.Lock()
 		recorder := session.recorder
 		session.mu.Unlock()
+
+		// dispatchMu orders actions so a recording's before/after snapshots see
+		// the page state its own action produced. Nothing outside recording
+		// needs it — the BiDi client is already safe for concurrent commands,
+		// and every session field this function touches (lastElementBox,
+		// handlerScreenshot, screenshotInFlight) is read only while recording.
+		// Taking it unconditionally serialized all 104 dispatched methods on
+		// every session, recording or not.
+		if recorder != nil && recorder.IsRecording() && !unblocksAnotherCommand(cmd.Method) {
+			session.dispatchMu.Lock()
+			defer session.dispatchMu.Unlock()
+		}
 
 		var callId string
 

--- a/tests/js/async/dispatch-concurrency.test.js
+++ b/tests/js/async/dispatch-concurrency.test.js
@@ -1,0 +1,81 @@
+/**
+ * JS Library Tests: command dispatch concurrency
+ *
+ * The engine serialized every dispatched vibium: command on a per-session mutex
+ * whose only purpose is keeping a recording's before/after snapshots consistent.
+ * It was taken unconditionally, so all 104 dispatched methods ran one at a time
+ * even with recording off.
+ *
+ * Uses a local HTTP server — no external network dependencies.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+
+const { browser } = require('../../../clients/javascript/dist');
+
+let server;
+let baseURL;
+let bro;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<html><head><title>Dispatch</title></head><body><h1>Dispatch</h1></body></html>');
+  });
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      baseURL = `http://127.0.0.1:${server.address().port}`;
+      resolve();
+    });
+  });
+  bro = await browser.start({ headless: true });
+});
+
+after(async () => {
+  await bro.stop();
+  if (server) server.close();
+});
+
+describe('Dispatch concurrency', () => {
+  test('commands overlap when not recording', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    // page.wait sleeps server-side for the requested duration, so three
+    // concurrent 800ms waits take ~800ms if they overlap and ~2400ms if the
+    // dispatcher serializes them.
+    const started = Date.now();
+    await Promise.all([vibe.wait(800), vibe.wait(800), vibe.wait(800)]);
+    const elapsed = Date.now() - started;
+
+    assert.ok(
+      elapsed < 2000,
+      `three concurrent 800ms waits took ${elapsed}ms — dispatch is still serialized`
+    );
+    await vibe.close();
+  });
+
+  test('a second page is not blocked by a slow command on the first', async () => {
+    const one = await bro.newPage();
+    const two = await bro.newPage();
+    await one.go(baseURL);
+    await two.go(baseURL);
+
+    const started = Date.now();
+    const slow = one.wait(1500);
+    const title = await two.title();
+    const titleElapsed = Date.now() - started;
+
+    assert.strictEqual(title, 'Dispatch');
+    assert.ok(
+      titleElapsed < 1200,
+      `title() on a second page waited ${titleElapsed}ms behind a slow command on the first`
+    );
+
+    await slow;
+    await one.close();
+    await two.close();
+  });
+});


### PR DESCRIPTION
`dispatchMu` was taken unconditionally at the top of every dispatched `vibium:` command (`router.go:226`), **before** the code even checks whether a recorder exists (`:235`). All 104 dispatched methods therefore ran one at a time per session — including the normal case, with recording off.

## What the lock is actually for

Keeping a recording's before/after snapshots consistent with the action between them. Nothing else needs it:

- `bidi.Client` already routes concurrent commands by id (its own demultiplexer)
- every session field this path touches — `lastElementBox`, `handlerScreenshot`, `screenshotInFlight` — is read **only** on the recording branch (`lastElementBox` is even commented "for recording")

So it is now taken only while recording.

## Measured

Three concurrent 800ms `page.wait` calls:

| | elapsed |
|---|---|
| before | **2404ms** (serialized) |
| after | **~800ms** (concurrent) |

A slow command on one page also no longer blocks a command on a different page.

## The deadlock carve-out

Commands that exist to *release* a blocked context must never wait on this lock. Chrome is launched with `unhandledPromptBehavior: {default: "ignore"}` (`browser/launcher.go:288`), so a dialog opened by a click stays open and Chrome answers nothing else for that context. If `dialog.accept` waits on `dispatchMu`, it waits on the very command the dialog is blocking — a circular wait with a 60s fuse.

Evidence this is real rather than theoretical: **all three clients already avoid `vibium:dialog.accept`**, sending raw `browsingContext.handleUserPrompt` instead. The Java client says why in a comment:

```java
// Use raw BiDi command to avoid dispatch mutex deadlock with element.click
```

Three clients independently routed around this lock instead of it being fixed.

## Testing

`tests/js/async/dispatch-concurrency.test.js` — two tests, both fail against the unconditional lock:

```
✖ commands overlap when not recording
  AssertionError: three concurrent 800ms waits took 2404ms — dispatch is still serialized
```

Recording behavior is covered by the existing `recording.test.js` suite, which passes unchanged.

Full `make test` passes.