### PR TITLE
Track SPA navigation via history.pushState (#126)

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -3920,6 +3920,7 @@ func (h *Handlers) browserRecordStart(args map[string]interface{}) (*ToolsCallRe
 			"browsingContext.downloadWillBegin",
 			"browsingContext.load",
 			"browsingContext.fragmentNavigated",
+			"browsingContext.historyUpdated",
 		},
 	})
 	h.recordDropBase = h.client.DroppedEvents()

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -195,6 +195,9 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 			"browsingContext.downloadEnd",
 			"browsingContext.load",
 			"browsingContext.fragmentNavigated",
+			// SPA routing via history.pushState/replaceState changes the URL
+			// without a load or fragment event (#126).
+			"browsingContext.historyUpdated",
 		},
 	})
 	if err != nil {
@@ -868,7 +871,7 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 			} `json:"params"`
 		}
 		if json.Unmarshal([]byte(msg), &bidiEvent) == nil {
-			if bidiEvent.Params.URL != "" && (bidiEvent.Method == "browsingContext.load" || bidiEvent.Method == "browsingContext.fragmentNavigated") {
+			if bidiEvent.Params.URL != "" && (bidiEvent.Method == "browsingContext.load" || bidiEvent.Method == "browsingContext.fragmentNavigated" || bidiEvent.Method == "browsingContext.historyUpdated") {
 				session.mu.Lock()
 				session.lastURL = bidiEvent.Params.URL
 				session.mu.Unlock()

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -295,7 +295,8 @@ export class Page {
             cb(url);
           }
         }
-      } else if (event.method === 'browsingContext.fragmentNavigated') {
+      } else if (event.method === 'browsingContext.fragmentNavigated'
+                 || event.method === 'browsingContext.historyUpdated') {
         const url = params.url as string | undefined;
         if (url) {
           for (const cb of this.navigationCallbacks) {

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -924,7 +924,7 @@ class Page:
             if url:
                 for cb in self._navigation_callbacks:
                     cb(url)
-        elif method == "browsingContext.fragmentNavigated":
+        elif method in ("browsingContext.fragmentNavigated", "browsingContext.historyUpdated"):
             url = params.get("url", "")
             if url:
                 for cb in self._navigation_callbacks:

--- a/tests/js/async/navigation.test.js
+++ b/tests/js/async/navigation.test.js
@@ -120,3 +120,19 @@ describe('JS Navigation', () => {
     assert.doesNotMatch(message, /^timeout:/i, `validation errors must not be tagged as timeouts: ${message}`);
   });
 });
+
+describe('SPA history navigation', () => {
+  test('url() and capture.navigation() see history.pushState (#126)', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    // Client-side routing changes the URL without a load or fragment event.
+    await vibe.evaluate(`history.pushState({}, '', '/spa-routed')`);
+    await vibe.wait(400);
+
+    const url = await vibe.url();
+    assert.match(url, /\/spa-routed/, `url() should track pushState, got ${url}`);
+
+    await vibe.close();
+  });
+});


### PR DESCRIPTION
`page.url()` returned the pre-navigation URL and `capture.navigation()` timed out whenever a page routed client-side.

`browsingContext.historyUpdated` — the BiDi event for `pushState`/`replaceState` — was subscribed **nowhere**. `grep -rn historyUpdated clicker/` returned nothing.

## Fix

Subscribe to it, and treat it as a URL change alongside `load` and `fragmentNavigated`, in every place that already handles those:

- the proxy's subscription list and its `lastURL` tracking
- the recorder's subscription
- the JS and Python client event demuxes

Spec shape is `{context, timestamp, url}` — the same as `fragmentNavigated`, so it slots into the existing handling rather than needing its own path.

## Verified

A page that `pushState`s on click:

```
before:           http://127.0.0.1:56194/
after pushState:  http://127.0.0.1:56194/routed     (was: unchanged)
```

The reporter's diagnosis was correct and complete — worth saying, since several issues this week turned out to have the wrong cause in the title.

Full `make test` passes.

## Overlap

Community PR #229 diagnosed the same issue and reached the same fix. This one landed first, so #229 has been closed as redundant.

Fixes #126
