### PR TITLE
Detect the dead-GPU stall instead of requiring a flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,10 +200,23 @@ else
 DEFAULT_PARALLEL := $(shell n=$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4); n=$$((n / 2)); [ $$n -lt 3 ] && n=3; echo $$n)
 endif
 
-# macOS VM guests with a dead virtual GPU pay ~15s per Chrome launch.
-# VM_FAST_LAUNCH=1 builds a Metal shim and points vibium at it. Probe first.
+# macOS VM guests with a dead virtual GPU pay ~15s per Chrome launch, which is
+# most of a local `make test`. A Metal shim skips it.
+#
+# This is decided by probing THIS machine, not by detecting a VM: a guest with
+# working GPU passthrough must not be shimmed, because the shim hides the GPU
+# rather than speeding it up. The probe costs ~15s once, then is cached.
+# Override with VM_FAST_LAUNCH=1 or =0.
 # See docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
 MTLSHIM := $(CURDIR)/clicker/bin/mtlshim.dylib
+MTLVERDICT := $(CURDIR)/clicker/bin/.mtl-verdict
+
+ifeq ($(UNAME_S),Darwin)
+ifeq ($(origin VM_FAST_LAUNCH),undefined)
+VM_FAST_LAUNCH := $(shell $(CURDIR)/scripts/mtl-verdict.sh $(MTLVERDICT))
+endif
+endif
+
 ifeq ($(VM_FAST_LAUNCH),1)
 ifeq ($(UNAME_S),Darwin)
 FAST_LAUNCH_DEP := mtlshim

--- a/scripts/mtl-verdict.sh
+++ b/scripts/mtl-verdict.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Prints 1 if this machine pays the dead-virtual-GPU stall that mtlshim.dylib
+# skips, 0 otherwise. The verdict is a property of the machine, so it is cached
+# after the first run — the probe itself takes ~15s on an affected guest, which
+# is precisely the cost being measured.
+#
+# Deliberately decides by probe rather than by environment: a VM with working
+# GPU passthrough must NOT be shimmed, since the shim hides the GPU rather than
+# speeding it up. See docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
+#
+# Usage: scripts/mtl-verdict.sh <cache-file>
+
+set -u
+CACHE="${1:?usage: mtl-verdict.sh <cache-file>}"
+SRC="$(dirname "$0")/mtlprobe.m"
+
+if [ -f "$CACHE" ]; then
+	cat "$CACHE"
+	exit 0
+fi
+
+# Anything other than a successful "affected" verdict means leave it alone:
+# no compiler, no Metal, a real GPU, or a probe that failed to run.
+verdict=0
+if [ "$(uname -s)" = "Darwin" ] && [ -f "$SRC" ]; then
+	probe="$(mktemp -t vibium-mtlprobe)" || probe=""
+	if [ -n "$probe" ]; then
+		if clang -fobjc-arc -framework Metal -framework Foundation \
+			-o "$probe" "$SRC" >/dev/null 2>&1; then
+			if "$probe" >/dev/null 2>&1; then
+				verdict=1
+			fi
+		fi
+		rm -f "$probe"
+	fi
+fi
+
+mkdir -p "$(dirname "$CACHE")" 2>/dev/null
+printf '%s' "$verdict" >"$CACHE" 2>/dev/null
+printf '%s' "$verdict"

--- a/scripts/mtlprobe.m
+++ b/scripts/mtlprobe.m
@@ -1,0 +1,38 @@
+// Reports whether this machine pays the dead-virtual-GPU stall that
+// clicker/bin/mtlshim.dylib exists to skip.
+//
+// Exit 0 means "affected": MTLCopyAllDevices was slow AND returned no devices.
+// Both halves matter — a slow call that finds a real GPU must not be shimmed,
+// because the shim hides the GPU rather than speeding it up.
+//
+// Built and run by `make mtlprobe`. See
+// docs/how-to-guides/slow-chrome-launch-in-macos-vm.md
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#import <stdio.h>
+#import <sys/time.h>
+
+// A healthy MTLCopyAllDevices returns in milliseconds; the affected guest takes
+// ~15s. Anything past a second is the stall, not variance.
+static const double kStallSeconds = 1.0;
+
+static double now(void) {
+  struct timeval t;
+  gettimeofday(&t, NULL);
+  return t.tv_sec + t.tv_usec / 1e6;
+}
+
+int main(void) {
+  @autoreleasepool {
+    double start = now();
+    NSArray<id<MTLDevice>> *devices = MTLCopyAllDevices();
+    double elapsed = now() - start;
+    unsigned long count = (unsigned long)[devices count];
+
+    int affected = (elapsed >= kStallSeconds && count == 0);
+    fprintf(stderr, "MTLCopyAllDevices: %.2fs (%lu devices) -> %s\n",
+            elapsed, count, affected ? "affected" : "healthy");
+    return affected ? 0 : 1;
+  }
+}


### PR DESCRIPTION
macOS VM guests with a dead virtual GPU pay ~15s per Chrome launch. The suite launches Chrome ~130 times, so a local `make test` takes **~18 minutes instead of ~4**.

The shim that skips this already existed, but it was opt-in via `VM_FAST_LAUNCH=1` — so the slow path was the default on exactly the machines that needed the fast one. I ran the suite 12 times in one session without it before noticing.

| | |
|---|---|
| `make test` before | ~18m |
| `make test VM_FAST_LAUNCH=1` | 4m18s |
| `make test` after this change | 4m18s, no flag |

## Decide by probe, not by VM

My first instinct was to check `hw.model` / `kern.hv_vmm_present`. That would be wrong, and the how-to already says so:

> **Decide by probe, not by environment.** The criterion is whether `MTLCopyAllDevices` is slow and reports zero devices *on that machine* — not whether it's a laptop or CI.

A guest with working GPU passthrough must **not** be shimmed: the shim hides the GPU rather than speeding it up, so enabling it on a healthy machine would break rendering and mask real GPU behavior.

So `scripts/mtlprobe.m` measures the actual criterion — slow **and** zero devices — and exits 0 only when both hold.

## Caching

The probe costs the very stall it measures, so it cannot run per-invocation. `scripts/mtl-verdict.sh` caches the answer in `clicker/bin/.mtl-verdict`: 15.6s on first run, 9ms after. That directory is already gitignored, so the verdict follows the machine rather than the repo.

## Overrides preserved

Only consulted when `VM_FAST_LAUNCH` is unset (`$(origin ...)`), so `=1` and `=0` both still win. Non-Darwin skips the probe entirely, and a healthy Mac caches `0` and behaves exactly as before.

The shim still ships nowhere: vibium does nothing unless `VIBIUM_VM_FAST_LAUNCH` points at a dylib, and that is only exported into make's own environment.
