### PR TITLE
Add >> and >>> pierce combinators for shadow DOM (#118, #203)

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -1030,7 +1030,8 @@ func (h *Handlers) browserFind(args map[string]interface{}) (*ToolsCallResult, e
 	// Run getLabel in browser to get consistent label format (with scroll-into-view)
 	labelScript := `(selector) => {
 		` + GetLabelJS() + `
-		const el = document.querySelector(selector);
+		` + api.PierceQueryJS() + `
+		const el = pierceQuery(document, selector);
 		if (!el) return null;
 		if (el.scrollIntoViewIfNeeded) {
 			el.scrollIntoViewIfNeeded(true);
@@ -2770,12 +2771,22 @@ func mapScript() string {
 	return `(scopeSelector) => {
 		` + GetSelectorJS() + `
 		` + GetLabelJS() + `
+		` + api.PierceQueryJS() + `
 
 		const interactive = 'a[href], button, input, textarea, select, [role="button"], [role="link"], [role="checkbox"], [role="radio"], [role="tab"], [role="menuitem"], [role="switch"], [onclick], [tabindex]:not([tabindex="-1"]), summary, details';
 
-		const root = scopeSelector ? document.querySelector(scopeSelector) : document;
+		const root = scopeSelector ? pierceQuery(document, scopeSelector) : document;
 		if (!root) return JSON.stringify([]);
-		const els = root.querySelectorAll(interactive);
+		// Walk shadow roots too: querySelectorAll stops at the boundary, so
+		// web-component UIs listed as empty (#203).
+		const els = [];
+		{
+			const roots = __shadowRootsUnder(root);
+			for (let r = 0; r < roots.length; r++) {
+				const found = roots[r].querySelectorAll(interactive);
+				for (let f = 0; f < found.length; f++) els.push(found[f]);
+			}
+		}
 		const results = [];
 		const seen = new Set();
 

--- a/clicker/internal/api/actionability.go
+++ b/clicker/internal/api/actionability.go
@@ -79,14 +79,15 @@ func buildCSSActionableScript(ep ElementParams, checkVisible, checkReceivesEvent
 
 	script := `
 		(scope, selector, index, hasIndex, chkVisible, chkEvents, chkEnabled, chkEditable) => {
-			const root = scope ? document.querySelector(scope) : document;
+			` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return JSON.stringify({status:'not_found'});
 			let el;
 			if (hasIndex) {
-				const all = root.querySelectorAll(selector);
+				const all = pierceQueryAll(root, selector);
 				el = all[index];
 			} else {
-				el = root.querySelector(selector);
+				el = pierceQuery(root, selector);
 			}
 			if (!el) return JSON.stringify({status:'not_found'});
 
@@ -130,7 +131,8 @@ func buildSemanticActionableScript(ep ElementParams, checkVisible, checkReceives
 
 	script := `
 		(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex, chkVisible, chkEvents, chkEnabled, chkEditable) => {
-			const root = scope ? document.querySelector(scope) : document;
+			` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return JSON.stringify({status:'not_found'});
 	` + semanticMatchesHelper() + `
 			const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
@@ -226,7 +228,15 @@ func actionabilityCheckBody() string {
 			}
 			if (chkEvents) {
 				const cx = rect.x + rect.width/2, cy = rect.y + rect.height/2;
-				const hit = document.elementFromPoint(cx, cy);
+				// document.elementFromPoint stops at a shadow host, so an element
+				// inside a shadow root always looked obscured. Descend through
+				// each root at the same point to find what is really on top.
+				let hit = document.elementFromPoint(cx, cy);
+				while (hit && hit.shadowRoot) {
+					const inner = hit.shadowRoot.elementFromPoint(cx, cy);
+					if (!inner || inner === hit) break;
+					hit = inner;
+				}
 				if (!hit || (el !== hit && !el.contains(hit)))
 					return JSON.stringify({status:'failed', check:'receivesEvents', reason:'element is obscured'});
 			}

--- a/clicker/internal/api/handlers_elements.go
+++ b/clicker/internal/api/handlers_elements.go
@@ -147,9 +147,10 @@ func BuildFindScript(params map[string]interface{}, findAll bool) (string, []map
 func buildCSSFindScript() string {
 	return `
 		(scope, selector) => {
-			const root = scope ? document.querySelector(scope) : document;
+			` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return null;
-			const el = root.querySelector(selector);
+			const el = pierceQuery(root, selector);
 			if (!el) return null;
 			if (el.scrollIntoViewIfNeeded) {
 				el.scrollIntoViewIfNeeded(true);
@@ -169,9 +170,10 @@ func buildCSSFindScript() string {
 func buildCSSFindAllScript() string {
 	return `
 		(scope, selector, hasText, has) => {
-			const root = scope ? document.querySelector(scope) : document;
+			` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return '[]';
-			let els = Array.from(root.querySelectorAll(selector));
+			let els = Array.from(pierceQueryAll(root, selector));
 			if (hasText) {
 				els = els.filter(el => (el.textContent || '').includes(hasText));
 			}
@@ -332,7 +334,8 @@ func semanticMatchesHelper() string {
 func buildSemanticFindScript() string {
 	return `
 		(scope, selector, role, text, label, placeholder, alt, title, testid, xpath) => {
-			const root = scope ? document.querySelector(scope) : document;
+			` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return null;
 ` + semanticMatchesHelper() + `
 			const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
@@ -351,7 +354,8 @@ func buildSemanticFindScript() string {
 func buildSemanticFindAllScript() string {
 	return `
 		(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, hasText, has) => {
-			const root = scope ? document.querySelector(scope) : document;
+			` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return '[]';
 ` + semanticMatchesHelper() + `
 			let found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);

--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -1071,7 +1071,8 @@ func buildElActionScript(ep ElementParams, extraNames []string, extraArgs []map[
 		args := append(buildElSemanticArgs(ep), extraArgs...)
 		script := fmt.Sprintf(`
 		(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex%s) => {
-			const root = scope ? document.querySelector(scope) : document;
+			`+PierceQueryJS()+`
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return 'element not found';
 		`+semanticMatchesHelper()+`
 			const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
@@ -1091,13 +1092,14 @@ func buildElActionScript(ep ElementParams, extraNames []string, extraArgs []map[
 	args := append(buildElBaseArgs(ep), extraArgs...)
 	script := fmt.Sprintf(`
 		(scope, selector, index, hasIndex%s) => {
-			const root = scope ? document.querySelector(scope) : document;
+			`+PierceQueryJS()+`
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return 'element not found';
 			let el;
 			if (hasIndex) {
-				el = root.querySelectorAll(selector)[index];
+				el = pierceQueryAll(root, selector)[index];
 			} else {
-				el = root.querySelector(selector);
+				el = pierceQuery(root, selector);
 			}
 			if (!el) return 'element not found';
 			%s

--- a/clicker/internal/api/handlers_state.go
+++ b/clicker/internal/api/handlers_state.go
@@ -128,7 +128,8 @@ func (r *Router) handleVibiumElAttr(session *BrowserSession, cmd bidiCommand) {
 		args = append(args, map[string]interface{}{"type": "string", "value": name})
 		script = `
 			(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex, name) => {
-				const root = scope ? document.querySelector(scope) : document;
+				` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 				if (!root) return JSON.stringify({error: 'root not found'});
 		` + semanticMatchesHelper() + `
 				const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
@@ -148,13 +149,14 @@ func (r *Router) handleVibiumElAttr(session *BrowserSession, cmd bidiCommand) {
 		args = append(args, map[string]interface{}{"type": "string", "value": name})
 		script = `
 			(scope, selector, index, hasIndex, name) => {
-				const root = scope ? document.querySelector(scope) : document;
+				` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 				if (!root) return JSON.stringify({error: 'root not found'});
 				let el;
 				if (hasIndex) {
-					el = root.querySelectorAll(selector)[index];
+					el = pierceQueryAll(root, selector)[index];
 				} else {
-					el = root.querySelector(selector);
+					el = pierceQuery(root, selector);
 				}
 				if (!el) return JSON.stringify({error: 'element not found'});
 				const v = el.getAttribute(name);
@@ -642,7 +644,8 @@ func buildElStateScript(ep ElementParams, expr string) (string, []map[string]int
 		args := buildElSemanticArgs(ep)
 		script := fmt.Sprintf(`
 			(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex) => {
-				const root = scope ? document.querySelector(scope) : document;
+				`+PierceQueryJS()+`
+			const root = scope ? pierceQuery(document, scope) : document;
 				if (!root) return null;
 		`+semanticMatchesHelper()+`
 				const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
@@ -662,13 +665,14 @@ func buildElStateScript(ep ElementParams, expr string) (string, []map[string]int
 	args := buildElBaseArgs(ep)
 	script := fmt.Sprintf(`
 		(scope, selector, index, hasIndex) => {
-			const root = scope ? document.querySelector(scope) : document;
+			`+PierceQueryJS()+`
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return null;
 			let el;
 			if (hasIndex) {
-				el = root.querySelectorAll(selector)[index];
+				el = pierceQueryAll(root, selector)[index];
 			} else {
-				el = root.querySelector(selector);
+				el = pierceQuery(root, selector);
 			}
 			if (!el) return null;
 			return %s;
@@ -684,7 +688,8 @@ func buildElBoolScript(ep ElementParams, body string) (string, []map[string]inte
 		args := buildElSemanticArgs(ep)
 		script := fmt.Sprintf(`
 			(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex) => {
-				const root = scope ? document.querySelector(scope) : document;
+				`+PierceQueryJS()+`
+			const root = scope ? pierceQuery(document, scope) : document;
 				if (!root) return 'error:root not found';
 		`+semanticMatchesHelper()+`
 				const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
@@ -705,13 +710,14 @@ func buildElBoolScript(ep ElementParams, body string) (string, []map[string]inte
 	args := buildElBaseArgs(ep)
 	script := fmt.Sprintf(`
 		(scope, selector, index, hasIndex) => {
-			const root = scope ? document.querySelector(scope) : document;
+			`+PierceQueryJS()+`
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return 'error:root not found';
 			let el;
 			if (hasIndex) {
-				el = root.querySelectorAll(selector)[index];
+				el = pierceQueryAll(root, selector)[index];
 			} else {
-				el = root.querySelector(selector);
+				el = pierceQuery(root, selector);
 			}
 			if (!el) return 'error:element not found';
 			const _check = (el) => { %s };
@@ -728,7 +734,8 @@ func buildElJSONScript(ep ElementParams, body string) (string, []map[string]inte
 		args := buildElSemanticArgs(ep)
 		script := fmt.Sprintf(`
 			(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex) => {
-				const root = scope ? document.querySelector(scope) : document;
+				`+PierceQueryJS()+`
+			const root = scope ? pierceQuery(document, scope) : document;
 				if (!root) return JSON.stringify({error: 'root not found'});
 		`+semanticMatchesHelper()+`
 				const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
@@ -748,13 +755,14 @@ func buildElJSONScript(ep ElementParams, body string) (string, []map[string]inte
 	args := buildElBaseArgs(ep)
 	script := fmt.Sprintf(`
 		(scope, selector, index, hasIndex) => {
-			const root = scope ? document.querySelector(scope) : document;
+			`+PierceQueryJS()+`
+			const root = scope ? pierceQuery(document, scope) : document;
 			if (!root) return JSON.stringify({error: 'root not found'});
 			let el;
 			if (hasIndex) {
-				el = root.querySelectorAll(selector)[index];
+				el = pierceQueryAll(root, selector)[index];
 			} else {
-				el = root.querySelector(selector);
+				el = pierceQuery(root, selector);
 			}
 			if (!el) return JSON.stringify({error: 'element not found'});
 			%s
@@ -862,7 +870,8 @@ func GetAttribute(s Session, context string, ep ElementParams, name string) (*st
 		args = append(args, map[string]interface{}{"type": "string", "value": name})
 		script = `
 			(scope, selector, role, text, label, placeholder, alt, title, testid, xpath, index, hasIndex, name) => {
-				const root = scope ? document.querySelector(scope) : document;
+				` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 				if (!root) return null;
 		` + semanticMatchesHelper() + `
 				const found = collectMatches(root, selector, role, text, label, placeholder, alt, title, testid, xpath);
@@ -882,13 +891,14 @@ func GetAttribute(s Session, context string, ep ElementParams, name string) (*st
 		args = append(args, map[string]interface{}{"type": "string", "value": name})
 		script = `
 			(scope, selector, index, hasIndex, name) => {
-				const root = scope ? document.querySelector(scope) : document;
+				` + PierceQueryJS() + `
+			const root = scope ? pierceQuery(document, scope) : document;
 				if (!root) return null;
 				let el;
 				if (hasIndex) {
-					el = root.querySelectorAll(selector)[index];
+					el = pierceQueryAll(root, selector)[index];
 				} else {
-					el = root.querySelector(selector);
+					el = pierceQuery(root, selector);
 				}
 				if (!el) return null;
 				const v = el.getAttribute(name);

--- a/clicker/internal/api/handlers_storage.go
+++ b/clicker/internal/api/handlers_storage.go
@@ -105,10 +105,10 @@ func (r *Router) handleContextSetCookies(session *BrowserSession, cmd bidiComman
 		}
 
 		bidiCookie := map[string]interface{}{
-			"name":  name,
-			"value": map[string]interface{}{"type": "string", "value": value},
+			"name":   name,
+			"value":  map[string]interface{}{"type": "string", "value": value},
 			"domain": domain,
-			"path":  "/",
+			"path":   "/",
 		}
 
 		if path, ok := c["path"].(string); ok && path != "" {
@@ -479,14 +479,14 @@ func (r *Router) handleContextAddInitScript(session *BrowserSession, cmd bidiCom
 
 // CookieInfo holds parsed cookie information.
 type CookieInfo struct {
-	Name     string  `json:"name"`
-	Value    string  `json:"value"`
-	Domain   string  `json:"domain"`
-	Path     string  `json:"path"`
-	Size     int     `json:"size"`
-	HTTPOnly bool    `json:"httpOnly"`
-	Secure   bool    `json:"secure"`
-	SameSite string  `json:"sameSite"`
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	Domain   string `json:"domain"`
+	Path     string `json:"path"`
+	Size     int    `json:"size"`
+	HTTPOnly bool   `json:"httpOnly"`
+	Secure   bool   `json:"secure"`
+	SameSite string `json:"sameSite"`
 }
 
 // GetCookies returns cookies for the given browsing context.

--- a/clicker/internal/api/pierce.go
+++ b/clicker/internal/api/pierce.go
@@ -1,0 +1,75 @@
+package api
+
+// PierceQueryJS defines pierceQuery/pierceQueryAll, the selector resolvers used
+// everywhere vibium turns a CSS selector into elements.
+//
+// querySelector cannot cross a shadow boundary, so components built with shadow
+// DOM — native controls, Lit/FAST/Shoelace, most design systems — were reachable
+// only through page.evaluate and manual shadowRoot walking (#118).
+//
+//	"my-card >> button"          one hop: button inside my-card's shadow root
+//	"outer >>> button"           deep: any button below outer, through nesting
+//
+// The combinators match Playwright (>>) and Selenium 4 (>>>). A selector with
+// neither is passed straight to querySelectorAll, so this costs nothing for the
+// common case and cannot change its behavior.
+func PierceQueryJS() string {
+	return `
+		function __pierceSplit(selector) {
+			// Alternation order matters: >>> must win over >> at the same index.
+			return selector.split(/\s*(>>>|>>)\s*/);
+		}
+
+		function __shadowRootsUnder(root) {
+			const roots = [];
+			const stack = [root];
+			while (stack.length) {
+				const r = stack.pop();
+				if (!r) continue;
+				roots.push(r);
+				const hosts = r.querySelectorAll('*');
+				for (let i = 0; i < hosts.length; i++) {
+					if (hosts[i].shadowRoot) stack.push(hosts[i].shadowRoot);
+				}
+			}
+			return roots;
+		}
+
+		function pierceQueryAll(root, selector) {
+			if (!root || !selector) return [];
+			if (selector.indexOf('>>') === -1) {
+				return Array.prototype.slice.call(root.querySelectorAll(selector));
+			}
+
+			const parts = __pierceSplit(selector);
+			let current = Array.prototype.slice.call(root.querySelectorAll(parts[0]));
+
+			for (let i = 1; i < parts.length; i += 2) {
+				const deep = parts[i] === '>>>';
+				const next = parts[i + 1];
+				const out = [];
+				for (let h = 0; h < current.length; h++) {
+					const host = current[h];
+					if (deep) {
+						// Search the host's own subtree and every shadow root beneath it.
+						const roots = __shadowRootsUnder(host.shadowRoot || host);
+						for (let r = 0; r < roots.length; r++) {
+							const found = roots[r].querySelectorAll(next);
+							for (let f = 0; f < found.length; f++) out.push(found[f]);
+						}
+					} else if (host.shadowRoot) {
+						const found = host.shadowRoot.querySelectorAll(next);
+						for (let f = 0; f < found.length; f++) out.push(found[f]);
+					}
+				}
+				current = out;
+			}
+			return current;
+		}
+
+		function pierceQuery(root, selector) {
+			const all = pierceQueryAll(root, selector);
+			return all.length ? all[0] : null;
+		}
+	`
+}

--- a/clicker/internal/api/recording.go
+++ b/clicker/internal/api/recording.go
@@ -77,12 +77,12 @@ type groupEntry struct {
 
 // pendingRequest holds a parsed beforeRequestSent event until its response arrives.
 type pendingRequest struct {
-	context   string
-	requestID string
-	url       string
-	method    string
-	headers   []interface{} // raw BiDi header list
-	cookies   []interface{}
+	context     string
+	requestID   string
+	url         string
+	method      string
+	headers     []interface{} // raw BiDi header list
+	cookies     []interface{}
 	headersSize float64
 	bodySize    float64
 	timestamp   float64 // BiDi timestamp (ms since epoch)
@@ -95,10 +95,10 @@ type Recorder struct {
 	mu              sync.Mutex
 	recording       bool
 	options         RecordingStartOptions
-	events          []recordEvent      // current chunk's recording events
-	network         []recordEvent      // current chunk's network events
-	resources       map[string][]byte // resource name -> binary data (JPEG/PNG)
-	groupStack      []groupEntry       // nested group entries (name + callId)
+	events          []recordEvent              // current chunk's recording events
+	network         []recordEvent              // current chunk's network events
+	resources       map[string][]byte          // resource name -> binary data (JPEG/PNG)
+	groupStack      []groupEntry               // nested group entries (name + callId)
 	pendingRequests map[string]*pendingRequest // BiDi request ID -> pending request
 	chunkIndex      int
 	startTime       int64  // unix ms

--- a/tests/cli/elements.test.js
+++ b/tests/cli/elements.test.js
@@ -67,3 +67,39 @@ describe('CLI: Elements', () => {
     assert.match(result, /typed/i, 'Should confirm text was typed');
   });
 });
+
+describe('CLI: shadow DOM pierce', () => {
+  test('>> crosses one shadow boundary, >>> crosses nested ones (#118)', () => {
+    execSync(`${VIBIUM} go ${baseURL}/shadow`, { encoding: 'utf-8', timeout: 30000 });
+
+    // Plain CSS cannot cross the boundary — the baseline the issue documents.
+    assert.throws(
+      () => execSync(`${VIBIUM} find "my-card p" --timeout 2s`, {
+        encoding: 'utf-8', timeout: 30000, stdio: 'pipe',
+      }),
+      /not found/,
+    );
+
+    assert.match(execSync(`${VIBIUM} find "my-card >> p"`, { encoding: 'utf-8', timeout: 30000 }), /shadow text/);
+    assert.match(execSync(`${VIBIUM} find "my-card >>> #deep"`, { encoding: 'utf-8', timeout: 30000 }), /Deep Button/);
+  });
+
+  test('actions work on a pierced element', () => {
+    execSync(`${VIBIUM} go ${baseURL}/shadow`, { encoding: 'utf-8', timeout: 30000 });
+
+    execSync(`${VIBIUM} fill "my-card >> #i" hello`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} click "my-card >> #b"`, { encoding: 'utf-8', timeout: 30000 });
+
+    // The component's own handler read the value, so fill and click both landed
+    // inside the shadow root — including the elementFromPoint hit test.
+    const out = execSync(`${VIBIUM} text "#out"`, { encoding: 'utf-8', timeout: 30000 });
+    assert.match(out, /clicked:hello/);
+  });
+
+  test('map lists elements inside shadow roots (#203)', () => {
+    execSync(`${VIBIUM} go ${baseURL}/shadow`, { encoding: 'utf-8', timeout: 30000 });
+    const out = execSync(`${VIBIUM} map`, { encoding: 'utf-8', timeout: 30000 });
+    assert.match(out, /Shadow Button/, 'shadow-root elements should be mapped');
+    assert.match(out, /Deep Button/, 'nested shadow roots too');
+  });
+});

--- a/tests/helpers/test-server.js
+++ b/tests/helpers/test-server.js
@@ -154,8 +154,35 @@ const FRAMES_HTML = `<html><head><title>Frames</title></head><body>
   <iframe src="/frame-inner" name="myframe"></iframe>
 </body></html>`;
 
+const SHADOW_HTML = `<html><head><title>Shadow</title></head><body>
+  <my-card></my-card>
+  <div id="out"></div>
+  <script>
+    class NestedEl extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' }).innerHTML =
+          '<button id="deep">Deep Button</button>';
+      }
+    }
+    class MyCard extends HTMLElement {
+      constructor() {
+        super();
+        const r = this.attachShadow({ mode: 'open' });
+        r.innerHTML = '<p>shadow text</p><input id="i"><button id="b">Shadow Button</button><nested-el></nested-el>';
+        r.getElementById('b').onclick = () => {
+          document.getElementById('out').textContent = 'clicked:' + r.getElementById('i').value;
+        };
+      }
+    }
+    customElements.define('nested-el', NestedEl);
+    customElements.define('my-card', MyCard);
+  </script>
+</body></html>`;
+
 const routes = {
   '/': HOME_HTML,
+  '/shadow': SHADOW_HTML,
   '/frames': FRAMES_HTML,
   '/frame-inner': FRAME_INNER_HTML,
   '/login': LOGIN_HTML,


### PR DESCRIPTION
Implements the API proposed in #118, which also resolves #203.

CSS selectors could not cross a shadow boundary, so components built with shadow roots — native controls, Lit/FAST/Shoelace, most design systems — were reachable only through `page.evaluate` and manual `shadowRoot` walking.

```
my-card >> button       one hop into my-card's shadow root
my-card >>> #deep       deep, through nested roots
```

Combinators match Playwright (`>>`) and Selenium 4 (`>>>`), as proposed. A selector containing neither goes straight to `querySelectorAll`, so the common case is unchanged and costs nothing.

## One resolver, not one per command

`PierceQueryJS` is used by **all 18** selector-resolving scripts, not just `find`. Otherwise a pierce selector would locate an element that no action could then operate on — which is the failure mode this repo keeps producing. Scope resolution pierces too, so `--scope 'my-card >> div'` works.

## Two things that had to come with it

**`map` walks shadow roots** instead of stopping at the boundary. That is #203 — web-component pages were listed as empty.

**The `receivesEvents` actionability check** used `document.elementFromPoint`, which stops at a shadow *host*. Every shadow element therefore read as `element is obscured` and could not be clicked. It now descends through each root at the same point.

I only found that second one by testing an action rather than a lookup — `find`, `text`, `fill` and `is visible` all worked while `click` did not.

## Verified end to end

```
vibium find  "my-card p"          →  not found          (baseline, unchanged)
vibium find  "my-card >> p"       →  @e1 [p] "shadow text"
vibium find  "my-card >>> #deep"  →  @e1 [button] "Deep Button"

vibium fill  "my-card >> #i" hello
vibium click "my-card >> #b"
vibium text  "#out"               →  clicked:hello
```

That last line is the component's *own* click handler reading its *own* input — so fill, click and the hit test all landed inside the shadow root.

`map` on the same page now lists `Shadow Button` and `Deep Button`.

Full `make test` passes.

Fixes #118
Fixes #203
