### PR TITLE
Document vibium serve as a BiDi endpoint, and which transport to use

### DIFF
--- a/docs/explanation/client-implementation-guide.md
+++ b/docs/explanation/client-implementation-guide.md
@@ -11,17 +11,18 @@ Use the **JS client** (`clients/javascript/`) and **Python client** (`clients/py
 ## Table of Contents
 
 1. [Architecture Overview](#architecture-overview)
-2. [Drive It By Hand First](#drive-it-by-hand-first)
-3. [Class Hierarchy](#class-hierarchy)
-4. [Command Reference](#command-reference) — see [API Reference](../reference/api.md) for full tables
-5. [Naming Conventions](#naming-conventions)
-6. [Error Types](#error-types)
-7. [Async / Sync Patterns](#async--sync-patterns)
-8. [Reserved Keyword Handling](#reserved-keyword-handling)
-9. [Aliases](#aliases)
-10. [Key Design Decisions](#key-design-decisions)
-11. [Binary Discovery](#binary-discovery)
-12. [Testing Checklist](#testing-checklist)
+2. [Which Transport](#which-transport)
+3. [Drive It By Hand First](#drive-it-by-hand-first)
+4. [Class Hierarchy](#class-hierarchy)
+5. [Command Reference](#command-reference) — see [API Reference](../reference/api.md) for full tables
+6. [Naming Conventions](#naming-conventions)
+7. [Error Types](#error-types)
+8. [Async / Sync Patterns](#async--sync-patterns)
+9. [Reserved Keyword Handling](#reserved-keyword-handling)
+10. [Aliases](#aliases)
+11. [Key Design Decisions](#key-design-decisions)
+12. [Binary Discovery](#binary-discovery)
+13. [Testing Checklist](#testing-checklist)
 
 ---
 
@@ -62,6 +63,32 @@ Use the **JS client** (`clients/javascript/`) and **Python client** (`clients/py
 ```
 
 ---
+
+## Which Transport
+
+vibium exposes the same capabilities over four surfaces. Two engines, two
+transports each. Knowing which one you are on matters, because a change to one
+engine does not reach the other.
+
+| Surface | Engine | Transport | Method names | Used by |
+|---|---|---|---|---|
+| `vibium pipe` | `api.Router` | stdin/stdout | `vibium:page.screenshot` | JS, Python, Java clients |
+| `vibium serve` | `api.Router` | WebSocket | `vibium:page.screenshot` | third-party BiDi clients |
+| `vibium daemon` | `agent.Handlers` | Unix socket | `browser_screenshot` | the `vibium` CLI |
+| `vibium mcp` | `agent.Handlers` | stdin/stdout | `browser_screenshot` | AI clients over MCP |
+
+**Write your client against `vibium pipe`.** It is what every shipped client
+uses, so it is the best tested path. There is no port to allocate, no
+authentication question, and the browser's lifetime is your process's lifetime,
+so a crashed client cannot leak a browser.
+
+`vibium serve` speaks the identical protocol over a WebSocket. It exists for
+clients that already speak WebDriver BiDi and should not have to learn to spawn
+our binary — see [use vibium as a BiDi endpoint](../how-to-guides/use-vibium-as-a-bidi-endpoint.md).
+If you are writing a vibium client, you do not want it.
+
+The daemon and MCP surfaces run a different engine with different method names.
+They are not alternative transports for a client library.
 
 ## Drive It By Hand First
 

--- a/docs/how-to-guides/use-vibium-as-a-bidi-endpoint.md
+++ b/docs/how-to-guides/use-vibium-as-a-bidi-endpoint.md
@@ -1,0 +1,104 @@
+# Use vibium as a WebDriver BiDi endpoint
+
+If you already have a WebDriver BiDi client — Selenium, WebdriverIO, Puppeteer's
+BiDi mode, or something you wrote — you do not need a vibium client library to
+use vibium. `vibium serve` is a BiDi endpoint that manages its own browser.
+
+```bash
+vibium serve --headless --port 9633
+# Server listening on ws://localhost:9633
+```
+
+Point your client at that URL and speak standard BiDi. There is no chromedriver
+to install, and no `POST /session` handshake — connect the WebSocket and send
+commands.
+
+```json
+→ {"id":1,"method":"session.status","params":{}}
+← {"id":1,"result":{"build":{"version":"151.0.7922.71"},"ready":false}}
+
+→ {"id":2,"method":"browsingContext.getTree","params":{}}
+← {"id":2,"result":{"contexts":[{"context":"E1B0A6CA...","url":"about:blank"}]}}
+
+→ {"id":3,"method":"browsingContext.navigate",
+   "params":{"context":"E1B0A6CA...","url":"https://example.com","wait":"complete"}}
+← {"id":3,"result":{"navigation":"1496dc0f-...","url":"https://example.com/"}}
+```
+
+Events arrive unsolicited, as usual:
+
+```json
+← {"method":"browsingContext.contextCreated","params":{...}}
+← {"method":"browsingContext.navigationStarted","params":{...}}
+← {"method":"network.beforeRequestSent","params":{...}}
+← {"method":"browsingContext.load","params":{...}}
+```
+
+vibium downloads and launches Chrome for Testing on the first connection and
+cleans it up when you disconnect.
+
+---
+
+## Which transport do I want?
+
+`serve` is one of two ways to reach vibium, and it is the right one only for
+some jobs.
+
+| You have | Use | Why |
+|---|---|---|
+| An existing BiDi client | `vibium serve` | It already speaks BiDi over a WebSocket. Nothing to integrate. |
+| A vibium client library (JS, Python, Java) | those clients | They spawn `vibium pipe` for you. |
+| A new client library you are writing | `vibium pipe` | No port, no auth, browser lifetime tied to your process. See the [client implementation guide](../explanation/client-implementation-guide.md). |
+
+Do not chain them. `vibium pipe --connect ws://localhost:9633` works, but it
+inserts a second router that translates nothing.
+
+---
+
+## Extension commands
+
+`serve` also accepts vibium's `vibium:` commands on the same connection —
+actionability-aware clicks, semantic locators, recording. Those are additions to
+BiDi, not replacements, so a plain BiDi client can ignore them entirely.
+
+```json
+→ {"id":4,"method":"vibium:browser.page","params":{}}
+← {"id":4,"type":"success","result":{"context":"B0EC708F...","userContext":"default"}}
+```
+
+See the [API reference](../reference/api.md) for the full list.
+
+---
+
+## Reaching it from elsewhere
+
+`serve` binds to `127.0.0.1` and rejects WebSocket upgrades whose `Origin` is
+not local. Browser automation is a remote code execution surface, so it is not
+exposed to the network by default.
+
+To reach it from a container or another machine, forward a local port rather
+than binding wider — for example `ssh -L 9633:localhost:9633 user@host`, or
+Docker's `-p 127.0.0.1:9633:9633` with the server inside the container.
+
+Clients that are not browsers (most BiDi libraries) send no `Origin` header and
+connect normally.
+
+---
+
+## When it does not fit
+
+**You want one browser shared by several clients.** Each connection to `serve`
+gets its own browser and its own session. For concurrent CLI use, see
+[running concurrent CLI sessions](concurrent-cli-sessions.md).
+
+**You want the browser to outlive the connection.** It does not. Disconnecting
+closes the browser. The daemon behind the `vibium` CLI is what keeps a browser
+alive between commands.
+
+---
+
+## Related
+
+- [Client implementation guide](../explanation/client-implementation-guide.md) — writing a client against `vibium pipe`
+- [Remote browser](../tutorials/remote-browser.md) — pointing vibium at someone else's browser, the opposite direction
+- [API reference](../reference/api.md) — the `vibium:` extension commands


### PR DESCRIPTION
`vibium serve` has been undocumented since it stopped being the client transport in `0d51988`. That is how #158 happened: a user found a command that starts cleanly, answers `wscat`, and has nothing saying what it is for.

It has a real role. A third-party BiDi client can drive it directly:

```
vibium serve --headless --port 9633

session.status              -> ok
browsingContext.getTree     -> ok
browsingContext.navigate    -> https://example.com/
script.evaluate             -> "Example Domain"
events: contextCreated, navigationStarted, network.*, load
```

No chromedriver, no `POST /session`, and vibium downloads and manages Chrome. That is the one thing `pipe` cannot offer, since it requires spawning our binary.

## New

`docs/how-to-guides/use-vibium-as-a-bidi-endpoint.md` — connecting an existing BiDi client, the `vibium:` extension commands available on the same connection, loopback binding and how to reach it from a container, and the two cases where it does not fit.

## Which Transport

A table in the client implementation guide covering all four surfaces, because two engines with two transports each is not obvious from any one of them:

| Surface | Engine | Transport | Used by |
|---|---|---|---|
| `pipe` | `api.Router` | stdin/stdout | JS, Python, Java clients |
| `serve` | `api.Router` | WebSocket | third-party BiDi clients |
| `daemon` | `agent.Handlers` | Unix socket | the `vibium` CLI |
| `mcp` | `agent.Handlers` | stdin/stdout | AI clients |

It says plainly to write new clients against `pipe`, and not to chain `pipe --connect` to `serve`.

Every claim was verified against a running server, including per-connection browser isolation and the loopback bind. Docs only. Full `make test` passes.