### PR TITLE
Detect a browser that went away instead of failing forever (#219)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ test-cli: build-go
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js tests/cli/prompt-blocked.test.js
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@echo "--- CLI Process Tests (sequential) ---"
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js tests/cli/dead-browser.test.js
 
 # Run JS library tests
 # Each test file owns its own browser (top-level before/after), so files are

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -2587,13 +2587,45 @@ func (h *Handlers) browserSleep(args map[string]interface{}) (*ToolsCallResult, 
 // ensureBrowser checks that a browser session is active.
 // If no browser is running, it auto-launches one (lazy launch).
 func (h *Handlers) ensureBrowser() error {
-	if h.client == nil {
-		_, err := h.browserLaunch(map[string]interface{}{})
-		if err != nil {
-			return fmt.Errorf("auto-launch failed: %w", err)
+	h.sessionMu.Lock()
+	client := h.client
+	h.sessionMu.Unlock()
+
+	if client != nil {
+		// A browser closed or crashed externally leaves this handle in place,
+		// so without a liveness check every later command fails with a raw
+		// transport error ("write: broken pipe") and never recovers (#219).
+		if dead, cause := client.Dead(); dead {
+			h.discardSession()
+			return fmt.Errorf("the browser is no longer running (%v) — run the command again to start a new one", cause)
 		}
+		return nil
+	}
+
+	if _, err := h.browserLaunch(map[string]interface{}{}); err != nil {
+		return fmt.Errorf("auto-launch failed: %w", err)
 	}
 	return nil
+}
+
+// discardSession drops a dead browser handle along with the state that only
+// meant anything alongside it. Element refs (@e1, …) name nodes in a document
+// that no longer exists, so carrying them into a freshly launched browser would
+// turn a clear failure into confidently wrong results.
+func (h *Handlers) discardSession() {
+	h.sessionMu.Lock()
+	defer h.sessionMu.Unlock()
+
+	if h.launchResult != nil {
+		h.launchResult.Close()
+		h.launchResult = nil
+	}
+	h.client = nil
+	h.conn = nil
+	h.prompts = nil
+	h.refMap = nil
+	h.lastMap = ""
+	h.activeContext = ""
 }
 
 // resolveRefsInArgs returns a copy of args with any @ref selector resolved

--- a/clicker/internal/bidi/session.go
+++ b/clicker/internal/bidi/session.go
@@ -74,6 +74,22 @@ func (c *Client) DroppedEvents() uint64 {
 	return c.droppedEvents.Load()
 }
 
+// Dead reports whether the reader has exited, which means the connection to the
+// browser is gone — it crashed, the user closed it, or the socket dropped. The
+// returned error says why.
+//
+// Holders of a Client have no other way to notice: the reader records the cause
+// and stops, but nothing pushes that outward, so every later command fails one
+// at a time with a raw transport error.
+func (c *Client) Dead() (bool, error) {
+	select {
+	case <-c.readerDone:
+		return true, c.readErr
+	default:
+		return false, nil
+	}
+}
+
 // readLoop is the only reader of the connection. Routing every message
 // through one goroutine keeps concurrent SendCommand callers from stealing
 // each other's responses and keeps events flowing between commands.

--- a/tests/cli/dead-browser.test.js
+++ b/tests/cli/dead-browser.test.js
@@ -24,11 +24,30 @@ function run(args) {
   }
 }
 
+// Same patterns as the Makefile's double-tap target: the macOS process name and
+// the cache path, which is what matches on Linux.
+const KILL_PATTERNS = ["Chrome for [T]esting", "chrome-for-testin[g]"];
+
+function browserCount() {
+  let total = 0;
+  for (const pattern of KILL_PATTERNS) {
+    try {
+      const out = execSync(`pgrep -f '${pattern}' || true`, { encoding: 'utf-8' });
+      total += out.split('\n').filter(Boolean).length;
+    } catch {
+      /* pgrep exits non-zero when nothing matches */
+    }
+  }
+  return total;
+}
+
 function killBrowser() {
-  try {
-    execSync("pkill -f 'Chrome for Testing' || true", { encoding: 'utf-8' });
-  } catch {
-    /* nothing to kill */
+  for (const pattern of KILL_PATTERNS) {
+    try {
+      execSync(`pkill -9 -f '${pattern}' || true`, { encoding: 'utf-8' });
+    } catch {
+      /* nothing to kill */
+    }
   }
 }
 
@@ -53,8 +72,12 @@ describe('CLI: browser closed externally', () => {
     run(`go ${baseURL}/example`);
     assert.match(run('title'), /Example Domain/, 'setup: the page should load');
 
+    assert.ok(browserCount() > 0, 'setup: a browser process should be running');
     killBrowser();
     execSync('sleep 2');
+    // Assert the kill worked, so a platform where the patterns miss fails here
+    // rather than further down with a confusing assertion about the message.
+    assert.strictEqual(browserCount(), 0, 'the browser process should be gone');
 
     const afterKill = run('title');
     assert.match(

--- a/tests/cli/dead-browser.test.js
+++ b/tests/cli/dead-browser.test.js
@@ -1,0 +1,76 @@
+/**
+ * CLI Tests: recovery after the browser goes away
+ *
+ * Closing the browser window (or a crash) leaves the daemon holding a dead
+ * handle. Without a liveness check every later command failed with a raw
+ * transport error and never recovered (#219).
+ *
+ * Runs its own daemon so killing Chrome cannot disturb other test files.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execSync, spawn } = require('node:child_process');
+const path = require('path');
+const { VIBIUM } = require('../helpers');
+
+let serverProcess, baseURL;
+
+function run(args) {
+  try {
+    return execSync(`${VIBIUM} ${args} 2>&1`, { encoding: 'utf-8', timeout: 90000 });
+  } catch (e) {
+    return (e.stdout || '') + (e.stderr || '');
+  }
+}
+
+function killBrowser() {
+  try {
+    execSync("pkill -f 'Chrome for Testing' || true", { encoding: 'utf-8' });
+  } catch {
+    /* nothing to kill */
+  }
+}
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => resolve(data.toString().trim()));
+  });
+  run('daemon stop');
+  run('daemon start --headless');
+});
+
+after(() => {
+  run('daemon stop');
+  if (serverProcess) serverProcess.kill();
+});
+
+describe('CLI: browser closed externally', () => {
+  test('reports the browser is gone, then recovers on the next command', () => {
+    run(`go ${baseURL}/example`);
+    assert.match(run('title'), /Example Domain/, 'setup: the page should load');
+
+    killBrowser();
+    execSync('sleep 2');
+
+    const afterKill = run('title');
+    assert.match(
+      afterKill,
+      /browser is no longer running/,
+      `expected an actionable error, got: ${afterKill.slice(0, 200)}`
+    );
+
+    // The dead handle must be cleared, so the next command starts fresh rather
+    // than failing forever against a connection that is gone.
+    run(`go ${baseURL}/example`);
+    const recovered = run('title');
+    assert.match(
+      recovered,
+      /Example Domain/,
+      `expected recovery on the next command, got: ${recovered.slice(0, 200)}`
+    );
+  });
+});


### PR DESCRIPTION
`ensureBrowser` only checked whether `h.client` was nil, and that field is cleared solely by an explicit `Close`. A browser the user closed — or one that crashed — left the handle in place, so **every** later command failed with a raw transport error and the daemon never recovered.

## Measured

CLI, killing Chrome out from under the daemon:

| | |
|---|---|
| before | `failed to get browsing context: ... websocket: close 1006 (abnormal closure)` — **forever**, on every subsequent command |
| after | `the browser is no longer running (...) — run the command again to start a new one`, then the next command launches a fresh browser and works |

## How

`bidi.Client` already knew. Its reader records why it stopped and closes `readerDone`; nothing exposed that outward, so every command discovered it independently, one raw error at a time. `Dead()` surfaces it and `ensureBrowser` checks it.

## Why it does not silently relaunch

On a dead handle it reports and discards the session rather than starting a new browser in place. Element refs (`@e1`, …) name nodes in a document that no longer exists — carrying them into a fresh browser converts a clear failure into confidently wrong results against a different page. So `discardSession` drops `refMap`, `lastMap` and `activeContext` alongside the connection, and the next command launches through the existing lazy-launch path.

## Coverage

`tests/cli/dead-browser.test.js`, on the agent path — the one this issue reports. Against `main` it fails:

```
✖ reports the browser is gone, then recovers on the next command
  AssertionError: expected an actionable error, got:
  Error: failed to get browsing context: cannot send browsingContext.getTree:
  connection read failed: websocket: close 1006 (abnormal closure): unexpected EOF
```

It runs in the sequential process-test group, since killing Chrome would disturb files sharing a daemon.

Full `make test` passes.

Fixes #219