### PR TITLE
Document the pierce combinators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,9 @@ screenshots/
 *-trace.zip
 saucedemo-record/
 
-# External reference checkouts
-reference/
+# External reference checkouts (root only — an unanchored pattern also
+# swallows docs/reference/, so new docs there could never be added)
+/reference/
 
 # Claude Code skill install state (local-only; no companion manifest)
 skills-lock.json

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -1744,7 +1744,8 @@ func (h *Handlers) browserFindAll(args map[string]interface{}) (*ToolsCallResult
 	findAllScript := `(selector, limit) => {
 		` + GetSelectorJS() + `
 		` + GetLabelJS() + `
-		const els = document.querySelectorAll(selector);
+		` + api.PierceQueryJS() + `
+		const els = pierceQueryAll(document, selector);
 		const results = [];
 		const n = Math.min(els.length, limit);
 		for (let i = 0; i < n; i++) {

--- a/clicker/internal/api/pierce.go
+++ b/clicker/internal/api/pierce.go
@@ -22,7 +22,10 @@ func PierceQueryJS() string {
 
 		function __shadowRootsUnder(root) {
 			const roots = [];
+			// A host passed in directly owns a shadow root that is not reachable
+			// by querying its light-DOM children, so seed with it explicitly.
 			const stack = [root];
+			if (root.shadowRoot) stack.push(root.shadowRoot);
 			while (stack.length) {
 				const r = stack.pop();
 				if (!r) continue;

--- a/docs/explanation/actionability.md
+++ b/docs/explanation/actionability.md
@@ -16,6 +16,21 @@ Before performing an action, Vibium verifies a subset of these conditions:
 | **Enabled** | Element isn't `disabled`, `aria-disabled="true"`, or inside a disabled `<fieldset>` | Disabled controls don't respond to input |
 | **Editable** | Element accepts text input (text-type `<input>`, `<textarea>`, or `contentEditable`), and isn't `readOnly` or `aria-readonly` | Only checked for fill actions |
 
+### ReceivesEvents and shadow DOM
+
+`document.elementFromPoint()` returns the shadow **host**, not what is rendered
+inside it. Taken literally that makes every element in a shadow root look
+covered by its own component, so nothing inside a web component could be
+clicked.
+
+The check therefore descends: after the first hit, it calls
+`elementFromPoint()` on that element's shadow root at the same coordinates, and
+repeats until the answer stops changing. What comes back is the element actually
+on top, wherever it lives.
+
+This only affects the hit test. Everything else about the check is unchanged —
+an element genuinely behind an overlay still fails, shadow root or not.
+
 ## Which Actions Run Which Checks
 
 Different actions require different check sets. These are defined as Go slices in `actionability.go`:

--- a/docs/how-to-guides/test-web-components.md
+++ b/docs/how-to-guides/test-web-components.md
@@ -1,0 +1,108 @@
+# Test a web component
+
+Web components hide their internals in a shadow root. `document.querySelector` stops at that boundary, so a plain CSS selector cannot see inside one.
+
+```html
+<my-card></my-card>
+<!-- shadow root: <p>shadow text</p><button id="b">Save</button> -->
+```
+
+```bash
+vibium find "my-card p"
+# Error: element not found: my-card p
+```
+
+Use a pierce combinator instead. Full syntax in the [selector reference](../reference/selectors.md).
+
+---
+
+## Reach inside a component
+
+`>>` crosses one shadow boundary:
+
+```bash
+vibium find "my-card >> p"
+# → @e1 [p] "shadow text"
+```
+
+```js
+const p = await vibe.find('my-card >> p');
+```
+
+Everything works on the result, not just `find`:
+
+```bash
+vibium fill  "my-card >> input" "hello"
+vibium click "my-card >> button"
+vibium text  "my-card >> p"
+vibium is visible "my-card >> button"
+```
+
+## Reach through nested components
+
+Component libraries nest hosts inside hosts. `>>>` searches any depth below the host, so you do not have to name every level:
+
+```bash
+# <my-card> contains <nested-el>, which has its own shadow root
+vibium find "my-card >>> #deep"
+```
+
+Chain them when you want to be explicit about the path:
+
+```bash
+vibium find "app-shell >> side-nav >> button"
+```
+
+Mix them when only part of the path is known — `outer >>> mid >> button` searches deeply for `mid`, then takes exactly one hop into it.
+
+## See what a component exposes
+
+`vibium map` traverses shadow roots on its own — no combinator needed. It is the fastest way to find out what a component actually renders:
+
+```bash
+vibium go https://example.com/component-page
+vibium map
+# @e1 [input]
+# @e2 [button] "Save"
+# @e3 [button] "Deep Button"
+```
+
+Scope it to one component with `--selector`, which accepts combinators too:
+
+```bash
+vibium map --selector "my-card >> .content"
+```
+
+## Don't know the structure?
+
+Ask the page directly, then write the selector:
+
+```bash
+vibium eval "document.querySelector('my-card').shadowRoot.innerHTML"
+```
+
+---
+
+## When it doesn't work
+
+**`attachShadow({ mode: 'closed' })`** — closed roots are unreachable by design. Nothing in the browser can query them, vibium included. Test through the component's public API (attributes, properties, events) instead.
+
+**The element is there but the click fails** — check `vibium is visible "my-card >> button"` first. If the component renders behind an overlay, that is a real obscured element, not a shadow problem.
+
+**A selector with `>` stopped working** — `>` (CSS child) and `>>` (pierce) are different. `div > p` is still an ordinary child selector; only `>>` and `>>>` hop boundaries.
+
+**Slotted content** — elements passed into a component with `<slot>` stay in the light DOM. Select them normally, without a combinator:
+
+```html
+<my-card><span>slotted</span></my-card>
+```
+```bash
+vibium find "my-card span"       # works — not in the shadow root
+```
+
+---
+
+## Related
+
+- [Selector reference](../reference/selectors.md) — full syntax
+- [Actionability](../explanation/actionability.md) — what is checked before a click

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -4,6 +4,8 @@ Command reference for every Vibium surface: wire protocol, CLI, MCP tools, JS cl
 
 **Legend:** Filled cell = implemented. `⬜` = planned, not yet done. `—` = not applicable for this surface.
 
+For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, and semantic locators — see [Selectors](selectors.md).
+
 ---
 
 ## Browser

--- a/docs/reference/selectors.md
+++ b/docs/reference/selectors.md
@@ -1,0 +1,123 @@
+# Selectors
+
+How vibium turns a selector into an element. Three kinds: CSS, pierce combinators for shadow DOM, and semantic locators.
+
+For which commands accept a selector, see [API Reference](api.md).
+
+---
+
+## CSS
+
+Any CSS selector the browser accepts.
+
+```bash
+vibium find "button.primary"
+vibium find "#login input[type=password]"
+vibium click "nav a:nth-child(2)"
+```
+
+```js
+await vibe.find('button.primary');
+```
+
+CSS selectors do not cross shadow boundaries. Use a pierce combinator for that.
+
+---
+
+## Pierce combinators
+
+Shadow roots are invisible to `querySelector`, so a component's internals need an explicit hop.
+
+| Combinator | Meaning |
+|---|---|
+| `>>` | Cross **one** shadow boundary — the host's own shadow root |
+| `>>>` | Cross **any depth** of nested shadow roots below the host |
+
+```bash
+# <my-card> has a shadow root containing <p>shadow text</p>
+vibium find "my-card >> p"
+
+# <my-card> contains <nested-el>, which has its own shadow root
+vibium find "my-card >>> #deep"
+```
+
+```js
+const p   = await vibe.find('my-card >> p');
+const btn = await vibe.find('outer-host >>> button');
+const all = await vibe.findAll('my-card >> li');
+```
+
+The syntax matches Playwright (`>>`) and Selenium 4 (`>>>`).
+
+### Chaining
+
+Each combinator hops from the elements matched so far, so they can be chained:
+
+```
+app-shell >> side-nav >> button
+```
+
+Combinators may be mixed — `outer >>> mid >> button` searches deeply for `mid`, then takes exactly one hop into it.
+
+### Where they work
+
+Anywhere a selector is accepted — `find`, `findAll`, `click`, `fill`, `text`, `is`, and `map --selector`.
+
+```bash
+vibium fill "my-form >> #email" "a@b.com"
+vibium click "my-form >> button"
+vibium text "my-card >> p"
+vibium map --selector "my-card >> .content"
+```
+
+### Notes
+
+- A selector with no `>>` is passed straight to `querySelectorAll`, so ordinary CSS is unaffected.
+- Only **open** shadow roots are reachable. `attachShadow({ mode: 'closed' })` hides its contents from any script, vibium included.
+- Whitespace is optional: `my-card>>p` and `my-card >> p` are the same.
+- `>` (CSS child) and `>>` (pierce) are distinct — `div > p` stays a normal CSS child selector.
+- `vibium map` traverses shadow roots automatically; you do not need a combinator to see component internals in its output.
+
+---
+
+## Semantic locators
+
+Find by what an element *is* rather than where it sits. Available as `find` subcommands on the CLI and as an options object in the clients.
+
+| Locator | Matches |
+|---|---|
+| `role` | ARIA role, explicit or implicit (`<button>` → `button`) |
+| `text` | Visible text content, substring match |
+| `label` | Accessible name — `aria-label`, `aria-labelledby`, `<label for>`, or an input's `value` for submit/reset/button |
+| `placeholder` | `placeholder` attribute |
+| `alt` | `alt` attribute |
+| `title` | `title` attribute |
+| `testid` | `data-testid` attribute |
+| `xpath` | XPath expression |
+
+```bash
+vibium find role button
+vibium find role button --name "Log in"
+vibium find text "Sign In"
+vibium find testid "submit-btn"
+```
+
+```js
+await vibe.find({ role: 'button', label: 'Log in' });
+await vibe.find({ testid: 'submit-btn' });
+```
+
+Locators combine — `{ role: 'button', text: 'Save' }` requires both. When several elements match, the one with the shortest text wins, so an exact match beats a container that happens to include it.
+
+---
+
+## Scope
+
+`--scope` (CLI) and `scope` (clients) restrict a search to a subtree. It accepts pierce combinators too.
+
+```bash
+vibium find "a" --scope "#sidebar"
+vibium map --scope "my-card >> .content"
+```
+
+Element objects scope automatically — `element.find(...)` searches within that element.


### PR DESCRIPTION
Docs for the pierce combinators from #118, plus three things writing them turned up.

## What went where

**`docs/reference/selectors.md`** (new) — selector syntax had no reference home at all. `api.md` is a command table and never says what goes *in* `<sel>`. Covers CSS, pierce combinators, and the semantic locators, with a pointer added from `api.md`.

**`docs/how-to-guides/test-web-components.md`** (new) — the task version: reach inside a component, reach through nested ones, discover what one exposes, and what to do when it doesn't work (closed roots, slotted content, `>` vs `>>`).

**`docs/explanation/actionability.md`** — a short section on why the hit test descends through shadow roots. Surprising, and only visible on `click`.

No tutorial: tutorials here are getting-started journeys, and this is a feature you look up rather than learn end to end.

## Two bugs found by running every example

I verified each snippet against a live browser rather than writing from memory, which caught:

- **`find --all` did not pierce at all.** `browserFindAll` had its own script that was never wired to the shared resolver, so `find "x >> y" --all` failed with *"not a valid selector"* while the same selector worked without `--all`.
- **`__shadowRootsUnder` missed the root's own shadow root** when the root was itself a host, so `map --selector "my-card >> nested-el"` found nothing.

It also corrected two claims I had written and not checked: `find` has no `--scope` flag, and `map` scopes with `--selector`.

## One repo bug

`.gitignore` had a bare `reference/` for the vendored external checkouts. The pattern is unanchored, so it also matched **`docs/reference/`** — existing files stay tracked, but no new doc could ever be added there, silently. `selectors.md` is the file that hit it. Anchored to `/reference/`; the root vendored dir is still ignored.

Full `make test` passes.
