### PR TITLE
Match a submit input by its accessible name (#204)

### DIFF
--- a/clicker/cmd/clicker/find.go
+++ b/clicker/cmd/clicker/find.go
@@ -101,7 +101,10 @@ func newFindCmd() *cobra.Command {
 			toolArgs := map[string]interface{}{"role": args[0]}
 			name, _ := cmd.Flags().GetString("name")
 			if name != "" {
-				toolArgs["text"] = name
+				// "label" is the accessible-name filter; "text" is a raw
+				// textContent match, which is "" for a void element like
+				// <input type="submit">.
+				toolArgs["label"] = name
 			}
 			result, err := daemonCall("browser_find", toolArgs)
 			if err != nil {

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -1107,6 +1107,12 @@ func findBySemanticScript() string {
 				const assocLabel = document.querySelector('label[for="' + el.id + '"]');
 				if (assocLabel) return (assocLabel.textContent || '').trim();
 			}
+			if (el.tagName === 'INPUT') {
+				const it = (el.getAttribute('type') || '').toLowerCase();
+				if ((it === 'submit' || it === 'reset' || it === 'button' || it === 'image') && el.value) {
+					return el.value;
+				}
+			}
 			const ph = el.getAttribute('placeholder');
 			if (ph) return ph;
 			const altAttr = el.getAttribute('alt');
@@ -1151,9 +1157,11 @@ func findBySemanticScript() string {
 				found.push(node);
 			}
 			if (found.length === 0) return null;
-			// Pick best: prefer shortest text match if text filter is used
+			// Pick best: prefer shortest text match when a name-ish filter is
+			// used. --name populates label, so gating on text alone would
+			// return tree-order first (usually an ancestor) instead.
 			el = found[0];
-			if (text && found.length > 1) {
+			if ((text || label) && found.length > 1) {
 				let bestLen = (el.textContent || '').length;
 				for (let i = 1; i < found.length; i++) {
 					const len = (found[i].textContent || '').length;

--- a/clicker/internal/api/handlers_elements.go
+++ b/clicker/internal/api/handlers_elements.go
@@ -264,6 +264,14 @@ func semanticMatchesHelper() string {
 						const assocLabel = document.querySelector('label[for="' + el.id + '"]');
 						if (assocLabel) labelText = labelText || (assocLabel.textContent || '').trim();
 					}
+					if (!labelText && el.tagName === 'INPUT') {
+						// Per HTML-AAM the value attribute is the accessible name
+						// for these input types.
+						const it = (el.getAttribute('type') || '').toLowerCase();
+						if (it === 'submit' || it === 'reset' || it === 'button' || it === 'image') {
+							labelText = el.value || '';
+						}
+					}
 					if (!labelText.includes(label)) return false;
 				}
 				if (placeholder && el.getAttribute('placeholder') !== placeholder) return false;

--- a/tests/daemon/cli-commands.test.js
+++ b/tests/daemon/cli-commands.test.js
@@ -133,6 +133,15 @@ describe('Daemon CLI: Accessibility and search commands', () => {
     assert.ok(result.result.includes('@e1'), 'Should return @e1 ref');
     assert.ok(result.result.includes('[a]'), 'Should find link element');
   });
+
+  test('find role button --name matches a submit input by its value (#204)', () => {
+    // <input type="submit" value="Login"> has no textContent, so --name used to
+    // land on a textContent filter and poll to the 30s timeout.
+    clicker(`go ${baseURL}/selectors`);
+    const result = clickerJSON('find role button --name "Login"');
+    assert.strictEqual(result.ok, true);
+    assert.ok(result.result.includes('[input'), `Should find the submit input, got: ${result.result}`);
+  });
 });
 
 describe('Daemon CLI: Waiting commands', () => {

--- a/tests/helpers/test-server.js
+++ b/tests/helpers/test-server.js
@@ -141,6 +141,7 @@ const SELECTORS_HTML = `<html><head><title>Selectors</title></head><body>
   <input type="text" id="username" name="username" />
   <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Logo image" />
   <button data-testid="submit-btn">Submit</button>
+  <input type="submit" value="Login" />
   <div class="container"><span class="inner-text">Hello from span</span></div>
 </body></html>`;
 

--- a/tests/js/async/elements.test.js
+++ b/tests/js/async/elements.test.js
@@ -19,6 +19,7 @@ const PAGE_HTML = `<html><head><title>Elements Test</title></head><body>
   <p>First paragraph with some text.</p>
   <p>Second paragraph with more content.</p>
   <p><a href="/other">Learn more about testing</a></p>
+  <input type="submit" value="Login" />
 </body></html>`;
 
 before(async () => {
@@ -117,6 +118,17 @@ describe('Element Finding', () => {
     const link = await vibe.find({ role: 'link' });
     assert.ok(link, 'Should find element with role=link');
     assert.ok(link.info.tag === 'a', 'Element with role=link should be an <a>');
+  });
+
+  test('find({ role: "button", label: "Login" }) matches a submit input by value (#204)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL);
+
+    // <input type="submit"> has no textContent; per HTML-AAM its accessible
+    // name comes from the value attribute.
+    const el = await vibe.find({ role: 'button', label: 'Login' });
+    assert.ok(el, 'Should find the submit input by its accessible name');
+    assert.strictEqual(el.info.tag, 'input');
   });
 
   test('find({ text: "Learn more" }) finds element by text', async () => {


### PR DESCRIPTION
`vibium find role button --name "Login"` polled to the 30s timeout on `<input type="submit" value="Login">`.

## The filed cause is wrong

The issue blames implicit ARIA role recognition, but the role table already maps `submit → button` correctly — in **both** copies (`agent/handlers.go:1060`, `api/handlers_elements.go:211`). Role matching was never the problem, which is probably why this sat.

Three things all had to be true for `--name` to work:

**1. `--name` populated the wrong filter.** `cmd/clicker/find.go` put it into `text`, a raw textContent substring match. A void `<input>` has no textContent, so nothing ever matched. It now populates `label` — the accessible-name filter, which is what the flag help already claimed it was.

**2. `getName` never consulted `el.value`.** So routing to `label` alone still returned `""`. Per [HTML-AAM](https://www.w3.org/TR/html-aam-1.0/) the `value` attribute *is* the accessible name for `input[type=submit|reset|button|image]`.

**3. That logic exists twice, and had already drifted.** `agent/handlers.go` for the CLI and MCP, `api/handlers_elements.go` for the library clients — only the agent copy falls back to textContent. Fixing one would have left every JS/Python/Java client broken.

## One thing that would have been a silent regression

The shortest-match tiebreak is gated on `text` alone. Moving `--name` to `label` takes it out of that gate, so a multi-match query would have started returning tree-order first — usually an ancestor — instead of the tightest node. Widened to `(text || label)`.

That is a regression the fix itself would have introduced, invisible unless you looked.

## Verification

```
before:  30s timeout, "element not found: role=button, text=Login"
after:   @e1 [input type="submit"]   (0.01s)
```

Tests on both paths — `tests/daemon/cli-commands.test.js` for the CLI, `tests/js/async/elements.test.js` for the client API, since a CLI test cannot reach the second copy. The API test is verified to fail without the fix (times out at 30s).

Existing `--name` behavior on ordinary elements still works (`find role link --name "More information"` → `@e1 [a]`).

Full `make test` passes.

Fixes #204