### PR TITLE
Read daemon messages with a reader that grows (#209)

### DIFF
--- a/clicker/internal/daemon/client.go
+++ b/clicker/internal/daemon/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/vibium/clicker/internal/agent"
@@ -136,17 +137,19 @@ func sendRequest(method string, params json.RawMessage) (*agent.Response, error)
 	}
 
 	conn.SetReadDeadline(time.Now().Add(readTimeout))
-	scanner := bufio.NewScanner(conn)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
+	// bufio.Reader grows as needed; bufio.Scanner failed with "token too long"
+	// on any response over its fixed buffer — a long page's text, a large
+	// storage state (#209).
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil && len(line) == 0 {
+		if err != io.EOF {
 			return nil, fmt.Errorf("read response: %w", err)
 		}
 		return nil, fmt.Errorf("daemon closed connection without response")
 	}
 
 	var resp agent.Response
-	if err := json.Unmarshal(scanner.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal(line, &resp); err != nil {
 		return nil, fmt.Errorf("unmarshal response: %w", err)
 	}
 

--- a/clicker/internal/daemon/daemon.go
+++ b/clicker/internal/daemon/daemon.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vibium/clicker/internal/log"
 	"github.com/vibium/clicker/internal/agent"
+	"github.com/vibium/clicker/internal/log"
 	"github.com/vibium/clicker/internal/paths"
 )
 

--- a/clicker/internal/daemon/router.go
+++ b/clicker/internal/daemon/router.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/vibium/clicker/internal/log"
 	"github.com/vibium/clicker/internal/agent"
+	"github.com/vibium/clicker/internal/log"
 )
 
 // StatusResult is returned by daemon/status.
@@ -31,14 +31,12 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 	// Set read deadline
 	conn.SetReadDeadline(time.Now().Add(60 * time.Second))
 
-	scanner := bufio.NewScanner(conn)
-	// Increase scanner buffer for large requests
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-
-	if !scanner.Scan() {
+	// bufio.Reader grows as needed; bufio.Scanner fails once a message exceeds
+	// its fixed buffer, and raising that cap only moves the ceiling (#209).
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil && len(line) == 0 {
 		return
 	}
-	line := scanner.Bytes()
 
 	response := d.handleRequest(line)
 	if response == nil {

--- a/tests/cli/page-reading.test.js
+++ b/tests/cli/page-reading.test.js
@@ -26,6 +26,28 @@ after(() => {
   if (serverProcess) serverProcess.kill();
 });
 
+describe('CLI: large payloads', () => {
+  test('page text over the old 1MB daemon cap survives the round trip (#209)', () => {
+    // The CLI<->daemon socket read used a fixed 1MB bufio.Scanner buffer, so
+    // any larger response died with "bufio.Scanner: token too long".
+    const size = 3 * 1024 * 1024;
+    execSync(
+      `${VIBIUM} eval "document.body.innerHTML = '<p>' + 'x'.repeat(${size}) + '</p>'; 'ok'"`,
+      { encoding: 'utf-8', timeout: 60000 }
+    );
+
+    const out = execSync(`${VIBIUM} text`, {
+      encoding: 'utf-8',
+      timeout: 60000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    assert.ok(
+      out.length >= size,
+      `expected at least ${size} bytes back, got ${out.length}`
+    );
+  });
+});
+
 describe('CLI: Page Reading', () => {
   test('text command returns page text', () => {
     const result = execSync(`${VIBIUM} text ${baseURL}/example`, {


### PR DESCRIPTION
`vibium text` crashed with `bufio.Scanner: token too long` on pages whose text exceeded 1MB.

Both directions of the CLI↔daemon socket read through a `bufio.Scanner` with a fixed 1MB buffer (`daemon/client.go:139`, `daemon/router.go:34`). Any larger message — a long page's text, a large storage state, a big JSON response — hit the cap.

## Fix

`bufio.Reader.ReadBytes('\n')`, which grows as needed.

Deliberately not "raise the cap": that only moves the ceiling to whatever the next payload-producing feature returns, which is the pattern this class of bug has already followed (#44 raised a WebSocket limit, #110/#168 hit the Python reader, this one hit the daemon socket).

## Verified

3MB of page text through the hop that previously failed at 1MB:

```
bytes returned: 3145728
```

Full `make test` passes.

## Overlap with #225

Community PR #225 diagnosed this identically and reached the same `ReadBytes` fix. Credit where due. This one landed first, so #225 has been closed as redundant.

Fixes #209
