### PR TITLE
Keep page.expose() functions across navigations (#135)

### DIFF
--- a/clicker/internal/api/handlers_state.go
+++ b/clicker/internal/api/handlers_state.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/vibium/clicker/internal/bidi"
+	"github.com/vibium/clicker/internal/log"
 )
 
 // handleVibiumElText handles vibium:element.text — returns element.textContent.
@@ -1220,11 +1221,26 @@ func (r *Router) handlePageAddStyle(session *BrowserSession, cmd bidiCommand) {
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"added": true})
 }
 
-// handlePageExpose handles vibium:page.expose — injects a named function via preload script.
-// Simplified: injects a function that stores calls (no callback channel).
+// handlePageExpose handles vibium:page.expose — defines a named function on
+// window and keeps it there across navigations.
+//
+// It used to inject only into the current document with script.callFunction, so
+// the function vanished on the next navigation even though the point of
+// exposing one is that the page can call it whenever it loads (#135). A preload
+// script runs on every new document, which is what makes it stick; the same
+// source is also run against the current document so the function is usable
+// immediately, without waiting for a navigation.
 func (r *Router) handlePageExpose(session *BrowserSession, cmd bidiCommand) {
 	name, _ := cmd.Params["name"].(string)
 	fn, _ := cmd.Params["fn"].(string)
+	if name == "" {
+		r.sendError(session, cmd.ID, fmt.Errorf("name is required"))
+		return
+	}
+	if fn == "" {
+		r.sendError(session, cmd.ID, fmt.Errorf("fn is required"))
+		return
+	}
 
 	context, err := r.resolveContext(session, cmd.Params)
 	if err != nil {
@@ -1232,24 +1248,63 @@ func (r *Router) handlePageExpose(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 
-	// Inject the function into the page via script.callFunction
-	script := `(name, fn) => {
-		window[name] = new Function('return ' + fn)();
-		return 'ok';
-	}`
+	// json.Marshal gives a correctly escaped JS string literal for the name.
+	// fn is source, so it is embedded directly, parenthesised so a function
+	// expression parses. Building the source here rather than passing it as an
+	// argument also avoids the Function constructor, which a page's CSP can
+	// block. addPreloadScript takes only channels as arguments, so a preload
+	// script has to carry its values in the declaration anyway.
+	nameLit, err := json.Marshal(name)
+	if err != nil {
+		r.sendError(session, cmd.ID, fmt.Errorf("invalid name: %w", err))
+		return
+	}
+	declaration := fmt.Sprintf("() => { window[%s] = (%s); }", nameLit, fn)
 
-	params := map[string]interface{}{
-		"functionDeclaration": script,
-		"target":              map[string]interface{}{"context": context},
-		"arguments": []map[string]interface{}{
-			{"type": "string", "value": name},
-			{"type": "string", "value": fn},
-		},
-		"awaitPromise":    false,
-		"resultOwnership": "root",
+	// Replace any previous script for this name rather than stacking another.
+	session.mu.Lock()
+	previous := session.exposedPreloadIDs[name]
+	session.mu.Unlock()
+	if previous != "" {
+		if _, err := r.sendInternalCommand(session, "script.removePreloadScript", map[string]interface{}{
+			"script": previous,
+		}); err != nil {
+			log.Debug("failed to remove previous exposed function", "name", name, "error", err)
+		}
 	}
 
-	if _, err := r.sendInternalCommand(session, "script.callFunction", params); err != nil {
+	resp, err := r.sendInternalCommand(session, "script.addPreloadScript", map[string]interface{}{
+		"functionDeclaration": declaration,
+	})
+	if err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+	if bidiErr := checkBidiError(resp); bidiErr != nil {
+		r.sendError(session, cmd.ID, bidiErr)
+		return
+	}
+
+	var added struct {
+		Result struct {
+			Script string `json:"script"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &added); err != nil {
+		r.sendError(session, cmd.ID, fmt.Errorf("failed to parse addPreloadScript response: %w", err))
+		return
+	}
+	session.mu.Lock()
+	session.exposedPreloadIDs[name] = added.Result.Script
+	session.mu.Unlock()
+
+	// The preload script only runs for documents loaded from now on, so define
+	// it in the document that is already open too.
+	if _, err := r.sendInternalCommand(session, "script.callFunction", map[string]interface{}{
+		"functionDeclaration": declaration,
+		"target":              map[string]interface{}{"context": context},
+		"awaitPromise":        false,
+	}); err != nil {
 		r.sendError(session, cmd.ID, err)
 		return
 	}

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -40,7 +40,10 @@ type BrowserSession struct {
 
 	// WebSocket monitoring state
 	wsPreloadScriptID string // "" if not installed
-	wsSubscribed      bool   // whether script.message is subscribed
+	// name -> preload script id, so page.expose survives navigation and a
+	// repeated expose replaces its script instead of stacking a new one.
+	exposedPreloadIDs map[string]string
+	wsSubscribed      bool // whether script.message is subscribed
 
 	// Download support
 	downloadDir string // temp dir for downloads, cleaned up on close
@@ -180,6 +183,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		abandonedInternal: make(map[int]struct{}),
 		nextInternalID:    1000000, // Start at high number to avoid collision with client IDs
 		prompts:           NewPromptTracker(),
+		exposedPreloadIDs: make(map[string]string),
 		navigations:       NewNavigationTracker(),
 	}
 

--- a/tests/js/async/input-eval.test.js
+++ b/tests/js/async/input-eval.test.js
@@ -247,6 +247,44 @@ describe('Evaluation: page-level', () => {
     const result = await vibe.evaluate('window.myAdd(2, 3)');
     assert.strictEqual(result, 5);
   });
+
+  test('expose() survives navigation (#135)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(`${baseURL}/example`);
+    await vibe.expose('myPersist', '(a, b) => a * b');
+
+    // The test above exposes after its only navigation, so it passed even when
+    // the function was injected into just the current document. The point of
+    // exposing one is that it is there whenever the page loads.
+    await vibe.go(`${baseURL}/login`);
+    assert.strictEqual(await vibe.evaluate('typeof window.myPersist'), 'function');
+    assert.strictEqual(await vibe.evaluate('window.myPersist(3, 4)'), 12);
+
+    await vibe.go(`${baseURL}/example`);
+    assert.strictEqual(await vibe.evaluate('window.myPersist(5, 6)'), 30);
+  });
+
+  test('expose() is usable before any navigation (#135)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(`${baseURL}/example`);
+    await vibe.expose('myNow', '() => "immediate"');
+
+    // Persisting must not come at the cost of the current document.
+    assert.strictEqual(await vibe.evaluate('window.myNow()'), 'immediate');
+  });
+
+  test('expose() replaces a previous function of the same name (#135)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(`${baseURL}/example`);
+
+    await vibe.expose('myDup', '() => "first"');
+    await vibe.expose('myDup', '() => "second"');
+    assert.strictEqual(await vibe.evaluate('window.myDup()'), 'second');
+
+    await vibe.go(`${baseURL}/login`);
+    assert.strictEqual(await vibe.evaluate('window.myDup()'), 'second',
+      'the replaced definition must not come back after a navigation');
+  });
 });
 
 // --- Checkpoint ---


### PR DESCRIPTION
`expose()` injected the function into the current document with `script.callFunction`, so it vanished on the next navigation. The handler's own comment said it used a preload script; it did not.

```
expose('vibAdd', '(a,b) => a+b')
typeof window.vibAdd            -> "function"      ok
window.vibAdd(2,3)              -> 5               ok
go(...)                         
typeof window.vibAdd            -> "undefined"     <- the bug
```

## Scope

The report said "callback, return value, and args all broken". They are not: args and return values work. The repro checked them *after* a navigation, so everything read as broken when only persistence was. Reported against the Java client, but it reproduces identically through the JS client, so it is server-side.

Java's `expose(String, Function<Object[], Object>)` promises a real callback into Java, which the wire protocol does not support at all. That is a separate gap, not this bug — the shipped JS and Python contract is "the function body is injected as a string", and that is what this fixes.

## Fix

Registers a preload script, which runs for every document, and runs the same source against the already-open document so the function works without waiting for a navigation. Re-exposing a name removes its previous script rather than stacking another.

Building the source instead of passing `name`/`fn` as arguments also drops the `Function` constructor, which a page's CSP can block. `addPreloadScript` takes only channels as arguments, so a preload script must carry its values in the declaration anyway.

## Tests

The existing test navigated *before* exposing and checked nothing afterwards, which is exactly why this survived. Three cases added: survives navigation, usable before any navigation, and replacement. Two of them fail against the pre-fix binary.

Full `make test` passes.

Does **not** fix #135. That was filed against the Java client, which sends no `fn` at all, so it is unaffected by this and now errors instead of silently no-opping. The real feature it asked for is tracked in #298.
