### PR TITLE
Fail fast when a context is blocked by an open dialog (#151)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ test-js-async: build-go
 		tests/js/async/frames.test.js \
 		tests/js/async/object-model.test.js \
 		tests/js/async/dispatch-concurrency.test.js \
+		tests/js/async/prompt-blocked.test.js \
 		tests/js/async/navigation.test.js \
 		tests/js/async/lifecycle.test.js
 

--- a/clicker/internal/api/prompt.go
+++ b/clicker/internal/api/prompt.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// PromptTracker records which browsing contexts have an open user prompt.
+//
+// The browser is launched with unhandledPromptBehavior "ignore"
+// (browser/launcher.go), so an alert/confirm/prompt opened by a click stays
+// open, and Chrome answers no script or input command for that context until
+// browsingContext.handleUserPrompt arrives. Without this state a doomed command
+// just sits in its 60s timeout.
+type PromptTracker struct {
+	mu   sync.Mutex
+	open map[string]string // context -> prompt type ("alert", "confirm", ...)
+}
+
+// NewPromptTracker creates an empty tracker.
+func NewPromptTracker() *PromptTracker {
+	return &PromptTracker{open: make(map[string]string)}
+}
+
+// Observe updates the tracker from a raw BiDi event. Anything that is not a
+// user-prompt event is ignored, so callers can hand it every event they see.
+func (t *PromptTracker) Observe(raw []byte) {
+	if t == nil {
+		return
+	}
+	var evt struct {
+		Method string `json:"method"`
+		Params struct {
+			Context string `json:"context"`
+			Type    string `json:"type"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(raw, &evt); err != nil {
+		return
+	}
+	if evt.Params.Context == "" {
+		return
+	}
+
+	switch evt.Method {
+	case "browsingContext.userPromptOpened":
+		promptType := evt.Params.Type
+		if promptType == "" {
+			promptType = "dialog"
+		}
+		t.mu.Lock()
+		t.open[evt.Params.Context] = promptType
+		t.mu.Unlock()
+	case "browsingContext.userPromptClosed":
+		t.mu.Lock()
+		delete(t.open, evt.Params.Context)
+		t.mu.Unlock()
+	}
+}
+
+// OpenPrompt returns the open prompt's type for a context, and whether one is open.
+func (t *PromptTracker) OpenPrompt(context string) (string, bool) {
+	if t == nil || context == "" {
+		return "", false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	promptType, ok := t.open[context]
+	return promptType, ok
+}
+
+// Clear forgets any prompt recorded for a context. Used when a context goes
+// away, so a destroyed context cannot leave a permanent block behind.
+func (t *PromptTracker) Clear(context string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	delete(t.open, context)
+	t.mu.Unlock()
+}
+
+// BlockedByPromptError is returned instead of waiting out the command timeout
+// when the target context has an open user prompt.
+type BlockedByPromptError struct {
+	Context    string
+	PromptType string
+}
+
+func (e *BlockedByPromptError) Error() string {
+	return fmt.Sprintf("context is blocked by an open %s dialog; accept or dismiss it first "+
+		"(dialog.accept / dialog.dismiss, or handle it with an onDialog listener)", e.PromptType)
+}
+
+// promptSensitiveMethods are the BiDi commands Chrome will not answer while a
+// user prompt is open. It is an allowlist rather than a denylist so an
+// unrecognised method keeps its current behavior; in particular
+// browsingContext.handleUserPrompt must always get through, since it is what
+// clears the block.
+var promptSensitiveMethods = map[string]bool{
+	"script.callFunction":               true,
+	"script.evaluate":                   true,
+	"input.performActions":              true,
+	"input.releaseActions":              true,
+	"input.setFiles":                    true,
+	"browsingContext.navigate":          true,
+	"browsingContext.reload":            true,
+	"browsingContext.traverseHistory":   true,
+	"browsingContext.captureScreenshot": true,
+	"browsingContext.print":             true,
+}
+
+// contextFromParams pulls the browsing context a command targets, covering both
+// the flat "context" param and script.*'s nested target object.
+func contextFromParams(params map[string]interface{}) string {
+	if ctx, ok := params["context"].(string); ok && ctx != "" {
+		return ctx
+	}
+	if target, ok := params["target"].(map[string]interface{}); ok {
+		if ctx, ok := target["context"].(string); ok {
+			return ctx
+		}
+	}
+	return ""
+}
+
+// checkPromptBlocked returns a BlockedByPromptError when the command would
+// target a context whose user prompt is open.
+func checkPromptBlocked(t *PromptTracker, method string, params map[string]interface{}) error {
+	if t == nil || !promptSensitiveMethods[method] {
+		return nil
+	}
+	context := contextFromParams(params)
+	if context == "" {
+		return nil
+	}
+	if promptType, open := t.OpenPrompt(context); open {
+		return &BlockedByPromptError{Context: context, PromptType: promptType}
+	}
+	return nil
+}

--- a/clicker/internal/api/prompt_test.go
+++ b/clicker/internal/api/prompt_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPromptTrackerObserve(t *testing.T) {
+	tr := NewPromptTracker()
+
+	if _, open := tr.OpenPrompt("ctx-1"); open {
+		t.Fatal("a fresh tracker should report no open prompt")
+	}
+
+	tr.Observe([]byte(`{"method":"browsingContext.userPromptOpened","params":{"context":"ctx-1","type":"alert","message":"hi"}}`))
+	promptType, open := tr.OpenPrompt("ctx-1")
+	if !open {
+		t.Fatal("userPromptOpened should mark the context blocked")
+	}
+	if promptType != "alert" {
+		t.Errorf("prompt type = %q, want %q", promptType, "alert")
+	}
+
+	// A different context is unaffected.
+	if _, open := tr.OpenPrompt("ctx-2"); open {
+		t.Error("a prompt in ctx-1 should not block ctx-2")
+	}
+
+	tr.Observe([]byte(`{"method":"browsingContext.userPromptClosed","params":{"context":"ctx-1","accepted":true,"type":"alert"}}`))
+	if _, open := tr.OpenPrompt("ctx-1"); open {
+		t.Error("userPromptClosed should clear the block")
+	}
+}
+
+func TestPromptTrackerIgnoresOtherEvents(t *testing.T) {
+	tr := NewPromptTracker()
+	for _, raw := range []string{
+		`{"method":"browsingContext.load","params":{"context":"ctx-1"}}`,
+		`{"method":"network.beforeRequestSent","params":{"context":"ctx-1"}}`,
+		`{"id":1,"type":"success","result":{}}`,
+		`not json at all`,
+		`{"method":"browsingContext.userPromptOpened","params":{}}`,
+	} {
+		tr.Observe([]byte(raw))
+	}
+	if _, open := tr.OpenPrompt("ctx-1"); open {
+		t.Error("only userPromptOpened with a context should block")
+	}
+}
+
+func TestPromptTrackerClear(t *testing.T) {
+	tr := NewPromptTracker()
+	tr.Observe([]byte(`{"method":"browsingContext.userPromptOpened","params":{"context":"ctx-1","type":"confirm"}}`))
+	tr.Clear("ctx-1")
+	if _, open := tr.OpenPrompt("ctx-1"); open {
+		t.Error("Clear should drop the block, so a destroyed context cannot block forever")
+	}
+}
+
+func TestCheckPromptBlocked(t *testing.T) {
+	tr := NewPromptTracker()
+	tr.Observe([]byte(`{"method":"browsingContext.userPromptOpened","params":{"context":"ctx-1","type":"alert"}}`))
+
+	tests := []struct {
+		name    string
+		method  string
+		params  map[string]interface{}
+		blocked bool
+	}{
+		{
+			name:    "script.callFunction on a blocked context",
+			method:  "script.callFunction",
+			params:  map[string]interface{}{"target": map[string]interface{}{"context": "ctx-1"}},
+			blocked: true,
+		},
+		{
+			name:    "input.performActions on a blocked context",
+			method:  "input.performActions",
+			params:  map[string]interface{}{"context": "ctx-1"},
+			blocked: true,
+		},
+		{
+			name:    "navigate on a blocked context",
+			method:  "browsingContext.navigate",
+			params:  map[string]interface{}{"context": "ctx-1"},
+			blocked: true,
+		},
+		{
+			// This is the command that clears the block; blocking it would be a
+			// deadlock.
+			name:    "handleUserPrompt is never blocked",
+			method:  "browsingContext.handleUserPrompt",
+			params:  map[string]interface{}{"context": "ctx-1"},
+			blocked: false,
+		},
+		{
+			name:    "getTree is not prompt-sensitive",
+			method:  "browsingContext.getTree",
+			params:  map[string]interface{}{"context": "ctx-1"},
+			blocked: false,
+		},
+		{
+			name:    "an unrelated context is not blocked",
+			method:  "script.callFunction",
+			params:  map[string]interface{}{"target": map[string]interface{}{"context": "ctx-2"}},
+			blocked: false,
+		},
+		{
+			name:    "no context means no decision",
+			method:  "script.callFunction",
+			params:  map[string]interface{}{},
+			blocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkPromptBlocked(tr, tt.method, tt.params)
+			if tt.blocked {
+				var blockErr *BlockedByPromptError
+				if !errors.As(err, &blockErr) {
+					t.Fatalf("error = %v, want *BlockedByPromptError", err)
+				}
+				if blockErr.PromptType != "alert" {
+					t.Errorf("PromptType = %q, want %q", blockErr.PromptType, "alert")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestCheckPromptBlockedNilTracker(t *testing.T) {
+	if err := checkPromptBlocked(nil, "script.callFunction", map[string]interface{}{"context": "ctx-1"}); err != nil {
+		t.Errorf("a nil tracker should never block: %v", err)
+	}
+}

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -44,13 +44,17 @@ type BrowserSession struct {
 
 	activeContext string // last context foregrounded for pointer input; "" = unknown
 
+	// prompts records which contexts have an open user prompt, so a command
+	// Chrome will not answer fails immediately instead of timing out.
+	prompts *PromptTracker
+
 	// Recording support
 	recorder           *Recorder
-	lastContext        string   // last browsing context resolved by a command
-	lastURL            string   // last known page URL, updated from load/navigation events
-	lastElementBox     *BoxInfo // last resolved element box, for recording
-	screenshotInFlight int32    // atomic; 1 = screenshot capture in progress
-	handlerScreenshot  int32    // atomic; 1 = handler already captured filmstrip screenshot
+	lastContext        string     // last browsing context resolved by a command
+	lastURL            string     // last known page URL, updated from load/navigation events
+	lastElementBox     *BoxInfo   // last resolved element box, for recording
+	screenshotInFlight int32      // atomic; 1 = screenshot capture in progress
+	handlerScreenshot  int32      // atomic; 1 = handler already captured filmstrip screenshot
 	dispatchMu         sync.Mutex // serializes dispatch goroutines so screenshots capture correct page state
 }
 
@@ -167,6 +171,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		stopChan:       make(chan struct{}),
 		internalCmds:   make(map[int]chan json.RawMessage),
 		nextInternalID: 1000000, // Start at high number to avoid collision with client IDs
+		prompts:        NewPromptTracker(),
 	}
 
 	r.sessions.Store(client.ID(), session)
@@ -184,6 +189,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 			"network.beforeRequestSent",
 			"network.responseCompleted",
 			"browsingContext.userPromptOpened",
+			"browsingContext.userPromptClosed",
 			"log.entryAdded",
 			"browsingContext.downloadWillBegin",
 			"browsingContext.downloadEnd",
@@ -869,6 +875,9 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 			}
 		}
 
+		// Track user prompts so prompt-sensitive commands can fail fast.
+		session.prompts.Observe([]byte(msg))
+
 		// Record event for recording (non-blocking)
 		session.mu.Lock()
 		recorder := session.recorder
@@ -929,6 +938,12 @@ func (r *Router) sendInternalCommand(session *BrowserSession, method string, par
 
 // sendInternalCommandWithTimeout sends a BiDi command and waits for the response with a custom timeout.
 func (r *Router) sendInternalCommandWithTimeout(session *BrowserSession, method string, params map[string]interface{}, timeout time.Duration) (json.RawMessage, error) {
+	// An open user prompt means Chrome will never answer this command, so
+	// report it now rather than after the timeout.
+	if err := checkPromptBlocked(session.prompts, method, params); err != nil {
+		return nil, err
+	}
+
 	// Chrome blocks ~5s dispatching pointer input to a backgrounded tab (#248),
 	// so foreground the target first — but only on a change of context. An
 	// activate round-trip between the two clicks of a dblclick would push them

--- a/clicker/internal/api/session.go
+++ b/clicker/internal/api/session.go
@@ -77,8 +77,9 @@ func (p *APISession) SetLastElementBox(box *BoxInfo) {
 // safe no-op.
 type AgentSession struct {
 	Client   *bidi.Client
-	Context  string              // optional explicit context override (active tab)
-	OnBoxSet func(box *BoxInfo)  // optional callback when element box is set
+	Context  string             // optional explicit context override (active tab)
+	OnBoxSet func(box *BoxInfo) // optional callback when element box is set
+	Prompts  *PromptTracker     // optional; when set, prompt-blocked commands fail fast
 }
 
 // NewAgentSession creates an AgentSession.
@@ -87,6 +88,9 @@ func NewAgentSession(client *bidi.Client) *AgentSession {
 }
 
 func (m *AgentSession) SendBidiCommand(method string, params map[string]interface{}) (json.RawMessage, error) {
+	if err := checkPromptBlocked(m.Prompts, method, params); err != nil {
+		return nil, err
+	}
 	msg, err := m.Client.SendCommand(method, params)
 	if err != nil {
 		return nil, err
@@ -101,6 +105,9 @@ func (m *AgentSession) SendBidiCommand(method string, params map[string]interfac
 }
 
 func (m *AgentSession) SendBidiCommandWithTimeout(method string, params map[string]interface{}, timeout time.Duration) (json.RawMessage, error) {
+	if err := checkPromptBlocked(m.Prompts, method, params); err != nil {
+		return nil, err
+	}
 	msg, err := m.Client.SendCommandWithTimeout(method, params, timeout)
 	if err != nil {
 		return nil, err

--- a/tests/js/async/prompt-blocked.test.js
+++ b/tests/js/async/prompt-blocked.test.js
@@ -1,0 +1,122 @@
+/**
+ * JS Library Tests: commands against a prompt-blocked context
+ *
+ * The browser is launched with unhandledPromptBehavior "ignore", so an alert
+ * opened by a click stays open and Chrome answers no script or input command
+ * for that context. Without prompt tracking every such command sat out the full
+ * 60s BiDi timeout (#151, #146).
+ *
+ * Uses a local HTTP server — no external network dependencies.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+
+const { browser } = require('../../../clients/javascript/dist');
+
+let server;
+let baseURL;
+let bro;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<html><head><title>Prompt</title></head><body>
+      <button id="alert-btn" onclick="alert('blocked')">Alert</button>
+    </body></html>`);
+  });
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      baseURL = `http://127.0.0.1:${server.address().port}`;
+      resolve();
+    });
+  });
+  bro = await browser.start({ headless: true });
+});
+
+after(async () => {
+  await bro.stop();
+  if (server) server.close();
+});
+
+describe('Prompt-blocked context', () => {
+  test('a command fails fast instead of timing out', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    // Observe the dialog without handling it, so the alert stays open and
+    // blocks the context. Waiting on the event rather than a fixed sleep keeps
+    // the test from racing the click.
+    let dialogOpen = false;
+    vibe.onDialog(() => { dialogOpen = true; });
+
+    vibe.find('#alert-btn').click().catch(() => {});
+    for (let i = 0; i < 50 && !dialogOpen; i++) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.ok(dialogOpen, 'the alert should have opened');
+
+    const started = Date.now();
+    let message = '';
+    try {
+      await vibe.title();
+      assert.fail('title() should fail while a dialog is open');
+    } catch (e) {
+      message = String(e.message);
+    }
+    const elapsed = Date.now() - started;
+
+    assert.match(
+      message,
+      /blocked by an open .* dialog/,
+      `expected an actionable prompt error, got: ${message}`
+    );
+    assert.ok(
+      elapsed < 5000,
+      `expected a fast failure, took ${elapsed}ms (the BiDi command timeout is 60s)`
+    );
+
+    await vibe.close();
+  });
+
+  test('dismissing the dialog unblocks the context', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    vibe.onDialog((dialog) => {
+      dialog.accept().catch(() => {});
+    });
+
+    await vibe.find('#alert-btn').click();
+    await vibe.wait(500);
+
+    // Once the prompt is handled the context must be usable again — the
+    // tracker has to clear on userPromptClosed, not just set on Opened.
+    const title = await vibe.title();
+    assert.strictEqual(title, 'Prompt');
+
+    await vibe.close();
+  });
+
+  test('a prompt on one page does not block another page', async () => {
+    const blocked = await bro.newPage();
+    const other = await bro.newPage();
+    await blocked.go(baseURL);
+    await other.go(baseURL);
+
+    let dialogOpen = false;
+    blocked.onDialog(() => { dialogOpen = true; });
+    blocked.find('#alert-btn').click().catch(() => {});
+    for (let i = 0; i < 50 && !dialogOpen; i++) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.ok(dialogOpen, 'the alert should have opened on the first page');
+
+    const title = await other.title();
+    assert.strictEqual(title, 'Prompt', 'a second page must be unaffected');
+
+    await blocked.close();
+    await other.close();
+  });
+});


### PR DESCRIPTION
The browser is launched with `unhandledPromptBehavior: {default: "ignore"}` (`browser/launcher.go:288`), so an `alert()` opened by a click **stays open**, and Chrome answers no script or input command for that context until `browsingContext.handleUserPrompt` arrives.

Nothing tracked that state. Every such command sat out the full 60s BiDi timeout.

## Measured

JS client, unhandled alert open, then `page.title()`:

| | |
|---|---|
| before | **60002ms** — `Command 'vibium:page.title' timed out after 60000ms` |
| after | **1ms** — `context is blocked by an open alert dialog; accept or dismiss it first` |

## How

Track open prompts per context from `userPromptOpened` / `userPromptClosed`, and check before sending.

The check is an **allowlist** of the commands Chrome will not answer (`script.*`, `input.*`, `navigate`, `reload`, `traverseHistory`, `captureScreenshot`, `print`), so anything unrecognised keeps its current behavior. `browsingContext.handleUserPrompt` is deliberately absent — blocking the command that clears the block would be a deadlock.

Both paths are covered, through the shared `Session.SendBidiCommand` seam: the proxy feeds the tracker from its browser→client pump, and the agent installs a single BiDi event handler feeding both the tracker and the recorder.

## Three things this surfaced

**`userPromptClosed` was never subscribed anywhere.** Without it the block could be set but never cleared, so a handled dialog would have wedged the context permanently. It is in the subscription list now, and `dismissing the dialog unblocks the context` covers it.

**Recording claimed `bidi.Client`'s single event-handler slot.** Left alone, starting a recording would have silently switched prompt tracking off for its duration. One handler now feeds both.

**`onDialog` was collateral damage.** In the before-run the listener never fired at all (`dialog observed: null`) — the serialized dispatch was starving the event path, so the very listener a user would add to handle the dialog could not run. It fires now.

## Depends on #260

With `dispatchMu` still taken unconditionally, the error was *correct* but arrived after **57s**, because `page.title` queued behind the click the dialog was blocking. #260 took it to 1ms. Neither change alone fixes #151 — worth knowing if either is ever reverted.

## Testing

`tests/js/async/prompt-blocked.test.js` — fast failure, unblock-after-dismiss, and isolation (a prompt on one page must not block another). Plus 4 unit tests on the tracker covering the never-block cases.

Full `make test` passes.

Fixes #151