### PR TITLE
Honor -o paths for pdf and record, like screenshot (#119)

### DIFF
--- a/clicker/cmd/clicker/pdf.go
+++ b/clicker/cmd/clicker/pdf.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +18,12 @@ func newPDFCmd() *cobra.Command {
 		Args: cobra.RangeArgs(0, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			output, _ := cmd.Flags().GetString("output")
+			// The daemon is a separate long-lived process whose working directory
+			// is not the user's, so resolve against this shell before the path goes
+			// over the socket (#119).
+			if abs, err := filepath.Abs(output); err == nil {
+				output = abs
+			}
 
 			// Navigate first if URL provided
 			if len(args) == 1 {

--- a/clicker/cmd/clicker/record.go
+++ b/clicker/cmd/clicker/record.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 )
 
@@ -96,6 +98,14 @@ func newRecordCmd() *cobra.Command {
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			output, _ := cmd.Flags().GetString("output")
+			// The daemon is a separate long-lived process whose working directory
+			// is not the user's, so resolve against this shell before the path goes
+			// over the socket (#119).
+			if output != "" {
+				if abs, err := filepath.Abs(output); err == nil {
+					output = abs
+				}
+			}
 
 			callArgs := map[string]interface{}{}
 			if output != "" {
@@ -207,6 +217,14 @@ func newRecordCmd() *cobra.Command {
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			output, _ := cmd.Flags().GetString("output")
+			// The daemon is a separate long-lived process whose working directory
+			// is not the user's, so resolve against this shell before the path goes
+			// over the socket (#119).
+			if output != "" {
+				if abs, err := filepath.Abs(output); err == nil {
+					output = abs
+				}
+			}
 
 			callArgs := map[string]interface{}{}
 			if output != "" {

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -2942,6 +2942,11 @@ func (h *Handlers) browserPDF(args map[string]interface{}) (*ToolsCallResult, er
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode PDF: %w", err)
 		}
+		// Match screenshot and record: a path the user typed is honored as
+		// given, including directories that do not exist yet (#119).
+		if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+			return nil, fmt.Errorf("failed to create PDF directory: %w", err)
+		}
 		if err := os.WriteFile(filename, pdfData, 0644); err != nil {
 			return nil, fmt.Errorf("failed to save PDF: %w", err)
 		}

--- a/tests/cli/navigation.test.js
+++ b/tests/cli/navigation.test.js
@@ -88,6 +88,38 @@ describe('CLI: Navigation', () => {
     }
   });
 
+  test('pdf and record honor -o paths like screenshot does (#119)', () => {
+    // pdf and record stop hand the path to the daemon, whose working directory
+    // is not the caller's, so a relative path used to land wherever the daemon
+    // was started. screenshot was fixed first; these are its siblings.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-out-'));
+    try {
+      const pdfPath = path.join(dir, 'nested', 'page.pdf');
+      const pdfOut = execSync(`${VIBIUM} pdf ${baseURL}/example -o ${pdfPath}`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+      });
+      assert.match(pdfOut, /saved/i, `pdf should report success, got: ${pdfOut}`);
+      assert.ok(fs.existsSync(pdfPath), 'pdf should be at the requested path');
+      assert.strictEqual(
+        fs.readFileSync(pdfPath).subarray(0, 4).toString(),
+        '%PDF',
+        'should be a real PDF'
+      );
+
+      const zipPath = path.join(dir, 'nested', 'trace.zip');
+      execSync(`${VIBIUM} record start --name outpath`, { encoding: 'utf-8', timeout: 30000 });
+      const recOut = execSync(`${VIBIUM} record stop -o ${zipPath}`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+      });
+      assert.match(recOut, /saved/i, `record stop should report success, got: ${recOut}`);
+      assert.ok(fs.existsSync(zipPath), 'recording should be at the requested path');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('eval command executes JavaScript', () => {
     const result = execSync(`${VIBIUM} eval ${baseURL}/example "document.title"`, {
       encoding: 'utf-8',


### PR DESCRIPTION
`vibium pdf -o` and `vibium record stop -o` hand the path to the daemon, whose working directory is not the caller's. A relative path landed wherever the daemon happened to be started, while the command reported success:

```
cd /tmp/work && vibium pdf -o report.pdf
# before: PDF saved to report.pdf        (actually written to the daemon's cwd)
# after:  PDF saved to /tmp/work/report.pdf
```

#286 fixed this for `screenshot` and stopped there. Found by sweeping the sibling commands: of the four that take an output path, `screenshot` was fixed, `storage -o` was already fine (it writes client-side), and `pdf` plus both `record stop` sites were broken.

`pdf` also now creates missing parent directories, which `screenshot` and `record` already did via `WriteRecordToFile`.

## Verified

```
vibium pdf -o t.pdf          -> ./t.pdf
vibium pdf -o sub/deep.pdf   -> ./sub/deep.pdf   (sub/ created)
vibium record stop -o sub/rec.zip -> ./sub/rec.zip
```

New case in `tests/cli/navigation.test.js` covering both commands; it fails against the pre-fix binary. Full `make test` passes.