### PR TITLE
Make `is` exit-honest and `find --timeout` real (#206)

### DIFF
--- a/clicker/cmd/clicker/find.go
+++ b/clicker/cmd/clicker/find.go
@@ -3,11 +3,13 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 func newFindCmd() *cobra.Command {
+	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "find [selector]",
 		Short: "Find elements by CSS selector or semantic locator",
@@ -47,6 +49,8 @@ func newFindCmd() *cobra.Command {
 				toolArgs["selector"] = args[0]
 			}
 
+			toolArgs["timeout"] = float64(timeout.Milliseconds())
+
 			if all {
 				limit, _ := cmd.Flags().GetInt("limit")
 				toolArgs["limit"] = float64(limit)
@@ -68,10 +72,12 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	addTimeoutFlag(cmd, &timeout)
 	cmd.Flags().Bool("all", false, "Find all matching elements")
 	cmd.Flags().Int("limit", 10, "Maximum number of elements to return (with --all)")
 
 	// Semantic locator subcommands
+	var textCmdTimeout time.Duration
 	textCmd := &cobra.Command{
 		Use:   "text [text]",
 		Short: "Find element by text content",
@@ -79,7 +85,7 @@ func newFindCmd() *cobra.Command {
   # → @e1 [button] "Sign In"`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := daemonCall("browser_find", map[string]interface{}{"text": args[0]})
+			result, err := daemonCall("browser_find", map[string]interface{}{"text": args[0], "timeout": float64(textCmdTimeout.Milliseconds())})
 			if err != nil {
 				printError(err)
 				return
@@ -88,6 +94,7 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	var roleCmdTimeout time.Duration
 	roleCmd := &cobra.Command{
 		Use:   "role [role]",
 		Short: "Find element by ARIA role",
@@ -106,6 +113,7 @@ func newFindCmd() *cobra.Command {
 				// <input type="submit">.
 				toolArgs["label"] = name
 			}
+			toolArgs["timeout"] = float64(roleCmdTimeout.Milliseconds())
 			result, err := daemonCall("browser_find", toolArgs)
 			if err != nil {
 				printError(err)
@@ -116,6 +124,7 @@ func newFindCmd() *cobra.Command {
 	}
 	roleCmd.Flags().String("name", "", "Accessible name filter")
 
+	var labelCmdTimeout time.Duration
 	labelCmd := &cobra.Command{
 		Use:   "label [label]",
 		Short: "Find input by associated label text",
@@ -123,7 +132,7 @@ func newFindCmd() *cobra.Command {
   # → @e1 [input type="email"] placeholder="Email"`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := daemonCall("browser_find", map[string]interface{}{"label": args[0]})
+			result, err := daemonCall("browser_find", map[string]interface{}{"label": args[0], "timeout": float64(labelCmdTimeout.Milliseconds())})
 			if err != nil {
 				printError(err)
 				return
@@ -132,6 +141,7 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	var placeholderCmdTimeout time.Duration
 	placeholderCmd := &cobra.Command{
 		Use:   "placeholder [placeholder]",
 		Short: "Find element by placeholder attribute",
@@ -139,7 +149,7 @@ func newFindCmd() *cobra.Command {
   # → @e1 [input] placeholder="Search..."`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := daemonCall("browser_find", map[string]interface{}{"placeholder": args[0]})
+			result, err := daemonCall("browser_find", map[string]interface{}{"placeholder": args[0], "timeout": float64(placeholderCmdTimeout.Milliseconds())})
 			if err != nil {
 				printError(err)
 				return
@@ -148,6 +158,7 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	var testidCmdTimeout time.Duration
 	testidCmd := &cobra.Command{
 		Use:   "testid [testid]",
 		Short: "Find element by data-testid attribute",
@@ -155,7 +166,7 @@ func newFindCmd() *cobra.Command {
   # → @e1 [button] data-testid="submit-btn"`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := daemonCall("browser_find", map[string]interface{}{"testid": args[0]})
+			result, err := daemonCall("browser_find", map[string]interface{}{"testid": args[0], "timeout": float64(testidCmdTimeout.Milliseconds())})
 			if err != nil {
 				printError(err)
 				return
@@ -164,6 +175,7 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	var xpathCmdTimeout time.Duration
 	xpathCmd := &cobra.Command{
 		Use:   "xpath [expression]",
 		Short: "Find element by XPath expression",
@@ -171,7 +183,7 @@ func newFindCmd() *cobra.Command {
   # → @e1 [div.main] ...`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := daemonCall("browser_find", map[string]interface{}{"xpath": args[0]})
+			result, err := daemonCall("browser_find", map[string]interface{}{"xpath": args[0], "timeout": float64(xpathCmdTimeout.Milliseconds())})
 			if err != nil {
 				printError(err)
 				return
@@ -180,13 +192,14 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	var altCmdTimeout time.Duration
 	altCmd := &cobra.Command{
-		Use:   "alt [alt]",
-		Short: "Find element by alt attribute",
+		Use:     "alt [alt]",
+		Short:   "Find element by alt attribute",
 		Example: `  vibium find alt "Logo"`,
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := daemonCall("browser_find", map[string]interface{}{"alt": args[0]})
+			result, err := daemonCall("browser_find", map[string]interface{}{"alt": args[0], "timeout": float64(altCmdTimeout.Milliseconds())})
 			if err != nil {
 				printError(err)
 				return
@@ -195,13 +208,14 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	var titleCmdTimeout time.Duration
 	titleCmd := &cobra.Command{
-		Use:   "title [title]",
-		Short: "Find element by title attribute",
+		Use:     "title [title]",
+		Short:   "Find element by title attribute",
 		Example: `  vibium find title "Close"`,
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := daemonCall("browser_find", map[string]interface{}{"title": args[0]})
+			result, err := daemonCall("browser_find", map[string]interface{}{"title": args[0], "timeout": float64(titleCmdTimeout.Milliseconds())})
 			if err != nil {
 				printError(err)
 				return
@@ -210,13 +224,21 @@ func newFindCmd() *cobra.Command {
 		},
 	}
 
+	addTimeoutFlag(textCmd, &textCmdTimeout)
 	cmd.AddCommand(textCmd)
+	addTimeoutFlag(roleCmd, &roleCmdTimeout)
 	cmd.AddCommand(roleCmd)
+	addTimeoutFlag(labelCmd, &labelCmdTimeout)
 	cmd.AddCommand(labelCmd)
+	addTimeoutFlag(placeholderCmd, &placeholderCmdTimeout)
 	cmd.AddCommand(placeholderCmd)
+	addTimeoutFlag(testidCmd, &testidCmdTimeout)
 	cmd.AddCommand(testidCmd)
+	addTimeoutFlag(xpathCmd, &xpathCmdTimeout)
 	cmd.AddCommand(xpathCmd)
+	addTimeoutFlag(altCmd, &altCmdTimeout)
 	cmd.AddCommand(altCmd)
+	addTimeoutFlag(titleCmd, &titleCmdTimeout)
 	cmd.AddCommand(titleCmd)
 
 	return cmd

--- a/clicker/cmd/clicker/is.go
+++ b/clicker/cmd/clicker/is.go
@@ -3,10 +3,25 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/vibium/clicker/internal/agent"
 	"github.com/vibium/clicker/internal/api"
+	"github.com/vibium/clicker/internal/process"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+// exitOnFalse makes `--fail` turn a "false" answer into a non-zero exit, so the
+// is-commands can be used in a conditional. Without it the only signal is
+// stdout, since a well-formed "false" is a successful query (#206).
+func exitOnFalse(cmd *cobra.Command, result *agent.ToolsCallResult) {
+	fail, _ := cmd.Flags().GetBool("fail")
+	if fail && strings.TrimSpace(extractText(result)) == "false" {
+		process.KillAll()
+		os.Exit(1)
+	}
+}
 
 func newIsCmd() *cobra.Command {
 	isCmd := &cobra.Command{
@@ -31,6 +46,7 @@ func newIsCmd() *cobra.Command {
 				return
 			}
 			printResult(result)
+			exitOnFalse(cmd, result)
 		},
 	}
 
@@ -47,6 +63,7 @@ func newIsCmd() *cobra.Command {
 				return
 			}
 			printResult(result)
+			exitOnFalse(cmd, result)
 		},
 	}
 
@@ -63,6 +80,7 @@ func newIsCmd() *cobra.Command {
 				return
 			}
 			printResult(result)
+			exitOnFalse(cmd, result)
 		},
 	}
 
@@ -174,6 +192,9 @@ func newIsCmd() *cobra.Command {
 		},
 	}
 
+	for _, c := range []*cobra.Command{visibleCmd, enabledCmd, checkedCmd} {
+		c.Flags().Bool("fail", false, "Exit non-zero when the answer is false")
+	}
 	isCmd.AddCommand(visibleCmd)
 	isCmd.AddCommand(enabledCmd)
 	isCmd.AddCommand(checkedCmd)

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -973,12 +973,14 @@ func (h *Handlers) browserFind(args map[string]interface{}) (*ToolsCallResult, e
 
 	hasSemantic := role != "" || text != "" || label != "" || placeholder != "" || testid != "" || xpath != "" || alt != "" || title != ""
 
-	if hasSemantic {
-		timeout := api.DefaultTimeout
-		if t, ok := argFloat(args, "timeout"); ok {
-			timeout = time.Duration(t) * time.Millisecond
-		}
+	// Shared by both branches: the CSS path polls too, so --timeout is not
+	// silently inert on the most common form of find (#206).
+	timeout := api.DefaultTimeout
+	if t, ok := argFloat(args, "timeout"); ok {
+		timeout = time.Duration(t) * time.Millisecond
+	}
 
+	if hasSemantic {
 		script := findBySemanticScript()
 		result, err := pollCallFunction(h, script, []interface{}{role, text, label, placeholder, testid, xpath, alt, title}, timeout)
 		if err != nil {
@@ -1037,9 +1039,13 @@ func (h *Handlers) browserFind(args map[string]interface{}) (*ToolsCallResult, e
 		}
 		return getLabel(el);
 	}`
-	labelResult, err := h.client.CallFunction(h.activeContext, labelScript, []interface{}{selector})
+	// Poll like the semantic branch does, so --timeout means something here and
+	// a CSS find waits for an element that has not rendered yet (#206). The
+	// single non-polling call also returned nil for a miss and still minted a
+	// @e1 ref, so `find` reported "@e1 <nil>" with exit 0.
+	labelResult, err := pollCallFunction(h, labelScript, []interface{}{selector}, timeout)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("element not found: %s (timeout %s)", selector, timeout)
 	}
 
 	// Store ref in refMap

--- a/tests/daemon/cli-commands.test.js
+++ b/tests/daemon/cli-commands.test.js
@@ -102,6 +102,38 @@ describe('Daemon CLI: Element state commands', () => {
     assert.ok(result.result.includes('/more-information'), 'Should return href value');
   });
 
+  test('is --fail exits non-zero on a false answer (#206)', () => {
+    clicker(`content '<h1 id="h">hi</h1>'`);
+
+    // Default exit code is unchanged — a well-formed "false" is a successful query.
+    const plain = clickerJSON('is visible "#nope"');
+    assert.strictEqual(plain.ok, true);
+    assert.strictEqual(plain.result.trim(), 'false');
+
+    assert.throws(
+      () => clicker('is visible "#nope" --fail'),
+      /.*/,
+      '--fail should turn a false answer into a non-zero exit'
+    );
+    // A true answer still succeeds with the flag on.
+    assert.match(clicker('is visible "#h" --fail'), /true/);
+  });
+
+  test('find honours --timeout and errors on a miss (#206)', () => {
+    clicker(`content '<h1 id="h">hi</h1>'`);
+
+    const started = Date.now();
+    assert.throws(
+      () => clicker(`find "#nothing" --timeout 2s`),
+      /element not found/,
+      'a CSS miss should error, not return "@e1 <nil>" with exit 0'
+    );
+    const elapsed = Date.now() - started;
+    assert.ok(elapsed < 15000, `--timeout 2s should bound the wait, took ${elapsed}ms`);
+
+    assert.match(clicker('find "#h"'), /@e1/, 'a real element still resolves');
+  });
+
   test('text returns textContent, not rendered text (#215)', () => {
     clicker(`content '<div id="d">vis<span style="display:none">HIDDEN</span></div>'`);
 


### PR DESCRIPTION
#206 reported three things.

**Part 1 — `count` crashes on unmarshal.** Already fixed by `fcf885d`, five weeks *before* the issue was filed, with a regression test at `tests/mcp/server.test.js`. Verified not reproducible on main.

**Part 2 — `is` exits 0 on false.** `is visible/enabled/checked` gain `--fail`, which turns a false answer into a non-zero exit so they work in a conditional. The default is unchanged — a well-formed "false" is a *successful query*, and an existing test depends on that.

**Part 3 — `find` timeout not adjustable.** `--timeout` added to the root command and each semantic subcommand.

## The part that would have been a no-op

Adding the flag alone ships something that does nothing on the reported path. The CSS branch of `browserFind` called the browser **once**, with no polling — so there was no wait to bound, and `--timeout` would have been silently inert on exactly the form the reporter used (`find '[data-testid=...]'`).

It now polls like the semantic branch. That also fixes a second defect in the same lines: a miss returned nil and *still* minted a `@e1` ref.

```
before:  find "#nothing" --timeout 2s   →  @e1 <nil>          exit 0
after:   find "#nothing" --timeout 2s   →  element not found  exit 1, in 2s
```

A real element still resolves immediately.

Full `make test` passes.

Fixes #206