### PR TITLE
Stop filmstrip captures from stalling on an in-flight navigation (#289)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ test-cli: build-go
 	@echo "--- CLI Tests ---"
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon start --headless
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js tests/cli/prompt-blocked.test.js tests/cli/storage.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/navigation.test.js tests/cli/elements.test.js tests/cli/actionability.test.js tests/cli/page-reading.test.js tests/cli/input-tools.test.js tests/cli/pages.test.js tests/cli/page-context.test.js tests/cli/find-refs.test.js tests/cli/prompt-blocked.test.js tests/cli/storage.test.js tests/cli/recording-latency.test.js
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@echo "--- CLI Process Tests (sequential) ---"
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js tests/cli/dead-browser.test.js

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -42,7 +42,8 @@ type Handlers struct {
 
 	// prompts records which contexts have an open user prompt, so a command
 	// Chrome will not answer fails immediately instead of timing out.
-	prompts *api.PromptTracker
+	prompts     *api.PromptTracker
+	navigations *api.NavigationTracker
 
 	// launchedHeadless is the mode the running browser was actually launched
 	// with, which is not necessarily the daemon's default.
@@ -67,6 +68,7 @@ func (h *Handlers) newSession() *api.AgentSession {
 	s := api.NewAgentSession(h.client)
 	s.Context = h.activeContext
 	s.Prompts = h.prompts
+	s.Navigations = h.navigations
 	s.OnBoxSet = func(box *api.BoxInfo) {
 		h.lastElementBox = box
 	}
@@ -718,9 +720,11 @@ func modeName(headless bool) string {
 // the tracker and the recorder rather than recording replacing prompt tracking.
 func (h *Handlers) startPromptTracking() {
 	tracker := api.NewPromptTracker()
+	navs := api.NewNavigationTracker()
 
 	h.sessionMu.Lock()
 	h.prompts = tracker
+	h.navigations = navs
 	client := h.client
 	h.sessionMu.Unlock()
 
@@ -732,6 +736,10 @@ func (h *Handlers) startPromptTracking() {
 		"events": []string{
 			"browsingContext.userPromptOpened",
 			"browsingContext.userPromptClosed",
+			"browsingContext.navigationStarted",
+			"browsingContext.navigationFailed",
+			"browsingContext.navigationAborted",
+			"browsingContext.load",
 		},
 	})
 	client.SetEventHandler(h.handleBidiEvent)
@@ -741,10 +749,12 @@ func (h *Handlers) startPromptTracking() {
 func (h *Handlers) handleBidiEvent(msg string) {
 	h.sessionMu.Lock()
 	tracker := h.prompts
+	navs := h.navigations
 	recorder := h.recorder
 	h.sessionMu.Unlock()
 
 	tracker.Observe([]byte(msg))
+	navs.Observe([]byte(msg))
 
 	if recorder != nil && recorder.IsRecording() {
 		recorder.RecordBidiEvent(msg)
@@ -3941,6 +3951,9 @@ func (h *Handlers) browserRecordStart(args map[string]interface{}) (*ToolsCallRe
 			"browsingContext.userPromptOpened",
 			"browsingContext.downloadWillBegin",
 			"browsingContext.load",
+			"browsingContext.navigationStarted",
+			"browsingContext.navigationFailed",
+			"browsingContext.navigationAborted",
 			"browsingContext.fragmentNavigated",
 			"browsingContext.historyUpdated",
 		},

--- a/clicker/internal/api/handlers_recording.go
+++ b/clicker/internal/api/handlers_recording.go
@@ -7,7 +7,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/vibium/clicker/internal/log"
 )
+
+// screenshotTimeout bounds both the wait for an in-flight navigation and the
+// capture command itself.
+const screenshotTimeout = 5 * time.Second
 
 // handleRecordingStart handles vibium:recording.start — starts recording.
 // Options: name, screenshots, snapshots, sources, title.
@@ -366,13 +372,30 @@ func CaptureRecordingScreenshot(s Session, recorder *Recorder, actionEnd time.Ti
 		return
 	}
 
+	// captureScreenshot does not answer while the context is navigating, so
+	// issuing one now would burn the whole timeout and return nothing. Wait for
+	// the navigation instead: it usually settles in well under the timeout, and
+	// the frame we then get is the result of the action rather than nothing at
+	// all (#289).
 	opts := recorder.Options()
-	resp, err := s.SendBidiCommandWithTimeout("browsingContext.captureScreenshot", ScreenshotParams(context, opts), 5*time.Second)
+
+	// A navigation triggered by the action we just ran is not reported until
+	// ~10ms after that action's command returns, so there is no way to check
+	// for one before capturing: the capture always wins the race. Instead run
+	// the capture and watch for a navigation starting underneath it. Chrome
+	// will not answer a capture across a navigation, so if one begins we
+	// abandon that attempt, wait for the page to settle, and take a fresh
+	// screenshot. Without this the doomed attempt burns its whole timeout and
+	// yields no frame at all (#289).
+	resp, err := captureWithNavigationRetry(s, context, opts)
 	if err != nil {
+		// Swallowing this is what let a 5s stall go unnoticed for months (#289).
+		log.Debug("recording screenshot failed", "context", context, "error", err)
 		return
 	}
 
 	if bidiErr := checkBidiError(resp); bidiErr != nil {
+		log.Debug("recording screenshot returned an error", "context", context, "error", bidiErr)
 		return
 	}
 
@@ -415,4 +438,50 @@ func (r *Router) queryViewport(session *BrowserSession) map[string]interface{} {
 		return nil
 	}
 	return map[string]interface{}{"width": w, "height": h}
+}
+
+// captureWithNavigationRetry takes a screenshot, restarting the attempt if a
+// navigation begins while it is in flight. See the call site for why this
+// cannot be decided up front.
+func captureWithNavigationRetry(s Session, context string, opts RecordingStartOptions) (json.RawMessage, error) {
+	nav := s.NavTracker()
+	send := func() (json.RawMessage, error) {
+		return s.SendBidiCommandWithTimeout("browsingContext.captureScreenshot",
+			ScreenshotParams(context, opts), screenshotTimeout)
+	}
+
+	if nav == nil {
+		return send()
+	}
+
+	// Already navigating: no point starting an attempt that cannot be answered.
+	if nav.IsNavigating(context) {
+		nav.WaitForSettled(context, screenshotTimeout)
+		return send()
+	}
+
+	started, cancel := nav.NotifyStart(context)
+	defer cancel()
+
+	type result struct {
+		resp json.RawMessage
+		err  error
+	}
+	// Buffered so the abandoned attempt can finish writing and exit.
+	done := make(chan result, 1)
+	go func() {
+		resp, err := send()
+		done <- result{resp, err}
+	}()
+
+	select {
+	case r := <-done:
+		return r.resp, r.err
+	case <-started:
+		// That attempt is now stuck behind the navigation and will time out on
+		// its own. Wait for the page to settle and take the frame that shows
+		// what the action actually did.
+		nav.WaitForSettled(context, screenshotTimeout)
+		return send()
+	}
 }

--- a/clicker/internal/api/navigation.go
+++ b/clicker/internal/api/navigation.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// NavigationTracker records which browsing contexts have a navigation in
+// flight.
+//
+// browsingContext.captureScreenshot does not answer while the target context is
+// navigating: Chrome holds the command until the new document settles, so a
+// capture issued right after a click that submits a form burns its entire
+// timeout and returns nothing (#289). The action still succeeds, so the only
+// visible symptom is that every navigating action costs the timeout.
+//
+// Waiting for the navigation first turns "5s, then no frame" into "as long as
+// the navigation actually takes, then the frame that shows its result" — which
+// is the frame a filmstrip most wants, since it is the outcome of the action.
+type NavigationTracker struct {
+	mu       sync.Mutex
+	inFlight map[string]chan struct{}   // context -> closed when the navigation settles
+	starting map[string][]chan struct{} // context -> waiters woken when one begins
+}
+
+// NewNavigationTracker creates an empty tracker.
+func NewNavigationTracker() *NavigationTracker {
+	return &NavigationTracker{
+		inFlight: make(map[string]chan struct{}),
+		starting: make(map[string][]chan struct{}),
+	}
+}
+
+// Observe updates the tracker from a raw BiDi event. Anything that is not a
+// navigation lifecycle event is ignored, so callers can hand it every event.
+func (t *NavigationTracker) Observe(raw []byte) {
+	if t == nil {
+		return
+	}
+	var evt struct {
+		Method string `json:"method"`
+		Params struct {
+			Context string `json:"context"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(raw, &evt); err != nil {
+		return
+	}
+	if evt.Params.Context == "" {
+		return
+	}
+
+	switch evt.Method {
+	case "browsingContext.navigationStarted":
+		t.mu.Lock()
+		if _, ok := t.inFlight[evt.Params.Context]; !ok {
+			t.inFlight[evt.Params.Context] = make(chan struct{})
+		}
+		for _, w := range t.starting[evt.Params.Context] {
+			close(w)
+		}
+		delete(t.starting, evt.Params.Context)
+		t.mu.Unlock()
+
+	// load is the settle signal; the failure events exist so an abandoned
+	// navigation cannot leave a context marked in-flight forever.
+	case "browsingContext.load",
+		"browsingContext.navigationFailed",
+		"browsingContext.navigationAborted":
+		t.Clear(evt.Params.Context)
+	}
+}
+
+// IsNavigating reports whether a navigation is in flight for a context.
+func (t *NavigationTracker) IsNavigating(context string) bool {
+	if t == nil || context == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, ok := t.inFlight[context]
+	return ok
+}
+
+// WaitForSettled blocks until the context's navigation completes, the timeout
+// elapses, or there was no navigation to begin with. It reports whether the
+// context is settled — false means the timeout won and a command issued now may
+// still block.
+func (t *NavigationTracker) WaitForSettled(context string, timeout time.Duration) bool {
+	if t == nil || context == "" {
+		return true
+	}
+
+	t.mu.Lock()
+	done, ok := t.inFlight[context]
+	t.mu.Unlock()
+	if !ok {
+		return true
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+// Clear marks a context settled and wakes anything waiting on it. Also used
+// when a context goes away, so a destroyed context leaves nothing behind.
+func (t *NavigationTracker) Clear(context string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if done, ok := t.inFlight[context]; ok {
+		delete(t.inFlight, context)
+		close(done)
+	}
+	t.mu.Unlock()
+}
+
+// NotifyStart returns a channel closed when a navigation begins for a context,
+// plus a cancel to deregister. A navigation started by an action is only
+// reported ~10ms after the action's command returns, far too late to check for
+// up front, so a capture has to react to one starting underneath it rather than
+// predict it (#289).
+func (t *NavigationTracker) NotifyStart(context string) (<-chan struct{}, func()) {
+	if t == nil || context == "" {
+		return nil, func() {}
+	}
+	ch := make(chan struct{})
+	t.mu.Lock()
+	t.starting[context] = append(t.starting[context], ch)
+	t.mu.Unlock()
+
+	return ch, func() {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		w := t.starting[context]
+		for i, c := range w {
+			if c == ch {
+				t.starting[context] = append(w[:i], w[i+1:]...)
+				break
+			}
+		}
+		if len(t.starting[context]) == 0 {
+			delete(t.starting, context)
+		}
+	}
+}

--- a/clicker/internal/api/navigation_test.go
+++ b/clicker/internal/api/navigation_test.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+const navStarted = `{"method":"browsingContext.navigationStarted","params":{"context":"ctx-1","url":"http://x/"}}`
+const navLoad = `{"method":"browsingContext.load","params":{"context":"ctx-1","url":"http://x/"}}`
+
+func TestTracksNavigationInFlight(t *testing.T) {
+	tr := NewNavigationTracker()
+
+	if tr.IsNavigating("ctx-1") {
+		t.Fatal("nothing observed yet, should not be navigating")
+	}
+
+	tr.Observe([]byte(navStarted))
+	if !tr.IsNavigating("ctx-1") {
+		t.Fatal("navigationStarted should mark the context in flight")
+	}
+	if tr.IsNavigating("ctx-2") {
+		t.Fatal("other contexts must be unaffected")
+	}
+
+	tr.Observe([]byte(navLoad))
+	if tr.IsNavigating("ctx-1") {
+		t.Fatal("load should settle the context")
+	}
+}
+
+func TestFailedNavigationDoesNotWedgeContext(t *testing.T) {
+	// Without these, an abandoned navigation would leave the context marked in
+	// flight forever and every later capture would wait out its full timeout.
+	for _, ev := range []string{
+		`{"method":"browsingContext.navigationFailed","params":{"context":"ctx-1"}}`,
+		`{"method":"browsingContext.navigationAborted","params":{"context":"ctx-1"}}`,
+	} {
+		tr := NewNavigationTracker()
+		tr.Observe([]byte(navStarted))
+		tr.Observe([]byte(ev))
+		if tr.IsNavigating("ctx-1") {
+			t.Fatalf("%s should settle the context", ev)
+		}
+	}
+}
+
+func TestWaitForSettledReturnsWhenLoadArrives(t *testing.T) {
+	tr := NewNavigationTracker()
+	tr.Observe([]byte(navStarted))
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		tr.Observe([]byte(navLoad))
+	}()
+
+	start := time.Now()
+	if !tr.WaitForSettled("ctx-1", 2*time.Second) {
+		t.Fatal("should report settled, not timed out")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("waited %s, should have woken on load", elapsed)
+	}
+}
+
+func TestWaitForSettledTimesOut(t *testing.T) {
+	tr := NewNavigationTracker()
+	tr.Observe([]byte(navStarted))
+
+	if tr.WaitForSettled("ctx-1", 30*time.Millisecond) {
+		t.Fatal("should report not-settled when the navigation never completes")
+	}
+}
+
+func TestWaitForSettledIsNoOpWhenIdle(t *testing.T) {
+	tr := NewNavigationTracker()
+	start := time.Now()
+	if !tr.WaitForSettled("ctx-1", time.Minute) {
+		t.Fatal("an idle context is already settled")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("blocked %s on an idle context", elapsed)
+	}
+}
+
+func TestNotifyStartFiresOnNavigation(t *testing.T) {
+	// This is the signal a capture races against: the navigation an action
+	// triggers is only reported after that action's command has returned.
+	tr := NewNavigationTracker()
+	started, cancel := tr.NotifyStart("ctx-1")
+	defer cancel()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		tr.Observe([]byte(navStarted))
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("NotifyStart should fire when a navigation begins")
+	}
+}
+
+func TestNotifyStartCancelDeregisters(t *testing.T) {
+	tr := NewNavigationTracker()
+	_, cancel := tr.NotifyStart("ctx-1")
+	cancel()
+
+	tr.Observe([]byte(navStarted))
+
+	tr.mu.Lock()
+	n := len(tr.starting["ctx-1"])
+	tr.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("cancelled waiter should be gone, found %d", n)
+	}
+}
+
+func TestNilTrackerIsSafe(t *testing.T) {
+	// Sessions without a recorder carry no tracker.
+	var tr *NavigationTracker
+	tr.Observe([]byte(navStarted))
+	if tr.IsNavigating("ctx-1") {
+		t.Fatal("nil tracker never navigates")
+	}
+	if !tr.WaitForSettled("ctx-1", time.Second) {
+		t.Fatal("nil tracker is always settled")
+	}
+	ch, cancel := tr.NotifyStart("ctx-1")
+	if ch != nil {
+		t.Fatal("nil tracker returns no channel")
+	}
+	cancel()
+	tr.Clear("ctx-1")
+}

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -46,7 +46,8 @@ type BrowserSession struct {
 
 	// prompts records which contexts have an open user prompt, so a command
 	// Chrome will not answer fails immediately instead of timing out.
-	prompts *PromptTracker
+	prompts     *PromptTracker
+	navigations *NavigationTracker
 
 	// Recording support
 	recorder           *Recorder
@@ -172,6 +173,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		internalCmds:   make(map[int]chan json.RawMessage),
 		nextInternalID: 1000000, // Start at high number to avoid collision with client IDs
 		prompts:        NewPromptTracker(),
+		navigations:    NewNavigationTracker(),
 	}
 
 	r.sessions.Store(client.ID(), session)
@@ -194,6 +196,11 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 			"browsingContext.downloadWillBegin",
 			"browsingContext.downloadEnd",
 			"browsingContext.load",
+			// navigationStarted/Failed/Aborted bracket an in-flight navigation, so
+			// a filmstrip capture can wait it out instead of timing out (#289).
+			"browsingContext.navigationStarted",
+			"browsingContext.navigationFailed",
+			"browsingContext.navigationAborted",
 			"browsingContext.fragmentNavigated",
 			// SPA routing via history.pushState/replaceState changes the URL
 			// without a load or fragment event (#126).
@@ -880,6 +887,7 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 
 		// Track user prompts so prompt-sensitive commands can fail fast.
 		session.prompts.Observe([]byte(msg))
+		session.navigations.Observe([]byte(msg))
 
 		// Record event for recording (non-blocking)
 		session.mu.Lock()

--- a/clicker/internal/api/session.go
+++ b/clicker/internal/api/session.go
@@ -28,6 +28,10 @@ type Session interface {
 
 	// SetLastElementBox stores the bounding box of the last resolved element for recording.
 	SetLastElementBox(box *BoxInfo)
+
+	// NavTracker returns the session's navigation tracker, or nil if it has
+	// none. Used to avoid issuing a screenshot into an in-flight navigation.
+	NavTracker() *NavigationTracker
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +84,8 @@ type AgentSession struct {
 	Context  string             // optional explicit context override (active tab)
 	OnBoxSet func(box *BoxInfo) // optional callback when element box is set
 	Prompts  *PromptTracker     // optional; when set, prompt-blocked commands fail fast
+	// optional; when set, captures wait out an in-flight navigation (#289)
+	Navigations *NavigationTracker
 }
 
 // NewAgentSession creates an AgentSession.
@@ -118,6 +124,15 @@ func (m *AgentSession) SendBidiCommandWithTimeout(method string, params map[stri
 	}
 	return wrapped, nil
 }
+
+func (p *APISession) NavTracker() *NavigationTracker {
+	if p.Session == nil {
+		return nil
+	}
+	return p.Session.navigations
+}
+
+func (m *AgentSession) NavTracker() *NavigationTracker { return m.Navigations }
 
 func (m *AgentSession) SetLastElementBox(box *BoxInfo) {
 	if m.OnBoxSet != nil {

--- a/tests/cli/recording-latency.test.js
+++ b/tests/cli/recording-latency.test.js
@@ -1,0 +1,77 @@
+/**
+ * CLI Tests: Recording latency
+ * A navigating action while recording used to burn the whole 5s screenshot
+ * timeout, because captureScreenshot is not answered across a navigation and
+ * the error was discarded (#289).
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execSync, spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { VIBIUM } = require('../helpers');
+
+// The bug produced ~5.1s; the fix produces ~0.2s. Anything under this means the
+// capture is no longer waiting out its timeout, with room for a slow CI box.
+const MAX_MS = 3000;
+
+let serverProcess, baseURL, tracePath;
+
+function timed(args) {
+  const t0 = Date.now();
+  execSync(`${VIBIUM} ${args}`, { encoding: 'utf-8', timeout: 60000 });
+  return Date.now() - t0;
+}
+
+before(async () => {
+  serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  baseURL = await new Promise((resolve) => {
+    serverProcess.stdout.once('data', (d) => resolve(d.toString().trim()));
+  });
+  tracePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-rec-')), 'trace.zip');
+});
+
+after(() => {
+  try {
+    execSync(`${VIBIUM} record stop -o ${tracePath}`, { encoding: 'utf-8', timeout: 30000 });
+  } catch {
+    // already stopped
+  }
+  if (tracePath && fs.existsSync(tracePath)) fs.rmSync(path.dirname(tracePath), { recursive: true, force: true });
+  if (serverProcess) serverProcess.kill();
+});
+
+describe('CLI: recording latency', () => {
+  test('a navigating click does not wait out the screenshot timeout (#289)', () => {
+    execSync(`${VIBIUM} go ${baseURL}/form-redirect`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} record start --screenshots --name latency`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+
+    // Submitting this form POSTs and 302-redirects back to the same page, so
+    // the click leaves a navigation in flight just as the filmstrip screenshot
+    // is taken. Whether the capture loses that race varies, so repeat: before
+    // the fix roughly two clicks in three stalled for the full timeout.
+    const timings = [];
+    for (let i = 0; i < 5; i++) timings.push(timed(`click "#go"`));
+
+    const worst = Math.max(...timings);
+    assert.ok(
+      worst < MAX_MS,
+      `slowest navigating click took ${worst}ms (all: ${timings.join(', ')}ms); ` +
+        `over ${MAX_MS}ms means a capture is waiting out its timeout again`
+    );
+
+    const result = execSync(`${VIBIUM} record stop -o ${tracePath}`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /saved/i, 'recording should stop cleanly');
+    assert.ok(fs.existsSync(tracePath), 'trace should be written');
+  });
+});

--- a/tests/helpers/test-server.js
+++ b/tests/helpers/test-server.js
@@ -35,6 +35,14 @@ const HOME_HTML = `<html><head><title>The Internet</title></head><body>
   </div>
 </body></html>`;
 
+const FORM_REDIRECT_HTML = `<html><head><title>Form Redirect</title></head><body>
+  <h2>Form Redirect</h2>
+  <form id="f" action="/form-redirect" method="post">
+    <input type="text" name="q" id="q" value="hello" />
+    <button type="submit" id="go">Submit</button>
+  </form>
+</body></html>`;
+
 const LOGIN_HTML = `<html><head><title>The Internet - Login</title></head><body>
   <h2>Login Page</h2>
   <form id="login" action="/authenticate" method="post">
@@ -196,9 +204,19 @@ const routes = {
   '/example': EXAMPLE_HTML,
   '/more-information': MORE_INFORMATION_HTML,
   '/selectors': SELECTORS_HTML,
+  '/form-redirect': FORM_REDIRECT_HTML,
 };
 
 function handleRequest(req, res) {
+  // Form POST that 302s back to the same page. The redirect leaves a navigation
+  // in flight just as a filmstrip screenshot is taken, which used to stall the
+  // action for the full capture timeout (#289).
+  if (req.url === '/form-redirect' && req.method === 'POST') {
+    res.writeHead(302, { Location: '/form-redirect' });
+    res.end();
+    return;
+  }
+
   // Handle login form POST → redirect to /secure
   if (req.url === '/authenticate' && req.method === 'POST') {
     res.writeHead(302, { 'Location': '/secure' });


### PR DESCRIPTION
While recording, every action that triggered a navigation took ~5s instead of ~200ms.

`browsingContext.captureScreenshot` is not answered across a navigation, so a capture issued right after a click that submits a form burned its entire 5s timeout and returned nothing. The error was discarded, so the only symptom was the latency, and the trace still looked fine.

## Why it could not be checked up front

The obvious fix is to skip the capture while a navigation is in flight. That does not work: the navigation an action triggers is not reported until **9-14ms after that action's command returns**, so the capture always wins the race.

```
15.249  capture check    isNavigating=false
15.258  navigationStarted observed        <- 9ms too late
20.250  screenshot failed: timeout after 5s
```

Skipping would also have been wrong for a second reason. `handlers_navigation.go` only captures for the explicit `navigate` command, not for a click-triggered navigation, so skipping would have dropped the frame that shows the action's result, which is the frame a filmstrip most wants.

## What it does instead

React rather than predict. The capture runs while watching for a navigation to begin underneath it. If one does, that attempt is abandoned, the tracker waits for the page to settle, and a fresh screenshot is taken.

`NavigationTracker` mirrors the existing `PromptTracker`: fed raw events by both the proxy and agent event handlers, consumed through the shared `Session` seam, so both surfaces are fixed in one place rather than two.

Also stops discarding the capture error. A silent 5s stall is what let this go unnoticed.

## Measured

Six navigating clicks against a form whose POST 302-redirects back to the same page:

| | Before | After |
|---|---|---|
| Navigating click | ~5,130ms (5 of 6) | ~200ms (6 of 6) |
| Non-navigating click | ~150ms | ~150ms |
| screencast-frame events | 6 | 12 |

The frame count is the part that matters most. Each action fires two capture attempts; the one racing the navigation timed out and was discarded, so half the filmstrip was silently missing, and specifically the frames spanning a navigation.

## Tests

- `clicker/internal/api/navigation_test.go` covers the tracker: in-flight tracking, settle on load, the failed/aborted paths that keep a context from wedging forever, the start notification, and nil-safety.
- `tests/cli/recording-latency.test.js` is the end-to-end guard. It fails against the pre-fix binary (36.8s for five clicks) and passes after.
- `tests/helpers/test-server.js` gains a `/form-redirect` fixture. The existing `/login` form redirects to a *different* page and completes too fast to reproduce this.

Full `make test` passes.

Fixes #289


