### PR TITLE
Track prompts on the agent path too (#151)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ test-cli: build-go
 	@echo "--- CLI Tests ---"
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon start --headless
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js tests/cli/prompt-blocked.test.js
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@echo "--- CLI Process Tests (sequential) ---"
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -12,10 +12,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vibium/clicker/internal/api"
 	"github.com/vibium/clicker/internal/bidi"
 	"github.com/vibium/clicker/internal/browser"
 	"github.com/vibium/clicker/internal/log"
-	"github.com/vibium/clicker/internal/api"
 )
 
 // Handlers manages browser session state and executes tool calls.
@@ -29,16 +29,20 @@ type Handlers struct {
 	conn           *bidi.Connection
 	screenshotDir  string
 	headless       bool
-	connectURL     string      // remote BiDi WebSocket URL (empty = local browser)
-	connectHeaders http.Header // headers for remote WebSocket connection
-	ownsRemote     bool        // remote session was created here, so Close() ends it
+	connectURL     string            // remote BiDi WebSocket URL (empty = local browser)
+	connectHeaders http.Header       // headers for remote WebSocket connection
+	ownsRemote     bool              // remote session was created here, so Close() ends it
 	refMap         map[string]string // @e1 -> CSS selector
 	lastMap        string            // last map output (for diff)
 	recorder       *api.Recorder
 	recordDropBase uint64 // client.DroppedEvents() at record start
 	downloadDir    string
 	lastElementBox *api.BoxInfo // stashed by AgentSession.SetLastElementBox via callback
-	activeContext  string         // last page context switched to or created
+	activeContext  string       // last page context switched to or created
+
+	// prompts records which contexts have an open user prompt, so a command
+	// Chrome will not answer fails immediately instead of timing out.
+	prompts *api.PromptTracker
 }
 
 // NewHandlers creates a new Handlers instance.
@@ -58,6 +62,7 @@ func NewHandlers(screenshotDir string, headless bool, connectURL string, connect
 func (h *Handlers) newSession() *api.AgentSession {
 	s := api.NewAgentSession(h.client)
 	s.Context = h.activeContext
+	s.Prompts = h.prompts
 	s.OnBoxSet = func(box *api.BoxInfo) {
 		h.lastElementBox = box
 	}
@@ -635,6 +640,7 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 		h.client = client
 		h.ownsRemote = session.Created
 		h.sessionMu.Unlock()
+		h.startPromptTracking()
 
 		verb := "Attached to"
 		if session.Created {
@@ -677,6 +683,7 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 	h.conn = conn
 	h.client = bidi.NewClient(conn)
 	h.sessionMu.Unlock()
+	h.startPromptTracking()
 
 	return &ToolsCallResult{
 		Content: []Content{{
@@ -684,6 +691,44 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 			Text: fmt.Sprintf("Browser launched (headless: %v)", useHeadless),
 		}},
 	}, nil
+}
+
+// startPromptTracking subscribes to user-prompt events and keeps h.prompts in
+// sync. bidi.Client has a single event-handler slot, so one handler feeds both
+// the tracker and the recorder rather than recording replacing prompt tracking.
+func (h *Handlers) startPromptTracking() {
+	tracker := api.NewPromptTracker()
+
+	h.sessionMu.Lock()
+	h.prompts = tracker
+	client := h.client
+	h.sessionMu.Unlock()
+
+	if client == nil {
+		return
+	}
+
+	client.SendCommand("session.subscribe", map[string]interface{}{
+		"events": []string{
+			"browsingContext.userPromptOpened",
+			"browsingContext.userPromptClosed",
+		},
+	})
+	client.SetEventHandler(h.handleBidiEvent)
+}
+
+// handleBidiEvent is the single BiDi event handler for the agent session.
+func (h *Handlers) handleBidiEvent(msg string) {
+	h.sessionMu.Lock()
+	tracker := h.prompts
+	recorder := h.recorder
+	h.sessionMu.Unlock()
+
+	tracker.Observe([]byte(msg))
+
+	if recorder != nil && recorder.IsRecording() {
+		recorder.RecordBidiEvent(msg)
+	}
 }
 
 // browserNavigate navigates to a URL.
@@ -1450,7 +1495,6 @@ func (h *Handlers) browserA11yTree(args map[string]interface{}) (*ToolsCallResul
 	}, nil
 }
 
-
 // browserHover moves the mouse over an element.
 func (h *Handlers) browserHover(args map[string]interface{}) (*ToolsCallResult, error) {
 	if err := h.ensureBrowser(); err != nil {
@@ -2060,7 +2104,6 @@ func (h *Handlers) pageClockSetTimezone(args map[string]interface{}) (*ToolsCall
 		Content: []Content{{Type: "text", Text: fmt.Sprintf("Timezone set to %s", tz)}},
 	}, nil
 }
-
 
 // pollCallFunction polls a JS function until it returns a non-null/non-empty result.
 func pollCallFunction(h *Handlers, script string, args []interface{}, timeout time.Duration) (interface{}, error) {
@@ -3803,9 +3846,8 @@ func (h *Handlers) browserRecordStart(args map[string]interface{}) (*ToolsCallRe
 		},
 	})
 	h.recordDropBase = h.client.DroppedEvents()
-	h.client.SetEventHandler(func(msg string) {
-		h.recorder.RecordBidiEvent(msg)
-	})
+	// handleBidiEvent already forwards to the recorder; replacing the handler
+	// here would silently turn off prompt tracking for the recording's duration.
 
 	return &ToolsCallResult{
 		Content: []Content{{
@@ -3821,9 +3863,9 @@ func (h *Handlers) browserRecordStop(args map[string]interface{}) (*ToolsCallRes
 		return nil, fmt.Errorf("no recording in progress")
 	}
 
-	// Stop forwarding events to the recorder
+	// h.recorder is cleared below, which stops handleBidiEvent forwarding.
+	// The handler itself stays installed so prompt tracking survives.
 	if h.client != nil {
-		h.client.SetEventHandler(nil)
 		h.recorder.NoteDroppedEvents(h.client.DroppedEvents() - h.recordDropBase)
 	}
 
@@ -4012,7 +4054,7 @@ func (h *Handlers) browserRestoreStorage(args map[string]interface{}) (*ToolsCal
 	}
 
 	var state struct {
-		Cookies []bidi.Cookie `json:"cookies"`
+		Cookies []bidi.Cookie   `json:"cookies"`
 		Storage json.RawMessage `json:"storage"`
 	}
 	if err := json.Unmarshal(data, &state); err != nil {

--- a/tests/cli/prompt-blocked.test.js
+++ b/tests/cli/prompt-blocked.test.js
@@ -1,0 +1,76 @@
+/**
+ * CLI Tests: commands against a prompt-blocked context
+ *
+ * The CLI runs over the agent path (daemon -> agent.Handlers -> bidi.Client),
+ * not the proxy the JS client uses. Prompt tracking has to be wired into both,
+ * so this covers the half a JS-client test cannot reach (#151).
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execSync, spawn } = require('node:child_process');
+const path = require('path');
+const { VIBIUM } = require('../helpers');
+
+let serverProcess, baseURL;
+
+function run(args) {
+  try {
+    return execSync(`${VIBIUM} ${args} 2>&1`, { encoding: 'utf-8', timeout: 90000 });
+  } catch (e) {
+    // Non-zero exit is expected for the blocked command; keep its output.
+    return (e.stdout || '') + (e.stderr || '');
+  }
+}
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => resolve(data.toString().trim()));
+  });
+});
+
+after(() => {
+  // Leave no dialog behind for the next test file sharing this daemon.
+  run('dialog accept');
+  if (serverProcess) serverProcess.kill();
+});
+
+describe('CLI: prompt-blocked context', () => {
+  test('a command fails fast with an actionable error', () => {
+    run(`go ${baseURL}/example`);
+
+    // Open an alert without handling it. The alert fires after eval returns,
+    // so eval itself is not the command that blocks.
+    run(`eval "setTimeout(() => alert('blocked'), 100); 'ok'"`);
+    execSync('sleep 1');
+
+    const started = Date.now();
+    const out = run('title');
+    const elapsed = Date.now() - started;
+
+    assert.match(
+      out,
+      /blocked by an open .* dialog/,
+      `expected an actionable prompt error, got: ${out.slice(0, 200)}`
+    );
+    assert.ok(
+      elapsed < 10000,
+      `expected a fast failure, took ${elapsed}ms (the BiDi command timeout is 60s)`
+    );
+  });
+
+  test('accepting the dialog unblocks the context', () => {
+    const accepted = run('dialog accept');
+    assert.doesNotMatch(accepted, /blocked by an open/, 'dialog accept must never be blocked');
+
+    const out = run('title');
+    assert.doesNotMatch(
+      out,
+      /blocked by an open/,
+      `context should be usable after the dialog is accepted, got: ${out.slice(0, 200)}`
+    );
+  });
+});


### PR DESCRIPTION
#261 wired prompt tracking into the proxy but not the agent. `AgentSession.Prompts` was never assigned, so it was always nil and the gate in `SendBidiCommand` could not fire — leaving the MCP and CLI path, which is what #151 actually reports, still waiting out the full timeout.

The regression test that covered #261 drives the JS client, which talks to the **proxy**. It passed while the reported path stayed broken. That is how this shipped.

## Fix

Give `Handlers` a tracker, subscribe to `userPromptOpened`/`userPromptClosed` when the session is established (both local launch and remote connect), and hand it to every `AgentSession`.

`bidi.Client` has a single event-handler slot and recording was taking it, which would have switched prompt tracking off for the duration of a recording. One handler now feeds both, and stopping a recording no longer clears it.

## Coverage

`tests/cli/prompt-blocked.test.js` exercises the agent path directly. Against `main` it fails:

```
✖ a command fails fast with an actionable error (77082ms)
  AssertionError: expected an actionable prompt error, got:
  Error: read response: read unix ->.../vibium.sock: i/o timeout
```

77 seconds, and the user does not even get the BiDi timeout message — the daemon's socket read gives up first. With the fix:

```
$ vibium title
Error: failed to get title: context is blocked by an open alert dialog; accept or dismiss it first (...)
27ms
```

The second test asserts `dialog accept` is never itself blocked and that the context is usable afterwards, since a tracker that sets the block but never clears it would wedge the context permanently.

Full `make test` passes.

Fixes #151