### PR TITLE
Say why session creation failed (#107)

### DIFF
--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -328,14 +328,18 @@ func createSession(baseURL, chromePath string, headless, verbose bool) (string, 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", "", "", fmt.Errorf("failed to create session: HTTP %d", resp.StatusCode)
-	}
-
 	// Read response body for logging and parsing
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to read session response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		// The body carries the real reason — a version mismatch, a bad binary
+		// path, a sandbox failure. Returning only the status code (#107) left
+		// users with "HTTP 500" and nothing to act on.
+		return "", "", "", fmt.Errorf("failed to create session: HTTP %d: %s",
+			resp.StatusCode, driverErrorMessage(respBody))
 	}
 
 	if verbose {
@@ -498,4 +502,31 @@ func CleanupOrphanedChromeTempDirs(minAge time.Duration) {
 	if count > 0 {
 		log.Debug("cleaned up orphaned Chrome temp dirs", "count", count, "minAge", minAge)
 	}
+}
+
+// driverErrorMessage pulls the human-readable part out of a WebDriver error
+// response, falling back to the raw body when it is not the expected shape.
+func driverErrorMessage(body []byte) string {
+	var e struct {
+		Value struct {
+			Error   string `json:"error"`
+			Message string `json:"message"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(body, &e); err == nil {
+		switch {
+		case e.Value.Message != "":
+			return strings.TrimSpace(e.Value.Message)
+		case e.Value.Error != "":
+			return e.Value.Error
+		}
+	}
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return "(empty response body)"
+	}
+	if len(trimmed) > 500 {
+		return trimmed[:500] + "…"
+	}
+	return trimmed
 }

--- a/clicker/internal/browser/launcher_test.go
+++ b/clicker/internal/browser/launcher_test.go
@@ -1,0 +1,53 @@
+package browser
+
+import "testing"
+
+// A session-creation failure used to surface as bare "HTTP 500", discarding the
+// body that says why (#107).
+func TestDriverErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "webdriver error shape",
+			body: `{"value":{"error":"session not created","message":"session not created: This version of ChromeDriver only supports Chrome version 146","stacktrace":"..."}}`,
+			want: "session not created: This version of ChromeDriver only supports Chrome version 146",
+		},
+		{
+			name: "error without message",
+			body: `{"value":{"error":"unknown error"}}`,
+			want: "unknown error",
+		},
+		{
+			name: "not the expected shape falls back to the raw body",
+			body: "upstream proxy exploded",
+			want: "upstream proxy exploded",
+		},
+		{
+			name: "empty body is stated rather than blank",
+			body: "",
+			want: "(empty response body)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := driverErrorMessage([]byte(tt.body)); got != tt.want {
+				t.Errorf("driverErrorMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDriverErrorMessageTruncatesRunaway(t *testing.T) {
+	body := make([]byte, 4000)
+	for i := range body {
+		body[i] = 'x'
+	}
+	got := driverErrorMessage(body)
+	if len(got) > 520 {
+		t.Errorf("message length %d, want it truncated", len(got))
+	}
+}


### PR DESCRIPTION
A chromedriver session failure surfaced as bare `failed to create session: HTTP 500`.

The status check ran *before* the body was read (`launcher.go:331`) and returned only the code — discarding the one part that says what actually went wrong: a Chrome/driver version mismatch, a bad binary path, a sandbox failure.

```
before:  failed to create session: HTTP 500
after:   failed to create session: HTTP 500: session not created: This version
         of ChromeDriver only supports Chrome version 146
```

Reads the body first and includes it, pulling `value.message` out of the WebDriver error shape and falling back to the raw body when it is something else (a proxy error page, an empty body). Truncated at 500 chars so a runaway body cannot flood the terminal.

Unit tests cover all four shapes without needing to provoke a real driver failure.

Note this makes the *underlying* cause visible rather than fixing any one cause — several reports of "HTTP 500" are likely distinct problems that were indistinguishable from the outside, including the version-pairing bug fixed in #265.

Full `make test` passes.

Fixes #107