### PR TITLE
Add a CLI round-trip test for storage export/restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ test-cli: build-go
 	@echo "--- CLI Tests ---"
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon start --headless
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js tests/cli/prompt-blocked.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js tests/cli/prompt-blocked.test.js tests/cli/storage.test.js
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@echo "--- CLI Process Tests (sequential) ---"
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js tests/cli/dead-browser.test.js

--- a/tests/cli/storage.test.js
+++ b/tests/cli/storage.test.js
@@ -1,0 +1,117 @@
+/**
+ * CLI Tests: Storage export/restore
+ * Verifies `vibium storage` / `vibium storage restore` round-trip
+ * localStorage and sessionStorage correctly (#217).
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execSync, spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { VIBIUM } = require('../helpers');
+
+let serverProcess, baseURL, statePath, legacyPath;
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (data) => {
+      resolve(data.toString().trim());
+    });
+  });
+  execSync(`${VIBIUM} go ${baseURL}/`, { encoding: 'utf-8', timeout: 30000 });
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-storage-'));
+  statePath = path.join(dir, 'state.json');
+  legacyPath = path.join(dir, 'legacy.json');
+});
+
+after(() => {
+  for (const p of [statePath, legacyPath]) {
+    if (p && fs.existsSync(p)) fs.unlinkSync(p);
+  }
+  if (serverProcess) serverProcess.kill();
+});
+
+describe('CLI: storage export/restore', () => {
+  test('export writes storage as a nested object, not a double-encoded string', () => {
+    execSync(`${VIBIUM} eval "localStorage.setItem('user', 'user_vibium')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    execSync(`${VIBIUM} eval "sessionStorage.setItem('session_id', 'session_vibium')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+
+    execSync(`${VIBIUM} storage -o ${statePath}`, { encoding: 'utf-8', timeout: 30000 });
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+
+    // The bug: Evaluate returns the JSON.stringify'd page result as a Go string,
+    // so storing it directly wrote a quoted blob that restore could not read.
+    assert.strictEqual(
+      typeof state.storage,
+      'object',
+      '"storage" must be a nested object, not a double-encoded string'
+    );
+    assert.strictEqual(state.storage.localStorage.user, 'user_vibium');
+    assert.strictEqual(state.storage.sessionStorage.session_id, 'session_vibium');
+  });
+
+  test('restore repopulates localStorage and sessionStorage', () => {
+    execSync(`${VIBIUM} eval "localStorage.clear(); sessionStorage.clear();"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+
+    // Confirm storage really is empty, so a passing restore cannot be a false positive.
+    const before = execSync(`${VIBIUM} eval "localStorage.getItem('user')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.match(before, /^(null|)$/, 'localStorage should be empty before restore');
+
+    const result = execSync(`${VIBIUM} storage restore ${statePath}`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /restored/i, 'should confirm storage was restored');
+
+    const user = execSync(`${VIBIUM} eval "localStorage.getItem('user')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    const sessionId = execSync(`${VIBIUM} eval "sessionStorage.getItem('session_id')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+
+    assert.strictEqual(user, 'user_vibium', 'localStorage should be restored');
+    assert.strictEqual(sessionId, 'session_vibium', 'sessionStorage should be restored');
+  });
+
+  test('restore still reads state files written in the old double-encoded shape', () => {
+    // Files saved before the fix hold storage as a JSON string; restore unwraps
+    // one level so they keep working.
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        cookies: [],
+        storage: JSON.stringify({ localStorage: { legacy: 'legacy_value' }, sessionStorage: {} }),
+      })
+    );
+
+    execSync(`${VIBIUM} eval "localStorage.clear()"`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} storage restore ${legacyPath}`, { encoding: 'utf-8', timeout: 30000 });
+
+    const legacy = execSync(`${VIBIUM} eval "localStorage.getItem('legacy')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(legacy, 'legacy_value', 'legacy state file should still restore');
+  });
+});


### PR DESCRIPTION
`vibium storage` / `storage restore` had no coverage on the agent code path, which is how the double-encoding bug in #217 shipped unnoticed.

The storage tests that already exist do not catch it. I confirmed that by reintroducing the bug:

- `tests/js/async/storage.test.js` and `tests/py/test_storage.py` do a full capture/clear/restore round trip, but against `api.Router`, which is a separate implementation. Both pass with the bug present.
- `tests/mcp/server.test.js` does hit the affected code, but only asserts the call does not error. The bug produced valid, error-free JSON, so it passes too.

Three cases, all failing against pre-#217 code and passing after:

1. export writes `storage` as a nested object rather than a double-encoded string
2. restore round trip repopulates localStorage and sessionStorage
3. restore still reads state files written in the old shape

Adapted from a test contributed by @Jhoan0714 in #218.

Full `make test` passes.
