### PR TITLE
Refuse to attach a browser running in the other mode (#194)

### DIFF
--- a/clicker/cmd/clicker/start.go
+++ b/clicker/cmd/clicker/start.go
@@ -43,8 +43,16 @@ Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.`,
 			}
 
 			if connectURL == "" {
-				// Local launch — just ensure daemon is running (lazy browser launch)
-				result, err := daemonCall("browser_start", map[string]interface{}{})
+				// Local launch — just ensure daemon is running (lazy browser launch).
+				// Carry --headless on the call: the flag otherwise only reaches a
+				// daemon we spawn ourselves, so it is silently dropped whenever one
+				// is already up. Only when explicitly given, so a bare `start`
+				// does not override a daemon deliberately started headless.
+				startArgs := map[string]interface{}{}
+				if cmd.Flags().Changed("headless") {
+					startArgs["headless"] = headless
+				}
+				result, err := daemonCall("browser_start", startArgs)
 				if err != nil {
 					printError(err)
 					return

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -43,6 +43,10 @@ type Handlers struct {
 	// prompts records which contexts have an open user prompt, so a command
 	// Chrome will not answer fails immediately instead of timing out.
 	prompts *api.PromptTracker
+
+	// launchedHeadless is the mode the running browser was actually launched
+	// with, which is not necessarily the daemon's default.
+	launchedHeadless bool
 }
 
 // NewHandlers creates a new Handlers instance.
@@ -619,8 +623,15 @@ func (h *Handlers) Close() {
 
 // browserLaunch launches a new browser session or connects to a remote one.
 func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult, error) {
-	// If browser is already running, return success (no-op)
+	// If browser is already running, return success (no-op) — unless the
+	// caller asked for a different mode than the one it is running in.
+	// Silently attaching them to the other mode is what #194 reported.
 	if h.client != nil {
+		if want, ok := args["headless"].(bool); ok && want != h.launchedHeadless {
+			return nil, fmt.Errorf(
+				"browser is already running %s; requested %s. Run `vibium stop` first, or drop the flag to use the running browser",
+				modeName(h.launchedHeadless), modeName(want))
+		}
 		return &ToolsCallResult{
 			Content: []Content{{
 				Type: "text",
@@ -682,6 +693,7 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 	h.launchResult = launchResult
 	h.conn = conn
 	h.client = bidi.NewClient(conn)
+	h.launchedHeadless = useHeadless
 	h.sessionMu.Unlock()
 	h.startPromptTracking()
 
@@ -691,6 +703,14 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 			Text: fmt.Sprintf("Browser launched (headless: %v)", useHeadless),
 		}},
 	}, nil
+}
+
+// modeName renders a launch mode the way the user typed it.
+func modeName(headless bool) string {
+	if headless {
+		return "headless"
+	}
+	return "headed"
 }
 
 // startPromptTracking subscribes to user-prompt events and keeps h.prompts in

--- a/tests/daemon/lifecycle.test.js
+++ b/tests/daemon/lifecycle.test.js
@@ -191,3 +191,37 @@ describe('Daemon: status exit code', () => {
     assert.match(status, /running/i);
   });
 });
+
+describe('Daemon: browser mode mismatch', () => {
+  before(() => {
+    stopDaemon();
+  });
+
+  after(() => {
+    stopDaemon();
+  });
+
+  test('requesting a different mode than the running browser is refused (#194)', () => {
+    // Headless daemon, so the request below asks for the opposite.
+    clicker('daemon start --headless');
+    clicker(`go ${baseURL}/example`);
+
+    try {
+      execSync(`${VIBIUM} --headless=false start`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+        stdio: 'pipe',
+      });
+      assert.fail('should refuse to attach a headed request to a headless browser');
+    } catch (err) {
+      const out = err.stdout + err.stderr;
+      assert.match(out, /already running headless/, `got: ${out.slice(0, 200)}`);
+      assert.match(out, /vibium stop/, 'should say how to resolve it');
+    }
+
+    // Matching mode still attaches, and so does no flag at all — the flag must
+    // only assert a mode when the user actually typed it.
+    assert.match(clicker('--headless start'), /already running/i);
+    assert.match(clicker('start'), /already running/i);
+  });
+});


### PR DESCRIPTION
Verified before fixing — it reproduces, though the title has gone stale.

| | before | after |
|---|---|---|
| headed daemon + `--headless start` | `Browser already running`, exit 0 — **silently headed** | `already running headed; requested headless…`, exit 1 |
| headless daemon + `start` | `Browser launched (headless: true)` — reports headless for a headed request | refused with the same message |

Confirmed from inside the browser: `window.outerWidth > 0` on a `--headless` request, so it really was handing back a headed browser.

## Two chained defects

`--headless` only ever reached a daemon **we** spawned, via argv (`daemon_client.go`). With one already up the flag went nowhere — `start` sent `browser_start` with empty args.

And even once carried, `browserLaunch` short-circuited on `h.client != nil` *before* reaching the per-call headless override, so the mode was frozen at daemon-spawn time.

## Two deliberate calls

**`Flags().Changed("headless")`**, not the raw value. Sending it unconditionally would make a bare `start` assert "headed" and start refusing to attach to a daemon deliberately started headless.

**Errors rather than relaunching.** Swapping the browser underneath the user discards their pages and cookies — the same reasoning as #219.

## Stale title

There is no HTTP 500 any more; it fails *silently*, which is worse. The original close ("filed before we had enough root-cause detail") was fair at the time.

Full `make test` passes.

Fixes #194