### PR TITLE
Refuse operations the element cannot support, and fix three CLI exit paths

### DIFF
--- a/clicker/cmd/clicker/content.go
+++ b/clicker/cmd/clicker/content.go
@@ -29,7 +29,7 @@ func newContentCmd() *cobra.Command {
 					os.Exit(1)
 				}
 				html = string(data)
-			} else if len(args) == 1 {
+			} else if len(args) == 1 && args[0] != "" {
 				html = args[0]
 			} else {
 				fmt.Fprintf(os.Stderr, "Error: html argument or --stdin flag is required\n")

--- a/clicker/cmd/clicker/daemon_cmd.go
+++ b/clicker/cmd/clicker/daemon_cmd.go
@@ -107,13 +107,16 @@ func newDaemonStatusCmd() *cobra.Command {
 		Short: "Show daemon status",
 		Run: func(cmd *cobra.Command, args []string) {
 			if !daemon.IsRunning() {
-				fmt.Println("Daemon is not running.")
+				// Exit non-zero so `vibium daemon status` is usable in a
+				// conditional, and keep the human line out of --json output.
 				if jsonOutput {
 					printJSON(map[string]interface{}{
 						"running": false,
 					})
+				} else {
+					fmt.Println("Daemon is not running.")
 				}
-				return
+				os.Exit(1)
 			}
 
 			status, err := daemon.Status()

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -2569,9 +2569,10 @@ func (h *Handlers) browserSleep(args map[string]interface{}) (*ToolsCallResult, 
 		return nil, fmt.Errorf("ms is required and must be positive")
 	}
 
-	// Cap at 30 seconds
+	// Reject rather than clamp: silently sleeping 30s for a requested 999999
+	// and then reporting "Slept for 30000 ms" hides the mistake.
 	if ms > 30000 {
-		ms = 30000
+		return nil, fmt.Errorf("ms must be 30000 or less (got %v)", ms)
 	}
 
 	time.Sleep(time.Duration(ms) * time.Millisecond)

--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -539,6 +539,11 @@ func (r *Router) handleVibiumElSetFiles(session *BrowserSession, cmd bidiCommand
 		files[i] = s
 	}
 
+	if err := RequireFileInput(NewAPISession(r, session, context), context, ep); err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+
 	// Resolve the element to get its BiDi sharedId
 	sharedID, err := r.resolveElementRef(session, context, ep)
 	if err != nil {
@@ -893,6 +898,11 @@ func IsChecked(s Session, context string, ep ElementParams) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// check/uncheck all resolve state through here, so gating the script covers
+	// every entry point rather than each of the four separately.
+	if val != "true" && val != "false" {
+		return false, fmt.Errorf("%s", val)
+	}
 	return val == "true", nil
 }
 
@@ -1029,6 +1039,13 @@ func buildIsCheckedScript(ep ElementParams) (string, []map[string]interface{}) {
 				el = root.querySelector(selector);
 			}
 			if (!el) return 'false';
+			const t = el.tagName === 'INPUT' ? (el.type || '').toLowerCase() : '';
+			const role = (el.getAttribute('role') || '').toLowerCase();
+			if (t !== 'checkbox' && t !== 'radio' &&
+				role !== 'checkbox' && role !== 'radio' && role !== 'switch') {
+				return 'not a checkbox or radio element';
+			}
+			if (t === '') return el.getAttribute('aria-checked') === 'true' ? 'true' : 'false';
 			return el.checked ? 'true' : 'false';
 		}
 	`

--- a/clicker/internal/api/handlers_lifecycle.go
+++ b/clicker/internal/api/handlers_lifecycle.go
@@ -327,8 +327,34 @@ func SetContent(s Session, context, html string) error {
 	return err
 }
 
+// RequireFileInput errors unless the element resolves to an <input type="file">.
+//
+// It deliberately does not go through actionability: file inputs are routinely
+// display:none, and a visibility check would reject the very elements upload is
+// most often used on.
+func RequireFileInput(s Session, context string, ep ElementParams) error {
+	script, args := buildElStateScript(ep,
+		`(el.tagName === 'INPUT' && (el.type || '').toLowerCase() === 'file') ? 'ok' : 'not an <input type="file"> element'`)
+	resp, err := CallScript(s, context, script, args)
+	if err != nil {
+		return err
+	}
+	val, err := parseScriptResult(resp)
+	if err != nil {
+		return err
+	}
+	if val != "ok" {
+		return fmt.Errorf("upload: %s", val)
+	}
+	return nil
+}
+
 // Upload sets files on an <input type="file"> element.
 func Upload(s Session, context string, ep ElementParams, files []string) error {
+	if err := RequireFileInput(s, context, ep); err != nil {
+		return err
+	}
+
 	sharedID, err := ResolveElementRef(s, context, ep)
 	if err != nil {
 		return err

--- a/clicker/internal/api/handlers_state.go
+++ b/clicker/internal/api/handlers_state.go
@@ -319,8 +319,9 @@ func (r *Router) handleVibiumElIsChecked(session *BrowserSession, cmd bidiComman
 		return
 	}
 
-	script, args := buildElBoolScript(ep, `return !!el.checked;`)
-	checked, err := r.evalBoolScript(session, context, script, args)
+	// Share IsChecked rather than a second `!!el.checked` script, so this and
+	// check/uncheck agree on what counts as a checkable element.
+	checked, err := IsChecked(NewAPISession(r, session, context), context, ep)
 	if err != nil {
 		r.sendError(session, cmd.ID, err)
 		return

--- a/tests/cli/actionability.test.js
+++ b/tests/cli/actionability.test.js
@@ -171,3 +171,43 @@ describe('CLI: fillable input types', () => {
     );
   });
 });
+
+describe('CLI: operation preconditions', () => {
+  test('check refuses a non-checkbox instead of silently succeeding (#195)', () => {
+    execSync(`${VIBIUM} content '<p id="p">not a checkbox</p><input type="checkbox" id="cb">'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+
+    assert.throws(
+      () => {
+        execSync(`${VIBIUM} check "#p"`, { encoding: 'utf-8', timeout: 30000, stdio: 'pipe' });
+      },
+      /not a checkbox or radio/i,
+      'check on a <p> should be refused, not reported as checked'
+    );
+
+    // The real checkbox must still work.
+    const ok = execSync(`${VIBIUM} check "#cb"`, { encoding: 'utf-8', timeout: 30000 });
+    assert.match(ok, /Checked/);
+  });
+
+  test('upload refuses a non-file-input with a readable error (#197)', () => {
+    execSync(`${VIBIUM} content '<p id="p">not an input</p>'`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+
+    assert.throws(
+      () => {
+        execSync(`${VIBIUM} upload "#p" /etc/hosts`, {
+          encoding: 'utf-8',
+          timeout: 30000,
+          stdio: 'pipe',
+        });
+      },
+      /input type="file"/i,
+      'should name the expected element type rather than surfacing a raw BiDi error'
+    );
+  });
+});

--- a/tests/cli/input-tools.test.js
+++ b/tests/cli/input-tools.test.js
@@ -72,6 +72,17 @@ describe('CLI: Negative value flag parsing', () => {
     }
   });
 
+  test('sleep rejects a value over the cap instead of silently clamping', () => {
+    try {
+      execSync(`${VIBIUM} sleep 999999`, { encoding: 'utf-8', timeout: 60000, stdio: 'pipe' });
+      assert.fail('Should have thrown');
+    } catch (err) {
+      const output = err.stderr + err.stdout;
+      assert.match(output, /30000 or less/, 'Should say what the limit is');
+      assert.doesNotMatch(output, /Slept for/, 'Should not report a shorter sleep as success');
+    }
+  });
+
   test('geolocation accepts negative coordinates', () => {
     const result = execSync(`${VIBIUM} geolocation 37.7749 -122.4194`, {
       encoding: 'utf-8',

--- a/tests/daemon/connect.test.js
+++ b/tests/daemon/connect.test.js
@@ -27,6 +27,15 @@ function clickerJSON(args, opts = {}) {
   return JSON.parse(result);
 }
 
+// `daemon status` exits non-zero when nothing is running, which is the contract.
+function clickerAllowExit(args, opts = {}) {
+  try {
+    return clicker(args, opts);
+  } catch (e) {
+    return ((e.stdout || '') + (e.stderr || '')).trim();
+  }
+}
+
 // Run vibium command but don't throw on non-zero exit (for error responses)
 function clickerJSONSafe(args, opts = {}) {
   try {
@@ -230,7 +239,7 @@ describe('Daemon: Remote browser connect', () => {
     assert.ok(result, 'Should return a result');
 
     // Verify daemon is not running
-    const status = clicker('daemon status');
+    const status = clickerAllowExit('daemon status');
     assert.match(status, /not running/i, 'Daemon should not be running');
   });
 });

--- a/tests/daemon/lifecycle.test.js
+++ b/tests/daemon/lifecycle.test.js
@@ -24,6 +24,16 @@ function clickerJSON(args, opts = {}) {
   return JSON.parse(result);
 }
 
+// `daemon status` exits non-zero when nothing is running, which is the contract.
+// Use this where the output matters but the exit code is expected to be non-zero.
+function clickerAllowExit(args, opts = {}) {
+  try {
+    return clicker(args, opts);
+  } catch (e) {
+    return ((e.stdout || '') + (e.stderr || '')).trim();
+  }
+}
+
 // Helper to stop daemon (ignore errors if not running)
 function stopDaemon() {
   try {
@@ -62,7 +72,7 @@ describe('Daemon: Lifecycle', () => {
   });
 
   test('daemon status reports not running when stopped', () => {
-    const result = clicker('daemon status');
+    const result = clickerAllowExit('daemon status');
     assert.match(result, /not running/i, 'Should report not running');
   });
 
@@ -81,7 +91,7 @@ describe('Daemon: Lifecycle', () => {
     assert.match(result, /stopped/i, 'Should confirm daemon stopped');
 
     // Verify not running
-    const status = clicker('daemon status');
+    const status = clickerAllowExit('daemon status');
     assert.match(status, /not running/i, 'Should report not running');
   });
 });
@@ -145,3 +155,39 @@ describe('Daemon: Auto-start', () => {
   });
 });
 
+
+describe('Daemon: status exit code', () => {
+  before(() => {
+    stopDaemon();
+  });
+
+  after(() => {
+    stopDaemon();
+  });
+
+  test('exits non-zero when the daemon is stopped', () => {
+    try {
+      execSync(`${VIBIUM} daemon status`, { encoding: 'utf-8', timeout: 10000, stdio: 'pipe' });
+      assert.fail('daemon status should exit non-zero when nothing is running');
+    } catch (err) {
+      assert.match(err.stdout + err.stderr, /not running/i);
+    }
+  });
+
+  test('--json emits only JSON when the daemon is stopped', () => {
+    try {
+      execSync(`${VIBIUM} --json daemon status`, { encoding: 'utf-8', timeout: 10000, stdio: 'pipe' });
+      assert.fail('daemon status should exit non-zero when nothing is running');
+    } catch (err) {
+      // The human-readable line used to be printed alongside the JSON, which
+      // broke any consumer piping this to a parser.
+      assert.deepStrictEqual(JSON.parse(err.stdout.trim()), { running: false });
+    }
+  });
+
+  test('exits zero when the daemon is running', () => {
+    clicker('daemon start --headless');
+    const status = clicker('daemon status');
+    assert.match(status, /running/i);
+  });
+});


### PR DESCRIPTION
Five small reported bugs that share a shape: a command accepts input it cannot act on and reports success anyway.

| | before | after |
|---|---|---|
| **#195** `check` on a `<p>` | `Checked` | `not a checkbox or radio element` |
| **#197** `upload` on a `<p>` | raw BiDi error | `not an <input type="file"> element` |
| **#211** `sleep 999999` | slept 30s, `Slept for 30000 ms`, exit 0 | `ms must be 30000 or less (got 999999)`, exit 1 |
| **#202** `daemon status` stopped | exit **0** | exit **1** |
| **#202** `--json daemon status` | `Daemon is not running.` then JSON | JSON only |
| **#213** `content ""` | terser message than `content` | identical |

## Both gates went in at the shared choke point

All four check/uncheck entry points resolve state through `IsChecked`, so the type gate lives in its script rather than being repeated four times. `Upload` and `handleVibiumElSetFiles` were copy-paste twins, so both call one `RequireFileInput`.

Two things the sibling sweep turned up that would otherwise have shipped broken:

- **`vibium:element.isChecked` had a second implementation.** `handleVibiumElIsChecked` ran its own `!!el.checked` script, so after gating `IsChecked` the two would have disagreed about what counts as checkable — the JS/Python clients on one answer, check/uncheck and MCP on another. It now calls `IsChecked`.
- **The #202 exit-code change broke three existing assertions** across `lifecycle.test.js` and `connect.test.js`, which had encoded the old exit-0 behavior. Updated to use a helper that tolerates the non-zero exit, since that is now the contract.

## Two deliberate calls

`RequireFileInput` does **not** go through actionability. File inputs are routinely `display:none`, and a visibility check would reject exactly the elements upload is most used on.

Erroring from `isChecked` on a non-checkbox matches Playwright, whose `isChecked()` throws "Not a checkbox or radio button".

Also: `--json daemon status` printing a human-readable line before the JSON was not in #202, which only reported the exit code — but it is the same three-line block and breaks any consumer piping to a parser.

Full `make test` passes.

Fixes #195
Fixes #197
Fixes #202
Fixes #211
Fixes #213