### PR TITLE
Guard the #128 route-before-navigate deadlock

### DIFF
--- a/tests/js/async/network-dialog.test.js
+++ b/tests/js/async/network-dialog.test.js
@@ -91,6 +91,33 @@ describe('Network Interception: page.route', () => {
     await vibe.close();
   });
 
+  test('a route that matches nothing does not block navigation (#128)', async () => {
+    const vibe = await bro.newPage();
+
+    // #128 reported that registering any route deadlocked the next go()
+    // permanently, and specifically that it happened even when the pattern
+    // could never match. The existing route tests all use patterns that do
+    // match, so this is the case they miss.
+    await vibe.route('**/*.jpg', (route) => route.continue());
+
+    await vibe.go(baseURL);
+    assert.strictEqual(await vibe.title(), 'Test Page', 'navigation should complete');
+
+    // Still responsive afterwards, not wedged behind the registration.
+    assert.strictEqual(await vibe.evaluate('1 + 1'), 2);
+    await vibe.close();
+  });
+
+  test('setHeaders() does not block navigation (#128)', async () => {
+    const vibe = await bro.newPage();
+
+    await vibe.setHeaders({ 'X-Vibium-Test': '128' });
+
+    await vibe.go(baseURL);
+    assert.strictEqual(await vibe.title(), 'Test Page', 'navigation should complete');
+    await vibe.close();
+  });
+
   test('route.fulfill() returns a mock response', async () => {
     const vibe = await bro.newPage();
     await vibe.go(baseURL);


### PR DESCRIPTION
#227 fixed the transport bug behind #128, but the specific case the issue emphasised was uncovered: the deadlock happened **even when the route pattern could never match**. Every existing route test uses a pattern that matches, and `setHeaders` was only exercised in `tests/manual/`.

Two cases added to `tests/js/async/network-dialog.test.js`:

- a route registered with `**/*.jpg` on a site that serves no images, then `go()`
- `setHeaders()` then `go()`

Both assert navigation completes and the page is still responsive afterwards.

Full `make test` passes.