### PR TITLE
Share the editable predicate, and resolve chrome/driver as a pair (#264, #265)

### DIFF
--- a/clicker/cmd/clicker/is.go
+++ b/clicker/cmd/clicker/is.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/vibium/clicker/internal/api"
 
 	"github.com/spf13/cobra"
 )
@@ -122,7 +123,7 @@ func newIsCmd() *cobra.Command {
 					const tag = el.tagName.toLowerCase();
 					if (tag === 'input') {
 						const t = (el.type || 'text').toLowerCase();
-						editable = ['text','password','email','number','search','tel','url'].includes(t);
+						editable = ` + api.FillableInputTypesJS + `.includes(t);
 					} else if (tag !== 'textarea' && !el.isContentEditable) {
 						editable = false;
 					}

--- a/clicker/internal/api/actionability.go
+++ b/clicker/internal/api/actionability.go
@@ -163,6 +163,25 @@ func buildSemanticActionableScript(ep ElementParams, checkVisible, checkReceives
 // actionabilityCheckBody returns the shared JS check body appended after
 // element finding + scroll. Uses the boolean flags passed as arguments.
 // Stability is NOT checked here — it's handled on the Go side via two calls.
+// FillableInputTypesJS is a JS array literal of the input types whose value
+// fill can set: text-like inputs plus the value-bearing pickers. Excludes
+// checkbox/radio (use check), file (use upload) and button/submit/reset/image.
+//
+// One definition, because the action path, `vibium is actionable` and
+// element.isEditable each had their own copy and they had already drifted —
+// fill worked on input[type=range] while `is actionable` called it not
+// editable (#264).
+const FillableInputTypesJS = `['text','password','email','number','search','tel','url',` +
+	`'range','color','date','time','datetime-local','month','week']`
+
+// EditablePredicateJS is a JS expression, evaluated with `el` in scope, that is
+// true when fill can set this element's value.
+const EditablePredicateJS = `(!el.disabled && !el.readOnly && el.getAttribute('aria-readonly') !== 'true' && (
+	el.tagName.toLowerCase() === 'input'
+		? ` + FillableInputTypesJS + `.includes((el.type || 'text').toLowerCase())
+		: (el.tagName.toLowerCase() === 'textarea' || el.isContentEditable)
+))`
+
 func actionabilityCheckBody() string {
 	return `
 			if (chkVisible) {
@@ -198,8 +217,7 @@ func actionabilityCheckBody() string {
 					// picker types (range/color/date/time family), not just text inputs.
 					// Excludes checkbox/radio (use check), file (use upload), and
 					// button/submit/reset/image (not value inputs).
-					const fillableTypes = ['text','password','email','number','search','tel','url',
-						'range','color','date','time','datetime-local','month','week'];
+					const fillableTypes = ` + FillableInputTypesJS + `;
 					if (!fillableTypes.includes(t))
 						return JSON.stringify({status:'failed', check:'editable', reason:'input type ' + t + ' not editable'});
 				} else if (tag !== 'textarea' && !el.isContentEditable) {

--- a/clicker/internal/api/handlers_state.go
+++ b/clicker/internal/api/handlers_state.go
@@ -336,7 +336,9 @@ func (r *Router) handleVibiumElIsEditable(session *BrowserSession, cmd bidiComma
 		return
 	}
 
-	script, args := buildElBoolScript(ep, `return !el.disabled && !el.readOnly;`)
+	// Same question as the fill path and `is actionable`, so the same predicate:
+	// !disabled && !readOnly alone called a <div> editable.
+	script, args := buildElBoolScript(ep, `return `+EditablePredicateJS+`;`)
 	editable, err := r.evalBoolScript(session, context, script, args)
 	if err != nil {
 		r.sendError(session, cmd.ID, err)

--- a/clicker/internal/paths/paths.go
+++ b/clicker/internal/paths/paths.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 // GetCacheDir returns the platform-specific cache directory for Vibium.
@@ -65,55 +68,91 @@ func GetChromeForTestingDir() (string, error) {
 	return filepath.Join(cacheDir, "chrome-for-testing"), nil
 }
 
+// resolveVersionDir returns the newest cached version directory containing BOTH
+// Chrome and chromedriver.
+//
+// They used to be resolved independently, each taking the first directory that
+// held its own binary, so a cache with Chrome under 146.x and chromedriver under
+// 147.x produced a mismatched pair that IsInstalled() certified as fine — the
+// failure surfaced later as chromedriver's "only supports Chrome version N"
+// (#265). Newest-first also replaces os.ReadDir's lexical order, under which
+// "99.0" sorts above "100.0".
+func resolveVersionDir() (string, error) {
+	cftDir, err := GetChromeForTestingDir()
+	if err != nil {
+		return "", err
+	}
+
+	entries, err := os.ReadDir(cftDir)
+	if err != nil {
+		return "", err
+	}
+
+	var complete []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(cftDir, entry.Name())
+		if _, err := os.Stat(getChromePathInVersion(dir)); err != nil {
+			continue
+		}
+		if _, err := os.Stat(getChromedriverPathInVersion(dir)); err != nil {
+			continue
+		}
+		complete = append(complete, entry.Name())
+	}
+	if len(complete) == 0 {
+		return "", os.ErrNotExist
+	}
+
+	sort.Slice(complete, func(i, j int) bool {
+		return compareVersions(complete[i], complete[j]) > 0
+	})
+	return filepath.Join(cftDir, complete[0]), nil
+}
+
+// compareVersions orders dotted numeric versions, falling back to string order
+// for anything that does not parse.
+func compareVersions(a, b string) int {
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var ai, bi int
+		if i < len(as) {
+			ai, _ = strconv.Atoi(as[i])
+		}
+		if i < len(bs) {
+			bi, _ = strconv.Atoi(bs[i])
+		}
+		if ai != bi {
+			if ai > bi {
+				return 1
+			}
+			return -1
+		}
+	}
+	return strings.Compare(a, b)
+}
+
 // GetChromeExecutable returns the path to Chrome for Testing executable.
 // Only checks Vibium cache - does not fall back to system Chrome.
 func GetChromeExecutable() (string, error) {
-	cftDir, err := GetChromeForTestingDir()
+	dir, err := resolveVersionDir()
 	if err != nil {
 		return "", err
 	}
-
-	// Look for version directories
-	entries, err := os.ReadDir(cftDir)
-	if err != nil {
-		return "", err
-	}
-
-	// Use the first (or latest) version found
-	for _, entry := range entries {
-		if entry.IsDir() {
-			chromePath := getChromePathInVersion(filepath.Join(cftDir, entry.Name()))
-			if _, err := os.Stat(chromePath); err == nil {
-				return chromePath, nil
-			}
-		}
-	}
-
-	return "", os.ErrNotExist
+	return getChromePathInVersion(dir), nil
 }
 
-// GetChromedriverPath returns the path to the cached chromedriver.
+// GetChromedriverPath returns the path to the cached chromedriver. It resolves
+// from the same version directory as GetChromeExecutable, so the two always
+// match.
 func GetChromedriverPath() (string, error) {
-	cftDir, err := GetChromeForTestingDir()
+	dir, err := resolveVersionDir()
 	if err != nil {
 		return "", err
 	}
-
-	entries, err := os.ReadDir(cftDir)
-	if err != nil {
-		return "", err
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			driverPath := getChromedriverPathInVersion(filepath.Join(cftDir, entry.Name()))
-			if _, err := os.Stat(driverPath); err == nil {
-				return driverPath, nil
-			}
-		}
-	}
-
-	return "", os.ErrNotExist
+	return getChromedriverPathInVersion(dir), nil
 }
 
 // getChromePathInVersion returns the Chrome executable path within a version directory.

--- a/clicker/internal/paths/paths_test.go
+++ b/clicker/internal/paths/paths_test.go
@@ -1,0 +1,101 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedVersion creates a version directory holding the requested binaries.
+func seedVersion(t *testing.T, cftDir, version string, chrome, driver bool) {
+	t.Helper()
+	dir := filepath.Join(cftDir, version)
+	if chrome {
+		p := getChromePathInVersion(dir)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("chrome"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if driver {
+		p := getChromedriverPathInVersion(dir)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("driver"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// withCache points the cache at a temp dir for the duration of a test.
+func withCache(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	dir, err := GetChromeForTestingDir()
+	if err != nil {
+		t.Fatalf("GetChromeForTestingDir: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A cache holding Chrome under one version and chromedriver under another used
+// to resolve to a mismatched pair, which IsInstalled() then certified (#265).
+func TestResolvesChromeAndDriverAsAPair(t *testing.T) {
+	cft := withCache(t)
+	seedVersion(t, cft, "146.0.7000.10", true, false) // chrome only
+	seedVersion(t, cft, "147.0.8000.20", false, true) // driver only
+	seedVersion(t, cft, "145.0.6000.30", true, true)  // the only complete pair
+
+	chrome, err := GetChromeExecutable()
+	if err != nil {
+		t.Fatalf("GetChromeExecutable: %v", err)
+	}
+	driver, err := GetChromedriverPath()
+	if err != nil {
+		t.Fatalf("GetChromedriverPath: %v", err)
+	}
+
+	if !strings.Contains(chrome, "145.0.6000.30") {
+		t.Errorf("chrome resolved to %q, want the complete 145 pair", chrome)
+	}
+	if !strings.Contains(driver, "145.0.6000.30") {
+		t.Errorf("driver resolved to %q, want the complete 145 pair", driver)
+	}
+}
+
+func TestPrefersNewestCompleteVersion(t *testing.T) {
+	cft := withCache(t)
+	seedVersion(t, cft, "99.0.1000.1", true, true)
+	seedVersion(t, cft, "100.0.1000.1", true, true)
+
+	chrome, err := GetChromeExecutable()
+	if err != nil {
+		t.Fatalf("GetChromeExecutable: %v", err)
+	}
+	// Lexically "99.0..." sorts after "100.0...", so this also pins that the
+	// comparison is numeric rather than os.ReadDir's string order.
+	if !strings.Contains(chrome, "100.0.1000.1") {
+		t.Errorf("chrome resolved to %q, want the newest complete version", chrome)
+	}
+}
+
+func TestNoCompleteVersionIsNotFound(t *testing.T) {
+	cft := withCache(t)
+	seedVersion(t, cft, "146.0.7000.10", true, false)
+
+	if _, err := GetChromeExecutable(); err == nil {
+		t.Error("a cache with no complete pair should not resolve")
+	}
+	if _, err := GetChromedriverPath(); err == nil {
+		t.Error("a cache with no complete pair should not resolve")
+	}
+}


### PR DESCRIPTION
Two defects found by audit rather than reported by users.

## #264 — three copies of one predicate, drifted

"Can `fill` set this element's value" existed three times:

| site | list |
|---|---|
| `internal/api/actionability.go` | post-#188, includes `range`, `color`, `date`… |
| `cmd/clicker/is.go` | **stale pre-#188** |
| `internal/api/handlers_state.go` | `!el.disabled && !el.readOnly` — calls a `<div>` editable |

So `vibium fill "#slider" 3` succeeded while `vibium is actionable "#slider"` reported it not editable. The divergence was *created* by the #188 fix, which widened one copy and left its twin.

```
before:   fill → Filled     is actionable → ✗ Editable: false
after:    fill → Filled     is actionable → ✓ Editable: true
```

One definition now (`FillableInputTypesJS`, `EditablePredicateJS`), used by all three. Zero stale copies remain.

## #265 — chrome and chromedriver resolved independently

Each scanned the cache and returned the first directory holding *its own* binary, so a cache with chrome under `146.x` and chromedriver under `147.x` produced a mismatched pair — which `IsInstalled()` then certified as fine, so the installer skipped repair and the failure surfaced later as chromedriver's "only supports Chrome version N".

They now resolve from one directory containing **both**. Selection is numeric rather than `os.ReadDir`'s lexical order, under which `"99.0"` sorts above `"100.0"`.

Unit tests fabricate the mismatched cache directly, so this is covered without needing two real Chrome versions installed.

Full `make test` passes.

Fixes #264
Fixes #265