### PR TITLE
Bump the pinned GitHub Actions off the Node 20 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # Every pin lives in the same workflow file, so ungrouped updates arrive
+    # as N PRs that all edit one line each and conflict with each other the
+    # moment one merges. One PR per run instead.
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,20 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Nothing here pushes, so keep the token out of .git/config where
           # build and test steps could read it.
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: clicker/go.mod
           cache-dependency-path: clicker/go.sum
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: npm
@@ -45,7 +45,7 @@ jobs:
             packages/python/vibium_linux_x64/pyproject.toml
 
       - name: Set up Java
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: temurin
@@ -58,7 +58,7 @@ jobs:
 
       # Keyed on installer.go so installer changes fetch a fresh Chrome.
       - name: Cache Chrome for Testing
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/vibium/chrome-for-testing
           key: ${{ runner.os }}-chrome-${{ hashFiles('clicker/internal/browser/installer.go') }}


### PR DESCRIPTION
Applies the five open dependabot bumps as one commit, and groups the ecosystem so this stops arriving as five PRs.

| Action | From | To | Dependabot PR | Its CI |
|---|---|---|---|---|
| checkout | v4.3.1 | v7.0.1 | #244 | pass |
| setup-go | v5.6.0 | v7.0.0 | #235 | fail (see below) |
| setup-node | v4.4.0 | v7.0.0 | #233 | pass |
| setup-java | v4.8.0 | v5.6.0 | #234 | pass |
| cache | v4.3.0 | v6.1.0 | #236 | pass |

## Why one commit

All five edit the same six-line block in `.github/workflows/test.yml`, so merging any one of them invalidates the other four and each needs a rebase and a fresh 6-minute CI run. Applying them together is one run instead of five plus four rebases.

## #235 was a stale base, not a real failure

Its run failed in `test-js-async` on `element.text() returns element text` and `element.type() enters text`, which is unrelated to `setup-go`. That run was 2026-08-01T03:50; the `element.text` fix (#215) landed 2026-08-02T20:53 in #273. It was testing a base that still had the bug.

## Grouping

`.github/dependabot.yml` now groups the `github-actions` ecosystem under a single `actions` group, so the next monthly run opens one PR covering every pin.

Closes #244, #236, #235, #234, #233.
