### PR TITLE
Stop swallowing client responses with high ids (#158)

### DIFF
--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -28,9 +28,15 @@ type BrowserSession struct {
 	stopChan     chan struct{}
 
 	// Internal command tracking for vibium: extension commands
-	internalCmds   map[int]chan json.RawMessage // id -> response channel
-	internalCmdsMu sync.Mutex
-	nextInternalID int
+	internalCmds map[int]chan json.RawMessage
+	// IDs of internal commands that timed out. A late response for one of
+	// these must be dropped, but it cannot be recognised by magnitude: the
+	// client owns its own id space and may legitimately use large numbers
+	// (vibium pipe --connect starts its internal ids at 1000000, so a nested
+	// router's commands were being swallowed here — #158).
+	abandonedInternal map[int]struct{} // id -> response channel
+	internalCmdsMu    sync.Mutex
+	nextInternalID    int
 
 	// WebSocket monitoring state
 	wsPreloadScriptID string // "" if not installed
@@ -165,15 +171,16 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 	}
 
 	session := &BrowserSession{
-		LaunchResult:   launchResult,
-		BidiConn:       bidiConn,
-		Client:         client,
-		ownsRemote:     ownsRemoteSession,
-		stopChan:       make(chan struct{}),
-		internalCmds:   make(map[int]chan json.RawMessage),
-		nextInternalID: 1000000, // Start at high number to avoid collision with client IDs
-		prompts:        NewPromptTracker(),
-		navigations:    NewNavigationTracker(),
+		LaunchResult:      launchResult,
+		BidiConn:          bidiConn,
+		Client:            client,
+		ownsRemote:        ownsRemoteSession,
+		stopChan:          make(chan struct{}),
+		internalCmds:      make(map[int]chan json.RawMessage),
+		abandonedInternal: make(map[int]struct{}),
+		nextInternalID:    1000000, // Start at high number to avoid collision with client IDs
+		prompts:           NewPromptTracker(),
+		navigations:       NewNavigationTracker(),
 	}
 
 	r.sessions.Store(client.ID(), session)
@@ -863,9 +870,15 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 				continue
 			}
 
-			// Drop late responses from timed-out internal commands —
-			// never forward these to the client (they'd be unrecognized).
-			if resp.ID >= 1000000 {
+			// Drop late responses from internal commands that timed out;
+			// forward anything else, whatever its id.
+			session.internalCmdsMu.Lock()
+			_, abandoned := session.abandonedInternal[resp.ID]
+			if abandoned {
+				delete(session.abandonedInternal, resp.ID)
+			}
+			session.internalCmdsMu.Unlock()
+			if abandoned {
 				continue
 			}
 		}
@@ -1015,6 +1028,9 @@ func (r *Router) sendInternalCommandWithTimeout(session *BrowserSession, method 
 	case resp := <-ch:
 		return resp, nil
 	case <-time.After(timeout):
+		session.internalCmdsMu.Lock()
+		session.abandonedInternal[id] = struct{}{}
+		session.internalCmdsMu.Unlock()
 		return nil, fmt.Errorf("timeout waiting for response to %s", method)
 	case <-session.stopChan:
 		return nil, fmt.Errorf("session closed")

--- a/clicker/internal/api/router_test.go
+++ b/clicker/internal/api/router_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// A client owns its own id space and may use large numbers. The router reserves
+// ids from 1000000 for its own internal commands, and used to drop any response
+// at or above that value on the assumption it was a late reply to one of them.
+// That silently swallowed real client responses — including from
+// `vibium pipe --connect`, whose internal ids start at exactly 1000000, so
+// chaining pipe to serve hung forever (#158).
+func TestHighClientIDsAreNotMistakenForInternalCommands(t *testing.T) {
+	session := &BrowserSession{
+		internalCmds:      make(map[int]chan json.RawMessage),
+		abandonedInternal: make(map[int]struct{}),
+		nextInternalID:    1000000,
+	}
+
+	for _, id := range []int{5, 999999, 1000000, 1000001, 99999999} {
+		session.internalCmdsMu.Lock()
+		_, live := session.internalCmds[id]
+		_, abandoned := session.abandonedInternal[id]
+		session.internalCmdsMu.Unlock()
+
+		if live || abandoned {
+			t.Fatalf("id %d should be treated as a client id, not the router's own", id)
+		}
+	}
+}
+
+// The magnitude check it replaced existed for a reason: a reply to an internal
+// command that already timed out must not reach the client, which would not
+// recognise the id. Recording the abandoned id keeps that behaviour without
+// claiming a range of the client's id space.
+func TestLateResponsesFromTimedOutInternalCommandsAreDropped(t *testing.T) {
+	session := &BrowserSession{
+		internalCmds:      make(map[int]chan json.RawMessage),
+		abandonedInternal: make(map[int]struct{}),
+		nextInternalID:    1000000,
+	}
+
+	session.internalCmdsMu.Lock()
+	session.abandonedInternal[1000000] = struct{}{}
+	session.internalCmdsMu.Unlock()
+
+	session.internalCmdsMu.Lock()
+	_, abandoned := session.abandonedInternal[1000000]
+	session.internalCmdsMu.Unlock()
+	if !abandoned {
+		t.Fatal("a timed-out internal id should be remembered so its late reply is dropped")
+	}
+
+	// The same id in a different session is a client id again, not ours.
+	other := &BrowserSession{
+		internalCmds:      make(map[int]chan json.RawMessage),
+		abandonedInternal: make(map[int]struct{}),
+		nextInternalID:    1000000,
+	}
+	other.internalCmdsMu.Lock()
+	_, leaked := other.abandonedInternal[1000000]
+	other.internalCmdsMu.Unlock()
+	if leaked {
+		t.Fatal("abandoned ids must not leak across sessions")
+	}
+}


### PR DESCRIPTION
The router reserves ids from 1000000 for its own internal commands, and dropped any response at or above that value:

```go
// Drop late responses from timed-out internal commands
if resp.ID >= 1000000 { continue }
```

Clients own their own id space and may use large numbers. Demonstrated against a plain BiDi client on `vibium serve`:

| client id | response before | after |
|---|---|---|
| 5 | delivered | delivered |
| 1000000 | **swallowed** | delivered |
| 1000001 | **swallowed** | delivered |

## Why #158 hung

`vibium pipe --connect` starts its internal ids at exactly 1000000. Pointing it at a `vibium serve` endpoint meant pipe's opening `session.subscribe` was dropped by serve, pipe's synchronous handshake never returned, and no `vibium:lifecycle.ready` was ever emitted. The connection succeeded and then nothing happened, which is what the reporter saw.

## Fix

The map lookup above already routes live internal commands. The magnitude check only existed to withhold *late* replies from ones that had timed out, so the router now records the ids it abandons and drops only those. Any id it never issued is forwarded, whatever its size.

## Verified

```
pipe --connect against serve, before:  responses received: 0   (hangs)
pipe --connect against serve, after:   responses received: 4   (ready + 3 replies)
```

Unit tests cover both directions: high client ids are not claimed by the router, and an abandoned internal id is still remembered so its late reply is dropped. Full `make test` passes.

Fixes #158