### PR TITLE
Listen for the download events the engine actually emits (#255)

### DIFF
--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -741,10 +741,10 @@ public class Page {
                     handleConsoleEvent(params);
                 }
                 break;
-            case "vibium:download.started":
+            case "browsingContext.downloadWillBegin":
                 handleDownloadStarted(params);
                 break;
-            case "vibium:download.completed":
+            case "browsingContext.downloadEnd":
                 handleDownloadCompleted(params);
                 break;
             case "vibium:network.intercepted":
@@ -800,7 +800,7 @@ public class Page {
     private void handleDownloadStarted(JsonObject params) {
         if (downloadListeners.isEmpty()) return;
         Download download = new Download(client, params);
-        String navId = params.has("navigationId") ? params.get("navigationId").getAsString() : "";
+        String navId = params.has("navigation") ? params.get("navigation").getAsString() : "";
         if (!navId.isEmpty()) {
             activeDownloads.put(navId, download);
         }
@@ -810,11 +810,11 @@ public class Page {
     }
 
     private void handleDownloadCompleted(JsonObject params) {
-        String navId = params.has("navigationId") ? params.get("navigationId").getAsString() : "";
+        String navId = params.has("navigation") ? params.get("navigation").getAsString() : "";
         Download download = activeDownloads.remove(navId);
         if (download != null) {
-            String status = params.has("status") ? params.get("status").getAsString() : "";
-            String path = params.has("path") ? params.get("path").getAsString() : null;
+            String status = params.has("status") ? params.get("status").getAsString() : "complete";
+            String path = params.has("filepath") ? params.get("filepath").getAsString() : null;
             download.complete(status, path);
         }
     }

--- a/clients/java/src/test/java/com/vibium/WireContractTest.java
+++ b/clients/java/src/test/java/com/vibium/WireContractTest.java
@@ -6,6 +6,13 @@ import com.vibium.types.A11yOptions;
 import com.vibium.types.StartOptions;
 import com.vibium.types.WaitOptions;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import java.util.List;
 
@@ -121,6 +128,34 @@ class WireContractTest {
         field.fill("Ada");
         assertEquals("Ada", field.value());
         assertTrue(field.isVisible());
+    }
+
+    /**
+     * onDownload could never fire: the client listened for vibium:download.*
+     * events the engine does not emit, and read navigationId where the BiDi
+     * payload carries navigation (#255).
+     */
+    @Test
+    void onDownloadFiresAndSaveAsWritesTheFile(@TempDir Path tmp) throws Exception {
+        page.go(server.baseUrl() + "/download");
+
+        CountDownLatch started = new CountDownLatch(1);
+        AtomicReference<Download> seen = new AtomicReference<>();
+        page.onDownload(d -> {
+            seen.set(d);
+            started.countDown();
+        });
+
+        page.find("#download-link").click();
+        assertTrue(started.await(30, TimeUnit.SECONDS), "onDownload should fire");
+        assertEquals("test.txt", seen.get().suggestedFilename());
+
+        // saveAs needs the completed temp path, which only arrives via
+        // downloadEnd — so this also covers the completion half.
+        Path dest = tmp.resolve("saved.txt");
+        seen.get().saveAs(dest.toString());
+        assertTrue(Files.exists(dest), "saveAs should have written the file");
+        assertEquals("download content", Files.readString(dest).trim());
     }
 
     private static int countNodes(A11yNode node) {


### PR DESCRIPTION
`page.onDownload` could never fire in the Java client.

It dispatched on `vibium:download.started` / `vibium:download.completed` — strings that appear **nowhere** in `clicker/`. The engine subscribes to and forwards the raw BiDi events (`router.go:188-189`):

```
browsingContext.downloadWillBegin
browsingContext.downloadEnd
```

which is what the JS client listens for (`page.ts:281,283`).

The payload keys were wrong too — `navigationId` where BiDi carries `navigation`, and `path` where it carries `filepath` — so even with the right event name, correlating start with end would have failed.

## Knock-on

This makes the `saveAs` param fix from #254 testable for the first time. You cannot obtain a `Download` object until the events work, which is why that fix shipped verified only against the handler rather than at runtime. The new test covers both halves: `onDownload` fires with the right `suggestedFilename`, and `saveAs` writes the file using the temp path that only arrives via `downloadEnd`.

All 7 `WireContractTest` tests pass; full `make test` passes.

Fixes #255