### PR TITLE
Target the active context from every script-backed command (#205)

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -871,7 +871,7 @@ func (h *Handlers) browserScreenshot(args map[string]interface{}) (*ToolsCallRes
 			}
 			return JSON.stringify({count: count});
 		}`
-		if _, err := h.client.CallFunction("", annotateScript, []interface{}{string(selectorsJSON)}); err != nil {
+		if _, err := h.client.CallFunction(h.activeContext, annotateScript, []interface{}{string(selectorsJSON)}); err != nil {
 			return nil, fmt.Errorf("failed to annotate: %w", err)
 		}
 	}
@@ -892,7 +892,7 @@ func (h *Handlers) browserScreenshot(args map[string]interface{}) (*ToolsCallRes
 			document.querySelectorAll('.__vibium_annotation').forEach(el => el.remove());
 			return 'cleaned';
 		}`
-		h.client.CallFunction("", cleanupScript, nil)
+		h.client.CallFunction(h.activeContext, cleanupScript, nil)
 	}
 
 	// If filename provided, save to file (only if screenshotDir is configured)
@@ -1017,7 +1017,7 @@ func (h *Handlers) browserFind(args map[string]interface{}) (*ToolsCallResult, e
 		}
 		return getLabel(el);
 	}`
-	labelResult, err := h.client.CallFunction("", labelScript, []interface{}{selector})
+	labelResult, err := h.client.CallFunction(h.activeContext, labelScript, []interface{}{selector})
 	if err != nil {
 		return nil, err
 	}
@@ -1254,7 +1254,7 @@ func (h *Handlers) browserEvaluate(args map[string]interface{}) (*ToolsCallResul
 		return nil, fmt.Errorf("expression is required")
 	}
 
-	result, err := h.client.Evaluate("", expression)
+	result, err := h.client.Evaluate(h.activeContext, expression)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate: %w", err)
 	}
@@ -1718,7 +1718,7 @@ func (h *Handlers) browserFindAll(args map[string]interface{}) (*ToolsCallResult
 		}
 		return JSON.stringify(results);
 	}`
-	result, err := h.client.CallFunction("", findAllScript, []interface{}{selector, limit})
+	result, err := h.client.CallFunction(h.activeContext, findAllScript, []interface{}{selector, limit})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find elements: %w", err)
 	}
@@ -2111,7 +2111,7 @@ func pollCallFunction(h *Handlers, script string, args []interface{}, timeout ti
 	interval := 100 * time.Millisecond
 
 	for {
-		result, err := h.client.CallFunction("", script, args)
+		result, err := h.client.CallFunction(h.activeContext, script, args)
 		if err == nil && result != nil {
 			s := fmt.Sprintf("%v", result)
 			if s != "" && s != "null" && s != "<nil>" {
@@ -2758,7 +2758,7 @@ func (h *Handlers) browserMap(args map[string]interface{}) (*ToolsCallResult, er
 	if sel, ok := args["selector"].(string); ok && sel != "" {
 		scopeSelector = sel
 	}
-	result, err := h.client.CallFunction("", mapScript(), []interface{}{scopeSelector})
+	result, err := h.client.CallFunction(h.activeContext, mapScript(), []interface{}{scopeSelector})
 	if err != nil {
 		return nil, fmt.Errorf("failed to map elements: %w", err)
 	}
@@ -2912,7 +2912,7 @@ func (h *Handlers) browserHighlight(args map[string]interface{}) (*ToolsCallResu
 		return 'highlighted';
 	}`
 
-	result, err := h.client.CallFunction("", script, []interface{}{selector})
+	result, err := h.client.CallFunction(h.activeContext, script, []interface{}{selector})
 	if err != nil {
 		return nil, fmt.Errorf("failed to highlight: %w", err)
 	}
@@ -3786,6 +3786,10 @@ func (h *Handlers) browserFrame(args map[string]interface{}) (*ToolsCallResult, 
 		return nil, fmt.Errorf("no frame matching %q", nameOrURL)
 	}
 
+	// The daemon is the only thing that survives between CLI invocations, so
+	// without this the frame is forgotten before the next command runs.
+	h.activeContext = frame.Context
+
 	result, _ := json.Marshal(frame)
 	return &ToolsCallResult{
 		Content: []Content{{
@@ -4050,7 +4054,7 @@ func (h *Handlers) browserStorageState(args map[string]interface{}) (*ToolsCallR
 		})()
 	})`
 
-	storageResult, err := h.client.Evaluate("", script)
+	storageResult, err := h.client.Evaluate(h.activeContext, script)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get storage: %w", err)
 	}
@@ -4117,7 +4121,7 @@ func (h *Handlers) browserRestoreStorage(args map[string]interface{}) (*ToolsCal
 			}
 			return 'ok';
 		})()`, string(state.Storage))
-		h.client.Evaluate("", script)
+		h.client.Evaluate(h.activeContext, script)
 	}
 
 	return &ToolsCallResult{

--- a/tests/cli/page-context.test.js
+++ b/tests/cli/page-context.test.js
@@ -127,3 +127,53 @@ describe('CLI: Page Context Tracking', () => {
     assert.ok(!pages.includes('[1]'), 'Should only have one page remaining');
   });
 });
+
+describe('CLI: active context reaches script-backed commands', () => {
+  // The commands above only exercised `title`, which routes through
+  // newSession(). eval/find/map called the BiDi client with an empty context,
+  // which resolves to "the first context" — so they silently ignored both page
+  // switches and frame switches (#205).
+
+  test('eval and find follow a page switch', () => {
+    execSync(`${VIBIUM} go ${baseURL}/`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} page new ${baseURL}/login`, { encoding: 'utf-8', timeout: 30000 });
+
+    const onNewPage = execSync(`${VIBIUM} eval "location.pathname"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.match(onNewPage, /\/login/, 'eval should run on the newly opened page');
+
+    execSync(`${VIBIUM} page switch 0`, { encoding: 'utf-8', timeout: 30000 });
+    const backOnHome = execSync(`${VIBIUM} eval "location.pathname"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(backOnHome, '/', 'eval should follow the switch back to page 0');
+
+    execSync(`${VIBIUM} page switch 1`, { encoding: 'utf-8', timeout: 30000 });
+    const found = execSync(`${VIBIUM} find h2`, { encoding: 'utf-8', timeout: 30000 });
+    assert.match(found, /Login/, 'find should search the active page');
+
+    execSync(`${VIBIUM} page close`, { encoding: 'utf-8', timeout: 30000 });
+  });
+
+  test('eval follows a frame switch and persists to the next command (#205)', () => {
+    execSync(`${VIBIUM} go ${baseURL}/frames`, { encoding: 'utf-8', timeout: 30000 });
+
+    const outer = execSync(`${VIBIUM} eval "document.querySelector('h1').id"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(outer, 'outer', 'setup: should start on the top-level document');
+
+    execSync(`${VIBIUM} frame myframe`, { encoding: 'utf-8', timeout: 30000 });
+
+    // Separate process — the frame only persists if the daemon recorded it.
+    const inner = execSync(`${VIBIUM} eval "document.querySelector('h1').id"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(inner, 'inner', 'eval should run inside the switched frame');
+  });
+});

--- a/tests/helpers/test-server.js
+++ b/tests/helpers/test-server.js
@@ -144,8 +144,19 @@ const SELECTORS_HTML = `<html><head><title>Selectors</title></head><body>
   <div class="container"><span class="inner-text">Hello from span</span></div>
 </body></html>`;
 
+const FRAME_INNER_HTML = `<html><head><title>Inner Frame</title></head><body>
+  <h1 id="inner">Inside the frame</h1>
+</body></html>`;
+
+const FRAMES_HTML = `<html><head><title>Frames</title></head><body>
+  <h1 id="outer">Outer page</h1>
+  <iframe src="/frame-inner" name="myframe"></iframe>
+</body></html>`;
+
 const routes = {
   '/': HOME_HTML,
+  '/frames': FRAMES_HTML,
+  '/frame-inner': FRAME_INNER_HTML,
   '/login': LOGIN_HTML,
   '/secure': SECURE_HTML,
   '/checkboxes': CHECKBOXES_HTML,


### PR DESCRIPTION
`vibium frame` had no effect on the next command — and the same cause meant **page switches were ignored too**, which is larger than #205 describes.

```
vibium page new /login
vibium url    →  http://.../login    ✓
vibium eval   →  /example            ✗  evaluating page 0
```

## Two defects

**`browserFrame` never recorded the frame.** It resolved it, marshalled it, and returned. The daemon is the only thing that survives between CLI invocations, so the frame was forgotten before the next command ran. `browserNewPage` and `browserSwitchPage` both set `activeContext`; this did not.

**Ten call sites passed `""` as the context.** Empty does not mean "current" — `bidi` resolves it to `tree.Contexts[0]`, the *first* page. So `eval`, `find`, `find --all`, `map`, `highlight`, `storage` and `screenshot --annotate` all operated on page 0 regardless of what was active. Every other handler in the file already routes through `newSession()`; these ten were the exceptions.

## The test that should have caught it

`tests/cli/page-context.test.js` already existed, described as verifying "that page switch and page new correctly track the active page **so subsequent commands target the right context**."

It asserted only on `title` — which routes through `newSession()` and always worked. It covered the working half and missed all ten broken commands.

Added assertions for the commands that were actually broken, plus an iframe fixture so the frame case is verified across separate CLI processes (which is the real claim in #205 — that the daemon has to remember it).

## Verified

```
frame:  eval → "outer",   vibium frame myframe,   eval → "inner"
page:   page new /login → eval /login;  page switch 0 → eval /
```

Full `make test` passes.

Fixes #205