### PR TITLE
Write screenshots where the CLI was told to (#119)

### DIFF
--- a/clicker/cmd/clicker/screenshot.go
+++ b/clicker/cmd/clicker/screenshot.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 )
 
@@ -8,8 +10,14 @@ func newScreenshotCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "screenshot [url]",
 		Short: "Capture a screenshot (optionally navigate to URL first)",
-		Example: `  vibium screenshot -o shot.png
-  # Screenshots the current page
+		Example: `  vibium screenshot
+  # Saves ./screenshot.png in the current directory
+
+  vibium screenshot -o shot.png
+  # Screenshots the current page to ./shot.png
+
+  vibium screenshot -o ~/Pictures/shot.png
+  # Paths are honored as given
 
   vibium screenshot https://example.com -o shot.png
   # Navigates to URL first, then screenshots
@@ -19,6 +27,15 @@ func newScreenshotCmd() *cobra.Command {
 		Args: cobra.RangeArgs(0, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			output, _ := cmd.Flags().GetString("output")
+			// The daemon is a separate long-lived process whose working
+			// directory is not the user's, so resolve against this shell
+			// before the path goes over the socket. Typing a path into a
+			// terminal means "here", not "wherever the daemon started" —
+			// the ~/Pictures/Vibium default exists for MCP, where the
+			// caller cannot see a working directory at all (#119).
+			if abs, err := filepath.Abs(output); err == nil {
+				output = abs
+			}
 			fullPage, _ := cmd.Flags().GetBool("full-page")
 			annotate, _ := cmd.Flags().GetBool("annotate")
 

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -917,18 +917,22 @@ func (h *Handlers) browserScreenshot(args map[string]interface{}) (*ToolsCallRes
 
 	// If filename provided, save to file (only if screenshotDir is configured)
 	if filename, ok := args["filename"].(string); ok && filename != "" {
-		if h.screenshotDir == "" {
-			return nil, fmt.Errorf("screenshot file saving is disabled (use --screenshot-dir to enable)")
+		// An absolute path is an explicit destination and is written as given;
+		// the CLI resolves -o against the user's shell so it always arrives in
+		// that form. A bare name has no directory to honor, so it lands in the
+		// configured screenshot dir — the MCP case, where the caller has no
+		// working directory to reason about (#119).
+		fullPath := filename
+		if !filepath.IsAbs(filename) {
+			if h.screenshotDir == "" {
+				return nil, fmt.Errorf("screenshot file saving is disabled (use --screenshot-dir to enable)")
+			}
+			fullPath = filepath.Join(h.screenshotDir, filepath.Base(filename))
 		}
 
-		// Create directory if it doesn't exist
-		if err := os.MkdirAll(h.screenshotDir, 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
 			return nil, fmt.Errorf("failed to create screenshot directory: %w", err)
 		}
-
-		// Use only the basename to prevent path traversal
-		safeName := filepath.Base(filename)
-		fullPath := filepath.Join(h.screenshotDir, safeName)
 
 		pngData, err := base64.StdEncoding.DecodeString(base64Data)
 		if err != nil {

--- a/docs/how-to-guides/screenshots.md
+++ b/docs/how-to-guides/screenshots.md
@@ -1,0 +1,54 @@
+# Save a screenshot where you want it
+
+`vibium screenshot` writes to your current directory.
+
+```bash
+vibium screenshot
+# Screenshot saved to /Users/you/project/screenshot.png
+```
+
+Name it with `-o`:
+
+```bash
+vibium screenshot -o login.png          # ./login.png
+vibium screenshot -o shots/login.png    # ./shots/login.png, creating shots/
+vibium screenshot -o /tmp/login.png     # exactly there
+vibium screenshot -o ~/Desktop/x.png    # your shell expands ~
+```
+
+Relative paths resolve against the shell you typed them into, not the daemon's. Missing directories are created for you.
+
+---
+
+## Capture options
+
+```bash
+vibium screenshot --full-page -o tall.png   # whole page, not just the viewport
+vibium screenshot --annotate -o labeled.png # number the interactive elements
+vibium screenshot https://example.com -o home.png  # navigate first, then capture
+```
+
+---
+
+## From an AI agent (MCP)
+
+Over MCP there is no working directory the user can see, so screenshots go to a fixed, findable place instead: `~/Pictures/Vibium/` on macOS and Linux, `Pictures\Vibium\` on Windows.
+
+Point it elsewhere when you set up the server:
+
+```bash
+claude mcp add vibium -- npx -y vibium mcp --screenshot-dir ./screenshots
+```
+
+Or return images inline and never touch the disk:
+
+```bash
+claude mcp add vibium -- npx -y vibium mcp --screenshot-dir ""
+```
+
+---
+
+## Related
+
+- [MCP setup](../tutorials/getting-started-mcp.md) — configuring the server
+- [API reference](../reference/api.md) — `page.screenshot()` in the clients

--- a/docs/tutorials/getting-started-mcp.md
+++ b/docs/tutorials/getting-started-mcp.md
@@ -53,7 +53,9 @@ You'll see:
 2. The page load
 3. The AI respond with the screenshot
 
-Screenshots are saved to `~/Pictures/Vibium/` (macOS/Linux) or `Pictures\Vibium\` (Windows).
+Screenshots are saved to `~/Pictures/Vibium/` (macOS/Linux) or `Pictures\Vibium\` (Windows). The AI has no working directory you can see, so they go somewhere you can reliably find them. Change it with `--screenshot-dir` below.
+
+The `vibium` CLI is different: there you *do* have a working directory, so `vibium screenshot` writes to it. See [Screenshots](../how-to-guides/screenshots.md).
 
 ---
 

--- a/tests/cli/navigation.test.js
+++ b/tests/cli/navigation.test.js
@@ -69,6 +69,25 @@ describe('CLI: Navigation', () => {
     }
   });
 
+  test('screenshot honors -o paths instead of redirecting to the screenshot dir (#119)', () => {
+    // The daemon used to reduce -o to its basename and join it with
+    // ~/Pictures/Vibium, so every path the user typed was discarded.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-shot-'));
+    const nested = path.join(dir, 'sub', 'deep.png');
+    try {
+      const result = execSync(`${VIBIUM} screenshot ${baseURL}/example -o ${nested}`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+      });
+      assert.match(result, new RegExp(nested.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+        `should report the path it was given, got: ${result}`);
+      assert.ok(fs.existsSync(nested), 'screenshot should be at the requested path');
+      assert.ok(fs.statSync(nested).size > 1000, 'should be a real PNG');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('eval command executes JavaScript', () => {
     const result = execSync(`${VIBIUM} eval ${baseURL}/example "document.title"`, {
       encoding: 'utf-8',


### PR DESCRIPTION
`vibium screenshot` reduced `-o` to its basename and joined it with the screenshot dir, so any path you typed was discarded:

```
vibium screenshot -o /tmp/abs-shot.png
# before: Screenshot saved to /Users/you/Pictures/Vibium/abs-shot.png
# after:  Screenshot saved to /tmp/abs-shot.png
```

## Why it could not just be fixed in the daemon

The daemon is a separate long-lived process started from some other directory, so it cannot resolve a relative path against the user's shell. The CLI resolves `-o` itself and sends an absolute path; the daemon writes an absolute path as given and creates missing parent directories. Same pattern `storage restore` already uses.

## The default changed too, on purpose

`vibium screenshot` with no `-o` now writes `./screenshot.png` instead of `~/Pictures/Vibium/screenshot.png`.

The old default predates the CLI. It was designed for MCP, where the caller has no working directory the user can see, so a fixed findable location is the only sensible answer. A developer typing into a terminal does have one, and expects it to be used.

**MCP behavior is unchanged.** A bare filename still lands in the screenshot dir, and MCP only ever sends bare filenames, so `~/Pictures/Vibium` remains the agent default and `--screenshot-dir` still works.

## Verified

```
vibium screenshot                  ->  ./screenshot.png
vibium screenshot -o shot.png      ->  ./shot.png
vibium screenshot -o sub/deep.png  ->  ./sub/deep.png   (sub/ created)
vibium screenshot -o /tmp/x.png    ->  /tmp/x.png
```

New regression test in `tests/cli/navigation.test.js` fails against the pre-fix binary and passes after. Full `make test` passes.

## Docs

- `docs/how-to-guides/screenshots.md` (new) covers CLI paths, capture options, and the MCP default.
- `docs/tutorials/getting-started-mcp.md` now says why the MCP default differs from the CLI.

Supersedes #119, which reported this and fixed the daemon half.
