### PR TITLE
Parse trailing flags without breaking negative positionals (#241)

### DIFF
--- a/clicker/cmd/clicker/daemon_client.go
+++ b/clicker/cmd/clicker/daemon_client.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/vibium/clicker/internal/daemon"
 	"github.com/vibium/clicker/internal/agent"
+	"github.com/vibium/clicker/internal/daemon"
 	"github.com/vibium/clicker/internal/paths"
 )
 
@@ -103,8 +103,8 @@ func isConnectionError(err error) bool {
 		"connect to daemon",
 		"connection refused",
 		"no such file or directory",
-		"The system cannot find the path",  // Windows named pipe not found
-		"The system cannot find the file",  // Windows named pipe not found (alt)
+		"The system cannot find the path", // Windows named pipe not found
+		"The system cannot find the file", // Windows named pipe not found (alt)
 	} {
 		if containsString(errMsg, pattern) {
 			return true

--- a/clicker/cmd/clicker/fill.go
+++ b/clicker/cmd/clicker/fill.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,8 +20,18 @@ func newFillCmd() *cobra.Command {
 
   vibium fill "#search" "vibium" --timeout 5s
   # Custom timeout (5s, or 5000 for milliseconds)`,
-		Args: cobra.ExactArgs(2),
+		DisableFlagParsing: true,
+		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			args, perr := parseFlagsAllowNegative(cmd, args)
+			if perr != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", perr)
+				os.Exit(1)
+			}
+			if len(args) != 2 {
+				fmt.Fprintf(os.Stderr, "Error: accepts 2 arg(s), received %d\n", len(args))
+				os.Exit(1)
+			}
 			selector := args[0]
 			text := args[1]
 			result, err := daemonCall("browser_fill", map[string]interface{}{
@@ -38,6 +50,5 @@ func newFillCmd() *cobra.Command {
 	// fill now carries a --timeout flag, so it can't disable flag parsing the way
 	// #179 did for the flagless case. SetInterspersed(false) instead keeps negative
 	// positional values (e.g. fill "#x" "-2") from being parsed as shorthand flags.
-	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/clicker/cmd/clicker/find.go
+++ b/clicker/cmd/clicker/find.go
@@ -181,8 +181,8 @@ func newFindCmd() *cobra.Command {
 	}
 
 	altCmd := &cobra.Command{
-		Use:   "alt [alt]",
-		Short: "Find element by alt attribute",
+		Use:     "alt [alt]",
+		Short:   "Find element by alt attribute",
 		Example: `  vibium find alt "Logo"`,
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -196,8 +196,8 @@ func newFindCmd() *cobra.Command {
 	}
 
 	titleCmd := &cobra.Command{
-		Use:   "title [title]",
-		Short: "Find element by title attribute",
+		Use:     "title [title]",
+		Short:   "Find element by title attribute",
 		Example: `  vibium find title "Close"`,
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/clicker/cmd/clicker/geolocation.go
+++ b/clicker/cmd/clicker/geolocation.go
@@ -17,8 +17,18 @@ func newGeolocationCmd() *cobra.Command {
 
   vibium geolocation 51.5074 -0.1278 --accuracy 10
   # Set location to London with 10m accuracy`,
-		Args: cobra.ExactArgs(2),
+		DisableFlagParsing: true,
+		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			args, perr := parseFlagsAllowNegative(cmd, args)
+			if perr != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", perr)
+				os.Exit(1)
+			}
+			if len(args) != 2 {
+				fmt.Fprintf(os.Stderr, "Error: accepts 2 arg(s), received %d\n", len(args))
+				os.Exit(1)
+			}
 			lat, err := strconv.ParseFloat(args[0], 64)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: invalid latitude: %s\n", args[0])
@@ -48,6 +58,5 @@ func newGeolocationCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Float64("accuracy", 0, "Accuracy in meters (default: 1)")
-	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/clicker/cmd/clicker/helpers.go
+++ b/clicker/cmd/clicker/helpers.go
@@ -1,6 +1,12 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 // printCheck prints an actionability check result with a checkmark or X.
 func printCheck(name string, passed bool) {
@@ -9,4 +15,69 @@ func printCheck(name string, passed bool) {
 	} else {
 		fmt.Printf("✗ %s: false\n", name)
 	}
+}
+
+// parseFlagsAllowNegative splits raw args into flags and positionals, treating a
+// token that starts with '-' as a positional when it parses as a number.
+//
+// pflag has no negative-number support, so `sleep -5` and
+// `geolocation 37.8 -122.4` are read as unknown flags. The two workarounds in
+// use — DisableFlagParsing and SetInterspersed(false) — both fix that by
+// breaking trailing flags, so `sleep 1 --json` printed plain text and
+// `fill '#x' y --timeout 5s` failed on arity (#241).
+//
+// Commands using this set DisableFlagParsing and cobra.ArbitraryArgs, then check
+// their own arity on the returned positionals.
+func parseFlagsAllowNegative(cmd *cobra.Command, raw []string) ([]string, error) {
+	// Touching InheritedFlags merges the parents' persistent flags (--json,
+	// --headless, --verbose) into cmd.Flags(). cmd.ParseFlags is not usable
+	// here: it returns early when DisableFlagParsing is set, which is exactly
+	// the mode these commands run in.
+	cmd.InheritedFlags()
+	flags := cmd.Flags()
+
+	var flagTokens, positionals []string
+
+	for i := 0; i < len(raw); i++ {
+		tok := raw[i]
+
+		if tok == "--" {
+			positionals = append(positionals, raw[i+1:]...)
+			break
+		}
+
+		if len(tok) < 2 || !strings.HasPrefix(tok, "-") {
+			positionals = append(positionals, tok)
+			continue
+		}
+
+		// "-5" and "-122.4" are values, not flags.
+		if _, err := strconv.ParseFloat(tok, 64); err == nil {
+			positionals = append(positionals, tok)
+			continue
+		}
+
+		flagTokens = append(flagTokens, tok)
+
+		// A flag that needs a value consumes the next token, unless it was
+		// given inline as --name=value.
+		if strings.Contains(tok, "=") {
+			continue
+		}
+		name := strings.TrimLeft(tok, "-")
+		f := flags.Lookup(name)
+		if f == nil && len(name) == 1 {
+			// ShorthandLookup panics on anything longer than one character.
+			f = flags.ShorthandLookup(name)
+		}
+		if f != nil && f.NoOptDefVal == "" && i+1 < len(raw) {
+			i++
+			flagTokens = append(flagTokens, raw[i])
+		}
+	}
+
+	if err := flags.Parse(flagTokens); err != nil {
+		return nil, err
+	}
+	return positionals, nil
 }

--- a/clicker/cmd/clicker/record.go
+++ b/clicker/cmd/clicker/record.go
@@ -140,8 +140,8 @@ func newRecordCmd() *cobra.Command {
 	}
 
 	groupStopCmd := &cobra.Command{
-		Use:   "stop",
-		Short: "End the current recording group",
+		Use:     "stop",
+		Short:   "End the current recording group",
 		Example: `  vibium record group stop`,
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/clicker/cmd/clicker/sleep_cmd.go
+++ b/clicker/cmd/clicker/sleep_cmd.go
@@ -18,8 +18,17 @@ func newSleepCmd() *cobra.Command {
   vibium sleep 500
   # Wait 500ms`,
 		DisableFlagParsing: true,
-		Args:               cobra.ExactArgs(1),
+		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			args, perr := parseFlagsAllowNegative(cmd, args)
+			if perr != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", perr)
+				os.Exit(1)
+			}
+			if len(args) != 1 {
+				fmt.Fprintf(os.Stderr, "Error: accepts 1 arg(s), received %d\n", len(args))
+				os.Exit(1)
+			}
 			ms, err := strconv.ParseFloat(args[0], 64)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: invalid milliseconds value: %s\n", args[0])
@@ -34,6 +43,5 @@ func newSleepCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/clicker/cmd/clicker/type_cmd.go
+++ b/clicker/cmd/clicker/type_cmd.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -19,8 +21,18 @@ func newTypeCmd() *cobra.Command {
 
   vibium type https://the-internet.herokuapp.com/inputs "input" "12345" --timeout 5s
   # Custom timeout (5s, or 5000 for milliseconds)`,
-		Args: cobra.RangeArgs(2, 3),
+		DisableFlagParsing: true,
+		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			args, perr := parseFlagsAllowNegative(cmd, args)
+			if perr != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", perr)
+				os.Exit(1)
+			}
+			if len(args) < 2 || len(args) > 3 {
+				fmt.Fprintf(os.Stderr, "Error: accepts between 2 and 3 arg(s), received %d\n", len(args))
+				os.Exit(1)
+			}
 			var selector, text string
 			if len(args) == 3 {
 				// type <url> <selector> <text> — navigate first
@@ -51,6 +63,5 @@ func newTypeCmd() *cobra.Command {
 		},
 	}
 	addTimeoutFlag(cmd, &timeout)
-	cmd.Flags().SetInterspersed(false)
 	return cmd
 }

--- a/tests/cli/input-tools.test.js
+++ b/tests/cli/input-tools.test.js
@@ -83,6 +83,38 @@ describe('CLI: Negative value flag parsing', () => {
     }
   });
 
+  test('trailing flags work alongside negative positionals (#241)', () => {
+    // sleep used DisableFlagParsing and fill/type/geolocation used
+    // SetInterspersed(false); both kept negatives working by swallowing any
+    // flag that came after a positional.
+    const json = execSync(`${VIBIUM} sleep 1 --json`, { encoding: 'utf-8', timeout: 30000 });
+    assert.strictEqual(JSON.parse(json.trim()).ok, true, 'sleep should honour a trailing --json');
+
+    execSync(`${VIBIUM} content '<input id="x"><input id="y">'`, { encoding: 'utf-8', timeout: 30000 });
+
+    assert.match(
+      execSync(`${VIBIUM} fill "#x" val --timeout 5s`, { encoding: 'utf-8', timeout: 30000 }),
+      /Filled/,
+      'fill should accept a trailing --timeout'
+    );
+    assert.match(
+      execSync(`${VIBIUM} type "#y" hi --timeout 5s`, { encoding: 'utf-8', timeout: 30000 }),
+      /Typed/,
+      'type should accept a trailing --timeout'
+    );
+
+    const geo = execSync(`${VIBIUM} geolocation 37.8 -122.4 --json`, { encoding: 'utf-8', timeout: 30000 });
+    assert.strictEqual(JSON.parse(geo.trim()).ok, true, 'a negative arg and a trailing flag together');
+  });
+
+  test('an unknown flag errors instead of being swallowed (#241)', () => {
+    assert.throws(
+      () => execSync(`${VIBIUM} sleep 1 --bogus`, { encoding: 'utf-8', timeout: 30000, stdio: 'pipe' }),
+      /unknown flag/,
+      'should report the flag, not treat it as a positional or panic'
+    );
+  });
+
   test('geolocation accepts negative coordinates', () => {
     const result = execSync(`${VIBIUM} geolocation 37.7749 -122.4194`, {
       encoding: 'utf-8',


### PR DESCRIPTION
pflag treats any token starting with `-` as a flag, so `sleep -5` and `geolocation 37.8 -122.4` were read as unknown flags. Two *different* workarounds had been applied for that, and both fixed it by breaking trailing flags:

| command | workaround | consequence |
|---|---|---|
| `sleep` | `DisableFlagParsing: true` | `--json` never parsed at all |
| `fill`, `type`, `geolocation` | `SetInterspersed(false)` | a flag after a positional became a positional |

So `sleep 1 --json` printed plain text, and `fill "#x" y --timeout 5s` failed on arity. Only `sleep` was reported; the other three were unreported siblings.

## Fix

One `parseFlagsAllowNegative`: a token starting with `-` is a flag only when it does **not** parse as a number. The four commands disable cobra parsing, run the splitter, and check their own arity.

Two things this had to get right that tripped me up first:

- **`cmd.ParseFlags` returns early when `DisableFlagParsing` is set** — which is exactly the mode these commands are in. So the flag set is parsed directly, after `InheritedFlags()` merges the root's persistent `--json`/`--headless`/`--verbose`.
- **`ShorthandLookup` panics** on names longer than one character (`vibium sleep 1 --bogus` → `panic: can not look up shorthand`). It is only consulted for single-character flags now.

## Verified both directions

```
sleep 1 --json                    {"ok":true,...}
--json sleep 1                    {"ok":true,...}
fill "#x" y --timeout 5s          Filled "y" into #x
type "#y" hi --timeout 5s         Typed into element: #y
geolocation 37.8 -122.4 --json    {"ok":true,...}

sleep -5                          Error: ms is required and must be positive
fill "#x" -- -2                   Filled "-2" into #x
geolocation -33.8 151.2           Geolocation set to (-33.800000, 151.200000)
sleep 1 --bogus                   Error: unknown flag: --bogus
```

Full `make test` passes.

Fixes #241