### PR TITLE
Five small CLI and client fixes

### DIFF
--- a/clicker/cmd/clicker/diagnostics.go
+++ b/clicker/cmd/clicker/diagnostics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vibium/clicker/internal/bidi"
@@ -112,6 +113,11 @@ func newWSTestCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			url := args[0]
+			if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+				ws := strings.Replace(strings.Replace(url, "https://", "wss://", 1), "http://", "ws://", 1)
+				fmt.Fprintf(os.Stderr, "Error: %s is not a WebSocket URL. Try: %s\n", url, ws)
+				os.Exit(1)
+			}
 			fmt.Printf("Connecting to %s...\n", url)
 
 			conn, err := bidi.Connect(url)

--- a/clicker/cmd/clicker/is.go
+++ b/clicker/cmd/clicker/is.go
@@ -68,24 +68,28 @@ func newIsCmd() *cobra.Command {
 	actionableCmd := &cobra.Command{
 		Use:   "actionable [url] [selector]",
 		Short: "Check actionability of an element (Visible, Stable, ReceivesEvents, Enabled, Editable)",
-		Example: `  vibium is actionable https://example.com "a"
+		Example: `  vibium is actionable "a"
   # Output:
   # Checking actionability for selector: a
   # ✓ Visible: true
   # ✓ Stable: true
   # ✓ ReceivesEvents: true
   # ✓ Enabled: true
-  # ✗ Editable: false`,
-		Args: cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			url := args[0]
-			selector := args[1]
+  # ✗ Editable: false
 
-			// Navigate to URL
-			_, err := daemonCall("browser_navigate", map[string]interface{}{"url": url})
-			if err != nil {
-				printError(err)
-				return
+  vibium is actionable https://example.com "a"
+  # Navigate first, then check`,
+		Args: cobra.RangeArgs(1, 2),
+		Run: func(cmd *cobra.Command, args []string) {
+			// The optional leading [url] matches the other is-commands and
+			// `find`; requiring it here made this the odd one out (#199).
+			selector := args[0]
+			if len(args) == 2 {
+				if _, err := daemonCall("browser_navigate", map[string]interface{}{"url": args[0]}); err != nil {
+					printError(err)
+					return
+				}
+				selector = args[1]
 			}
 
 			fmt.Printf("\nChecking actionability for selector: %s\n", selector)

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -1832,7 +1832,11 @@ func (h *Handlers) browserGetText(args map[string]interface{}) (*ToolsCallResult
 	var text string
 	if selector, ok := args["selector"].(string); ok && selector != "" {
 		selector = h.resolveSelector(selector)
-		text, err = api.GetInnerText(s, ctx, api.ElementParams{Selector: selector})
+		// GetText, not GetInnerText: this tool is documented as "text content",
+		// traces record it as vibium:element.text, and every client's .text()
+		// is textContent. Page-level text below stays innerText — "what the
+		// page reads as" is a different question from one element's content.
+		text, err = api.GetText(s, ctx, api.ElementParams{Selector: selector})
 	} else {
 		text, err = api.EvalSimpleScript(s, ctx, "() => document.body.innerText")
 	}
@@ -4075,10 +4079,22 @@ func (h *Handlers) browserStorageState(args map[string]interface{}) (*ToolsCallR
 		return nil, fmt.Errorf("failed to get storage: %w", err)
 	}
 
+	// The page script returns JSON.stringify(...), so Evaluate hands back a Go
+	// string. Storing that directly wrote the storage as a quoted blob, which
+	// restore then spliced into JS as a string literal — state.localStorage was
+	// undefined and every key was silently skipped (#217).
+	storage := storageResult
+	if raw, ok := storageResult.(string); ok {
+		var decoded interface{}
+		if err := json.Unmarshal([]byte(raw), &decoded); err == nil {
+			storage = decoded
+		}
+	}
+
 	// Build combined state
 	state := map[string]interface{}{
 		"cookies": cookies,
-		"storage": storageResult,
+		"storage": storage,
 	}
 
 	stateJSON, _ := json.MarshalIndent(state, "", "  ")
@@ -4123,6 +4139,14 @@ func (h *Handlers) browserRestoreStorage(args map[string]interface{}) (*ToolsCal
 
 	// Restore localStorage/sessionStorage if present
 	if len(state.Storage) > 0 {
+		// Files written before #217 hold the storage as a JSON *string* rather
+		// than an object; unwrap one level so those still restore.
+		storageJSON := state.Storage
+		var legacy string
+		if err := json.Unmarshal(storageJSON, &legacy); err == nil {
+			storageJSON = json.RawMessage(legacy)
+		}
+
 		script := fmt.Sprintf(`(function() {
 			var state = %s;
 			if (state.localStorage) {
@@ -4136,8 +4160,10 @@ func (h *Handlers) browserRestoreStorage(args map[string]interface{}) (*ToolsCal
 				}
 			}
 			return 'ok';
-		})()`, string(state.Storage))
-		h.client.Evaluate(h.activeContext, script)
+		})()`, string(storageJSON))
+		if _, err := h.client.Evaluate(h.activeContext, script); err != nil {
+			return nil, fmt.Errorf("failed to restore storage: %w", err)
+		}
 	}
 
 	return &ToolsCallResult{

--- a/clicker/internal/api/handlers_state.go
+++ b/clicker/internal/api/handlers_state.go
@@ -19,8 +19,7 @@ func (r *Router) handleVibiumElText(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 
-	script, args := buildElStateScript(ep, `(el.innerText || '').trim()`)
-	val, err := r.evalElementScript(session, context, script, args)
+	val, err := GetText(NewAPISession(r, session, context), context, ep)
 	if err != nil {
 		r.sendError(session, cmd.ID, err)
 		return
@@ -67,8 +66,7 @@ func (r *Router) handleVibiumElInnerText(session *BrowserSession, cmd bidiComman
 		return
 	}
 
-	script, args := buildElStateScript(ep, `(el.innerText || '').trim()`)
-	val, err := r.evalElementScript(session, context, script, args)
+	val, err := GetInnerText(NewAPISession(r, session, context), context, ep)
 	if err != nil {
 		r.sendError(session, cmd.ID, err)
 		return
@@ -819,9 +817,10 @@ func (r *Router) resolveElementNoWait(session *BrowserSession, context string, e
 // Exported standalone state query functions — usable from both proxy and MCP.
 // ---------------------------------------------------------------------------
 
-// GetText returns the visible text of an element (innerText).
+// GetText returns the element's textContent, trimmed. GetInnerText is the
+// rendered-text variant; keeping both on innerText made them the same command.
 func GetText(s Session, context string, ep ElementParams) (string, error) {
-	script, args := buildElStateScript(ep, `(el.innerText || '').trim()`)
+	script, args := buildElStateScript(ep, `(el.textContent || '').trim()`)
 	return EvalElementScript(s, context, script, args)
 }
 

--- a/clients/python/src/vibium/async_api/element.py
+++ b/clients/python/src/vibium/async_api/element.py
@@ -91,6 +91,10 @@ class Element:
     async def focus(self, timeout: Optional[int] = None) -> None:
         await self._client.send("vibium:element.focus", self._command_params({"timeout": timeout}))
 
+    async def highlight(self, timeout: Optional[int] = None) -> None:
+        """Briefly outline the element so a human watching can see it."""
+        await self._client.send("vibium:element.highlight", self._command_params({"timeout": timeout}))
+
     async def drag_to(self, target: Element, timeout: Optional[int] = None) -> None:
         await self._client.send("vibium:element.dragTo", self._command_params({
             "target": target._to_params(),

--- a/clients/python/src/vibium/sync_api/element.py
+++ b/clients/python/src/vibium/sync_api/element.py
@@ -60,6 +60,10 @@ class Element:
     def focus(self, timeout: Optional[int] = None) -> None:
         self._loop.run(self._async.focus(timeout))
 
+    def highlight(self, timeout: Optional[int] = None) -> None:
+        """Briefly outline the element so a human watching can see it."""
+        self._loop.run(self._async.highlight(timeout))
+
     def drag_to(self, target: Element, timeout: Optional[int] = None) -> None:
         self._loop.run(self._async.drag_to(target._async, timeout))
 

--- a/tests/cli/wrapper.test.js
+++ b/tests/cli/wrapper.test.js
@@ -7,8 +7,9 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
-const { spawnSync } = require('node:child_process');
+const { spawnSync, execSync } = require('node:child_process');
 const path = require('node:path');
+const { VIBIUM } = require('../helpers');
 
 const CLI_JS = path.join(__dirname, '../../packages/vibium/bin/cli.js');
 
@@ -28,5 +29,21 @@ describe('CLI: npm wrapper error handling', () => {
     );
     // The binary's own error message should still be shown.
     assert.match(out, /unknown command|Error|usage/i, `should show the binary's message, got:\n${out}`);
+  });
+});
+
+describe('CLI: ws-test scheme hint', () => {
+  test('names the ws:// form when given http:// (#196)', () => {
+    try {
+      execSync(`${VIBIUM} ws-test http://localhost:59999`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+        stdio: 'pipe',
+      });
+      assert.fail('should reject an http:// URL');
+    } catch (err) {
+      const out = err.stdout + err.stderr;
+      assert.match(out, /ws:\/\/localhost:59999/, `should suggest the ws:// form, got: ${out.slice(0, 200)}`);
+    }
   });
 });

--- a/tests/daemon/cli-commands.test.js
+++ b/tests/daemon/cli-commands.test.js
@@ -102,6 +102,26 @@ describe('Daemon CLI: Element state commands', () => {
     assert.ok(result.result.includes('/more-information'), 'Should return href value');
   });
 
+  test('text returns textContent, not rendered text (#215)', () => {
+    clicker(`content '<div id="d">vis<span style="display:none">HIDDEN</span></div>'`);
+
+    const el = clickerJSON('text "#d"');
+    assert.strictEqual(el.result, 'visHIDDEN', 'element text is textContent, so hidden text is included');
+
+    // Page-level text is a different question and stays rendered text.
+    const page = clickerJSON('text');
+    assert.ok(!page.result.includes('HIDDEN'), 'page text stays innerText');
+  });
+
+  test('is actionable accepts a bare selector like its siblings (#199)', () => {
+    clicker(`go ${baseURL}/example`);
+    const out = clicker('is actionable "h1"');
+    assert.match(out, /Visible/, `1-arg form should work, got: ${out.slice(0, 120)}`);
+
+    const withUrl = clicker(`is actionable ${baseURL}/example "h1"`);
+    assert.match(withUrl, /Visible/, 'the 2-arg form must keep working');
+  });
+
   test('attr distinguishes a present-but-empty attribute from an absent one (#198)', () => {
     clicker(`content '<button id="b" disabled>Go</button>'`);
 


### PR DESCRIPTION
Five small reported bugs.

## #215 — `element.text` returned rendered text

It used `innerText`, making it byte-identical to `element.innerText` and dropping hidden text — contradicting the handler's own doc comment, `docs/reference/api.md`, and every client's `.text()`.

The fix reaches all three surfaces from **one line**: `handleVibiumElText` (wire command) and `browser_get_text` (MCP/CLI) now both call `GetText` instead of rebuilding the same script, so the `textContent` semantic exists once and cannot drift again. Same collapse applied to `innerText`.

Page-level `vibium text` stays on `innerText` deliberately — "what does this page read as" is a different question from "what is this element's content".

```
<div id="d">vis<span style="display:none">HIDDEN</span></div>

vibium text "#d"   ->  visHIDDEN   (was: vis)
vibium text        ->  vis         (unchanged)
```

## #217 — storage restore silently did nothing

The save path stored the page's `JSON.stringify(...)` result as a Go string, so the file held a quoted blob rather than an object. Restore spliced that into JS as a **string literal**, so `state.localStorage` was `undefined`, both loops were skipped, and the script still returned `'ok'`. Cookies restored fine, which is why it looked partial.

Decode once on save; unwrap one level on restore so files already written in the broken shape still restore; and stop discarding the `Evaluate` error that made the failure silent in the first place.

## #196 — `ws-test` on an http:// URL

Passed straight to gorilla, surfacing `malformed ws or wss URL`. Now names the equivalent:

```
Error: http://localhost:9999 is not a WebSocket URL. Try: ws://localhost:9999
```

## #199 — `is actionable` arity

Required 2 args while its sibling `is` commands and `find` take an optional leading `[url]`. Now `RangeArgs(1, 2)`; both forms work.

## #208 — Python `element.highlight()`

Missing from the client though the engine has supported `vibium:element.highlight` for a while. Added to async and sync.

Full `make test` passes.

Fixes #215
Fixes #217
Fixes #196
Fixes #199
Fixes #208
