### PR TITLE
Tell an absent attribute apart from a present, valueless one (#198)

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -2338,11 +2338,19 @@ func (h *Handlers) browserGetAttribute(args map[string]interface{}) (*ToolsCallR
 	if err != nil {
 		return nil, fmt.Errorf("failed to get attribute: %w", err)
 	}
+	// A present-but-valueless attribute (<button disabled>) reads as "", so
+	// absence needs a distinct value to be tellable apart (#198). It must stay
+	// a normal result rather than an error: erroring on an absent attribute is
+	// what #153 was about.
+	text := "null"
+	if value != nil {
+		text = *value
+	}
 
 	return &ToolsCallResult{
 		Content: []Content{{
 			Type: "text",
-			Text: value,
+			Text: text,
 		}},
 	}, nil
 }

--- a/clicker/internal/api/handlers_state.go
+++ b/clicker/internal/api/handlers_state.go
@@ -849,8 +849,10 @@ func GetValue(s Session, context string, ep ElementParams) (string, error) {
 	return EvalElementScript(s, context, script, args)
 }
 
-// GetAttribute returns the value of an HTML attribute on an element.
-func GetAttribute(s Session, context string, ep ElementParams, name string) (string, error) {
+// GetAttribute returns the value of an HTML attribute, or nil when the
+// attribute is absent. A present-but-empty attribute (<button disabled>) and a
+// missing one are different things, and a plain string cannot tell them apart.
+func GetAttribute(s Session, context string, ep ElementParams, name string) (*string, error) {
 	var args []map[string]interface{}
 	var script string
 
@@ -871,7 +873,7 @@ func GetAttribute(s Session, context string, ep ElementParams, name string) (str
 				}
 				if (!el) return null;
 				const v = el.getAttribute(name);
-				return v === null ? '' : v;
+				return JSON.stringify({value: v});
 			}
 		`
 	} else {
@@ -889,12 +891,23 @@ func GetAttribute(s Session, context string, ep ElementParams, name string) (str
 				}
 				if (!el) return null;
 				const v = el.getAttribute(name);
-				return v === null ? '' : v;
+				return JSON.stringify({value: v});
 			}
 		`
 	}
 
-	return EvalElementScript(s, context, script, args)
+	val, err := EvalElementScript(s, context, script, args)
+	if err != nil {
+		return nil, err
+	}
+
+	var out struct {
+		Value *string `json:"value"`
+	}
+	if err := json.Unmarshal([]byte(val), &out); err != nil {
+		return nil, fmt.Errorf("attr parse failed: %w", err)
+	}
+	return out.Value, nil
 }
 
 // IsVisible checks if an element is visible (not hidden, not zero-size).

--- a/tests/daemon/cli-commands.test.js
+++ b/tests/daemon/cli-commands.test.js
@@ -101,6 +101,21 @@ describe('Daemon CLI: Element state commands', () => {
     assert.strictEqual(result.ok, true);
     assert.ok(result.result.includes('/more-information'), 'Should return href value');
   });
+
+  test('attr distinguishes a present-but-empty attribute from an absent one (#198)', () => {
+    clicker(`content '<button id="b" disabled>Go</button>'`);
+
+    // Present but valueless: empty string, and a success exit.
+    const present = clickerJSON('attr "#b" "disabled"');
+    assert.strictEqual(present.ok, true);
+    assert.strictEqual(present.result, '', 'a valueless attribute is present with an empty value');
+
+    // Absent: a distinct value, but still a normal result — erroring here is
+    // what #153 was about.
+    const absent = clickerJSON('attr "#b" "nonexistent"');
+    assert.strictEqual(absent.ok, true, 'an absent attribute must not error (#153)');
+    assert.strictEqual(absent.result, 'null', 'absent must be distinguishable from present-but-empty');
+  });
 });
 
 describe('Daemon CLI: Accessibility and search commands', () => {


### PR DESCRIPTION
`vibium attr` returned `""` with exit 0 whether an attribute was present-and-valueless (`<input required>`) or missing entirely.

```
vibium content '<input id="req" required><input id="norq">'
vibium attr "#req"  required   ->  ""      exit 0
vibium attr "#norq" required   ->  "null"  exit 0     (was "" — identical)
```

## Cause

`GetAttribute` returned `(string, error)` — a type with nowhere to put "absent" — and **both** injected script branches ended with `v === null ? '' : v`, erasing the distinction before it could reach Go. It now returns `(*string, error)` and carries the null through as `{value: v}`.

Both branches, since fixing one and leaving its twin is the failure mode this file has a history of.

## Why "null" rather than an error

My first attempt errored on absent. That satisfies #198 and **regresses #153**, whose entire complaint was `browser_get_attribute` erroring on an absent attribute. The existing regression test caught it:

```
✖ browser_get_attribute on an absent attribute does not error (#153)
  AssertionError: absent attribute should not error
```

#198's own text asks for "non-empty for present, ''/null for absent", so a distinct **value** is what the two issues jointly want. Both regression tests now pass together, which is the real proof they are not trading off against each other.

## Note

`handleVibiumElAttr` — the path the JS/Python/Java clients use — already returned a `*string` and was correct. So the library clients could tell absent from empty all along, while the CLI and MCP could not. Two implementations of one query, one of them lossy. They agree now.

Full `make test` passes.

Fixes #198
