### PR TITLE
Resolve elements semantically in the interaction builders (#106, #108)

### DIFF
--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -1001,7 +1001,7 @@ func ScrollWheel(s Session, context string, x, y, deltaX, deltaY int) error {
 				"id":   "wheel",
 				"actions": []map[string]interface{}{
 					{
-						"type":    "scroll",
+						"type":   "scroll",
 						"x":      x,
 						"y":      y,
 						"deltaX": deltaX,
@@ -1020,25 +1020,7 @@ func ScrollWheel(s Session, context string, x, y, deltaX, deltaY int) error {
 
 // buildIsCheckedScript builds a JS function to check if an element is checked.
 func buildIsCheckedScript(ep ElementParams) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-	}
-
-	script := `
-		(scope, selector, index, hasIndex) => {
-			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'false';
-			let el;
-			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
-			} else {
-				el = root.querySelector(selector);
-			}
-			if (!el) return 'false';
+	return buildElActionScript(ep, nil, nil, `
 			const t = el.tagName === 'INPUT' ? (el.type || '').toLowerCase() : '';
 			const role = (el.getAttribute('role') || '').toLowerCase();
 			if (t !== 'checkbox' && t !== 'radio' &&
@@ -1047,33 +1029,15 @@ func buildIsCheckedScript(ep ElementParams) (string, []map[string]interface{}) {
 			}
 			if (t === '') return el.getAttribute('aria-checked') === 'true' ? 'true' : 'false';
 			return el.checked ? 'true' : 'false';
-		}
-	`
-	return script, args
+		`)
 }
 
 // buildSelectOptionScript builds a JS function to set a select element's value.
 func buildSelectOptionScript(ep ElementParams, value string) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-		{"type": "string", "value": value},
-	}
-
-	script := `
-		(scope, selector, index, hasIndex, value) => {
-			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'element not found';
-			let el;
-			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
-			} else {
-				el = root.querySelector(selector);
-			}
-			if (!el) return 'element not found';
+	return buildElActionScript(ep,
+		[]string{"value"},
+		[]map[string]interface{}{{"type": "string", "value": value}},
+		`
 			if (el.tagName !== 'SELECT') return 'not a <select> element';
 			// Match by option value, then fall back to the visible label/text so
 			// passing "California" (for <option value="CA">California</option>)
@@ -1086,33 +1050,67 @@ func buildSelectOptionScript(ep ElementParams, value string) (string, []map[stri
 			el.dispatchEvent(new Event('input', { bubbles: true }));
 			el.dispatchEvent(new Event('change', { bubbles: true }));
 			return 'ok';
-		}
-	`
-	return script, args
+		`)
 }
 
 // buildSetValueScript builds a JS function to set an element's value and dispatch events.
-func buildSetValueScript(ep ElementParams, value string) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-		{"type": "string", "value": value},
+// buildElActionScript wraps an action body in the same element-resolution
+// prologue the state builders use, so an element found semantically (role/text/
+// label/...) resolves here too. Without it these builders did a CSS-only
+// querySelector(selector), and selector is "" for a semantic find — issue #108.
+//
+// body runs with `el` bound and returns a string; extraNames/extraArgs append
+// parameters after the resolution ones.
+func buildElActionScript(ep ElementParams, extraNames []string, extraArgs []map[string]interface{}, body string) (string, []map[string]interface{}) {
+	joined := ""
+	for _, n := range extraNames {
+		joined += ", " + n
 	}
 
-	script := `
-		(scope, selector, index, hasIndex, value) => {
+	if hasSemantic(ep) {
+		args := append(buildElSemanticArgs(ep), extraArgs...)
+		script := fmt.Sprintf(`
+		(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex%s) => {
+			const root = scope ? document.querySelector(scope) : document;
+			if (!root) return 'element not found';
+		`+semanticMatchesHelper()+`
+			const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
+			let el;
+			if (hasIndex) {
+				el = found[index];
+			} else {
+				el = pickBest(found, text);
+			}
+			if (!el) return 'element not found';
+			%s
+		}
+	`, joined, body)
+		return script, args
+	}
+
+	args := append(buildElBaseArgs(ep), extraArgs...)
+	script := fmt.Sprintf(`
+		(scope, selector, index, hasIndex%s) => {
 			const root = scope ? document.querySelector(scope) : document;
 			if (!root) return 'element not found';
 			let el;
 			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
+				el = root.querySelectorAll(selector)[index];
 			} else {
 				el = root.querySelector(selector);
 			}
 			if (!el) return 'element not found';
+			%s
+		}
+	`, joined, body)
+	return script, args
+}
+
+func buildSetValueScript(ep ElementParams, value string) (string, []map[string]interface{}) {
+	return buildElActionScript(ep,
+		[]string{"value"},
+		[]map[string]interface{}{{"type": "string", "value": value}},
+		`
 			el.focus();
 			// Pick the native value setter for the element's ACTUAL type. Calling
 			// the HTMLInputElement setter on a <textarea> throws "Illegal
@@ -1133,67 +1131,28 @@ func buildSetValueScript(ep ElementParams, value string) (string, []map[string]i
 			el.dispatchEvent(new Event('input', { bubbles: true }));
 			el.dispatchEvent(new Event('change', { bubbles: true }));
 			return 'ok';
-		}
-	`
-	return script, args
+		`)
 }
 
 // buildFocusScript builds a JS function to focus an element.
 func buildFocusScript(ep ElementParams) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-	}
-
-	script := `
-		(scope, selector, index, hasIndex) => {
-			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'not found';
-			let el;
-			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
-			} else {
-				el = root.querySelector(selector);
-			}
-			if (!el) return 'not found';
+	return buildElActionScript(ep, nil, nil, `
 			el.focus();
 			return 'ok';
-		}
-	`
-	return script, args
+		`)
 }
 
 // buildDispatchEventScript builds a JS function to dispatch an event on an element.
 func buildDispatchEventScript(ep ElementParams, eventType, initJSON string) (string, []map[string]interface{}) {
-	args := []map[string]interface{}{
-		{"type": "string", "value": ep.Scope},
-		{"type": "string", "value": ep.Selector},
-		{"type": "number", "value": ep.Index},
-		{"type": "boolean", "value": ep.HasIndex},
-		{"type": "string", "value": eventType},
-		{"type": "string", "value": initJSON},
-	}
-
-	script := `
-		(scope, selector, index, hasIndex, eventType, initJSON) => {
-			const root = scope ? document.querySelector(scope) : document;
-			if (!root) return 'not found';
-			let el;
-			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
-				el = all[index];
-			} else {
-				el = root.querySelector(selector);
-			}
-			if (!el) return 'not found';
+	return buildElActionScript(ep,
+		[]string{"eventType", "initJSON"},
+		[]map[string]interface{}{
+			{"type": "string", "value": eventType},
+			{"type": "string", "value": initJSON},
+		},
+		`
 			const init = JSON.parse(initJSON);
 			el.dispatchEvent(new Event(eventType, init));
 			return 'ok';
-		}
-	`
-	return script, args
+		`)
 }
-

--- a/clients/java/src/main/java/com/vibium/Element.java
+++ b/clients/java/src/main/java/com/vibium/Element.java
@@ -20,13 +20,21 @@ public class Element {
     private final String selector;
     private final int index;
     private final ElementInfo info;
+    /** Semantic locator params (role/text/label/...) this element was found by. */
+    private final Map<String, Object> params;
 
     Element(BiDiClient client, String contextId, String selector, int index, ElementInfo info) {
+        this(client, contextId, selector, index, info, null);
+    }
+
+    Element(BiDiClient client, String contextId, String selector, int index, ElementInfo info,
+            Map<String, Object> params) {
         this.client = client;
         this.contextId = contextId;
         this.selector = selector;
         this.index = index;
         this.info = info;
+        this.params = params == null ? Collections.emptyMap() : params;
     }
 
     /** Get info about this element (tag, text, bounding box). */
@@ -283,7 +291,7 @@ public class Element {
             params.add(entry.getKey(), GSON.toJsonTree(entry.getValue()));
         }
         JsonObject result = client.send("vibium:element.find", params);
-        return elementFromResult(result);
+        return elementFromResult(result, "", locatorParams(childOptions));
     }
 
     /** Find all child elements by CSS selector. */
@@ -309,7 +317,7 @@ public class Element {
             params.add(entry.getKey(), GSON.toJsonTree(entry.getValue()));
         }
         JsonObject result = client.send("vibium:element.findAll", params);
-        return elementsFromResult(result);
+        return elementsFromResult(result, "", locatorParams(childOptions));
     }
 
     // ── Internal ────────────────────────────────────────────────
@@ -317,6 +325,11 @@ public class Element {
     private JsonObject elementParams() {
         JsonObject params = new JsonObject();
         params.addProperty("context", contextId);
+        // A semantically-found element has selector "", so without these the
+        // engine falls back to querySelector("") and nothing resolves (#106).
+        for (Map.Entry<String, Object> e : this.params.entrySet()) {
+            params.add(e.getKey(), GSON.toJsonTree(e.getValue()));
+        }
         params.addProperty("selector", selector);
         if (index > 0) {
             params.addProperty("index", index);
@@ -342,17 +355,32 @@ public class Element {
 
     // The find response carries only tag/text/box, so the child's selector has to
     // come from the caller or the returned element cannot be re-resolved.
+    /** The locator an element was found by, minus per-call options. */
+    private static Map<String, Object> locatorParams(SelectorOptions options) {
+        Map<String, Object> p = new LinkedHashMap<>(options.toParams());
+        p.remove("timeout");
+        return p;
+    }
+
     private Element elementFromResult(JsonObject result, String selector) {
+        return elementFromResult(result, selector, null);
+    }
+
+    private Element elementFromResult(JsonObject result, String selector, Map<String, Object> locator) {
         int idx = result.has("index") ? result.get("index").getAsInt() : 0;
         ElementInfo eInfo = parseElementInfo(result);
-        return new Element(client, contextId, selector, idx, eInfo);
+        return new Element(client, contextId, selector, idx, eInfo, locator);
     }
 
     private List<Element> elementsFromResult(JsonObject result, String selector) {
+        return elementsFromResult(result, selector, null);
+    }
+
+    private List<Element> elementsFromResult(JsonObject result, String selector, Map<String, Object> locator) {
         List<Element> elements = new ArrayList<>();
         com.google.gson.JsonArray arr = result.has("elements") ? result.getAsJsonArray("elements") : new com.google.gson.JsonArray();
         for (int i = 0; i < arr.size(); i++) {
-            elements.add(new Element(client, contextId, selector, i, parseElementInfo(arr.get(i).getAsJsonObject())));
+            elements.add(new Element(client, contextId, selector, i, parseElementInfo(arr.get(i).getAsJsonObject()), locator));
         }
         return elements;
     }

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -154,7 +154,7 @@ public class Page {
             params.add(entry.getKey(), GSON.toJsonTree(entry.getValue()));
         }
         JsonObject result = client.send("vibium:page.find", params);
-        return elementFromResult(result, "", 0);
+        return elementFromResult(result, "", 0, locatorParams(options));
     }
 
     /** Find all matching elements by CSS selector. */
@@ -180,7 +180,7 @@ public class Page {
             params.add(entry.getKey(), GSON.toJsonTree(entry.getValue()));
         }
         JsonObject result = client.send("vibium:page.findAll", params);
-        return elementsFromResult(result, "");
+        return elementsFromResult(result, "", locatorParams(options));
     }
 
     // ── Screenshots & PDF ───────────────────────────────────────
@@ -630,17 +630,34 @@ public class Page {
     }
 
     private Element elementFromResult(JsonObject result, String selector, int index) {
+        return elementFromResult(result, selector, index, null);
+    }
+
+    private Element elementFromResult(JsonObject result, String selector, int index,
+                                      Map<String, Object> locator) {
         ElementInfo info = parseElementInfo(result);
-        return new Element(client, contextId, selector, index, info);
+        return new Element(client, contextId, selector, index, info, locator);
+    }
+
+    /** The locator an element was found by, minus per-call options. */
+    private static Map<String, Object> locatorParams(SelectorOptions options) {
+        Map<String, Object> p = new LinkedHashMap<>(options.toParams());
+        p.remove("timeout");
+        return p;
     }
 
     private List<Element> elementsFromResult(JsonObject result, String selector) {
+        return elementsFromResult(result, selector, null);
+    }
+
+    private List<Element> elementsFromResult(JsonObject result, String selector,
+                                             Map<String, Object> locator) {
         List<Element> elements = new ArrayList<>();
         JsonArray arr = result.has("elements") ? result.getAsJsonArray("elements") : new JsonArray();
         for (int i = 0; i < arr.size(); i++) {
             JsonObject el = arr.get(i).getAsJsonObject();
             ElementInfo info = parseElementInfo(el);
-            elements.add(new Element(client, contextId, selector, i, info));
+            elements.add(new Element(client, contextId, selector, i, info, locator));
         }
         return elements;
     }

--- a/clients/java/src/test/java/com/vibium/WireContractTest.java
+++ b/clients/java/src/test/java/com/vibium/WireContractTest.java
@@ -1,6 +1,7 @@
 package com.vibium;
 
 import com.vibium.types.A11yNode;
+import com.vibium.types.SelectorOptions;
 import com.vibium.types.A11yOptions;
 import com.vibium.types.StartOptions;
 import com.vibium.types.WaitOptions;
@@ -103,6 +104,23 @@ class WireContractTest {
         assertTrue(everything > interesting,
             "everything(true) should include uninteresting nodes: "
                 + everything + " vs " + interesting);
+    }
+
+    /**
+     * A semantically-found element has selector "", so unless it carries the
+     * locator it was found by, every follow-up command resolves nothing (#106).
+     */
+    @Test
+    void semanticallyFoundElementSupportsFollowUpCommands() {
+        page.go(server.baseUrl() + "/form");
+
+        Element field = page.find(new SelectorOptions().label("Name"));
+        assertEquals("input", field.info().tag());
+
+        // These all re-resolve server-side from the element's own params.
+        field.fill("Ada");
+        assertEquals("Ada", field.value());
+        assertTrue(field.isVisible());
     }
 
     private static int countNodes(A11yNode node) {


### PR DESCRIPTION
Two issues that turn out to be chained — neither fix works alone.

## #108 — the interaction builders never resolved semantically

`buildSetValueScript`, `buildSelectOptionScript`, `buildFocusScript`, `buildDispatchEventScript` and `buildIsCheckedScript` all did a CSS-only `root.querySelector(selector)` and never branched on `hasSemantic`. `grep -n hasSemantic handlers_interaction.go` returned **zero hits** — they were the only unbranched element-resolution sites left in `internal/api`.

An element found by `role`/`text`/`label` has `selector == ""`, so `fill`, `clear`, `selectOption`, `focus` and `dispatchEvent` failed with:

```
SyntaxError: Failed to execute 'querySelector' on 'Document': The provided selector is empty.
```

…even though `resolveWithActionability` had resolved that element correctly moments before.

Rather than add the same branch five times, they now share one `buildElActionScript` that wraps an action body in the resolution prologue the state builders already use. One CSS prologue remains in the file, inside that helper.

## #106 — different cause than the title

`SelectorOptions` **are** applied at lookup — `Page.java` copies every entry into `vibium:page.find`. The defect is that the returned `Element` drops them: it stored only a `selector`, which is `""` for a semantic find, so every follow-up command shipped an empty locator.

Java's `Element` now carries the params it was found by, which the JS and Python clients already did.

## Why one PR

They are chained. With only #106 fixed, the params reach the engine and #108 rejects them. With only #108 fixed, Java never sends them. The new Java test fails against either half alone — it was the thing that surfaced the chaining:

```
FAIL semanticallyFoundElementSupportsFollowUpCommands()
  VibiumException: fill failed: SyntaxError: ... The provided selector is empty.
```

All 6 `WireContractTest` tests pass now, and full `make test` passes.

Fixes #106
Fixes #108
