### PR TITLE
Type newlines as Enter (#61)

### DIFF
--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -648,6 +648,7 @@ func DblClickAtCenter(s Session, context string, info *ElementInfo) error {
 func TypeText(s Session, context, text string) error {
 	keyActions := make([]map[string]interface{}, 0, len(text)*2)
 	for _, char := range text {
+		char = bidi.ConvertToKeyChar(char)
 		keyActions = append(keyActions,
 			map[string]interface{}{"type": "keyDown", "value": string(char)},
 			map[string]interface{}{"type": "keyUp", "value": string(char)},

--- a/clicker/internal/bidi/input.go
+++ b/clicker/internal/bidi/input.go
@@ -97,13 +97,14 @@ func (c *Client) TypeText(context, text string) error {
 	// Build key actions for each character
 	keyActions := make([]map[string]interface{}, 0, len(text)*2)
 	for _, char := range text {
+		char = ConvertToKeyChar(char)
 		keyActions = append(keyActions,
 			map[string]interface{}{
-				"type": "keyDown",
+				"type":  "keyDown",
 				"value": string(char),
 			},
 			map[string]interface{}{
-				"type": "keyUp",
+				"type":  "keyUp",
 				"value": string(char),
 			},
 		)
@@ -200,4 +201,3 @@ func ResolveKey(name string) string {
 	}
 	return name
 }
-

--- a/clicker/internal/bidi/keys.go
+++ b/clicker/internal/bidi/keys.go
@@ -1,0 +1,11 @@
+package bidi
+
+// ConvertToKeyChar maps string literal characters to their WebDriver BiDi key
+// equivalents for keyboard input. For example, newline (\n) is a line break in
+// strings but must be sent as the Return key (\uE006) to produce a key press.
+func ConvertToKeyChar(r rune) rune {
+	if r == '\n' {
+		return '\uE006'
+	}
+	return r
+}

--- a/tests/cli/elements.test.js
+++ b/tests/cli/elements.test.js
@@ -66,6 +66,36 @@ describe('CLI: Elements', () => {
     );
     assert.match(result, /typed/i, 'Should confirm text was typed');
   });
+
+  test('type enters text containing a carriage return (#61)', () => {
+    execSync(`${VIBIUM} go ${baseURL}/inputs`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} type "#multiline" "$(printf '123\\r456')"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+      shell: '/bin/bash',
+    });
+
+    const value = execSync(`${VIBIUM} eval "document.querySelector('#multiline').value"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(value, '123\n456');
+  });
+
+  test('type enters text containing a newline (#61)', () => {
+    // A literal newline is not a key. It used to be sent as a key value the
+    // browser ignored, so "123\n456" arrived as "123456".
+    execSync(`${VIBIUM} go ${baseURL}/inputs`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} type "#multiline" "123
+456"`, { encoding: 'utf-8', timeout: 30000 });
+
+    const value = execSync(`${VIBIUM} eval "document.querySelector('#multiline').value"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(value, '123\n456');
+  });
+
 });
 
 describe('CLI: shadow DOM pierce', () => {

--- a/tests/helpers/test-server.js
+++ b/tests/helpers/test-server.js
@@ -94,6 +94,7 @@ const DROPDOWN_HTML = `<html><head><title>The Internet - Dropdown</title></head>
 const INPUTS_HTML = `<html><head><title>The Internet - Inputs</title></head><body>
   <h3>Inputs</h3>
   <input type="number" />
+  <textarea id="multiline" rows="5" cols="30"></textarea>
 </body></html>`;
 
 const DYNAMIC_LOADING_HTML = `<html><head><title>The Internet - Dynamic Loading</title></head><body>

--- a/tests/js/async/async-api.test.js
+++ b/tests/js/async/async-api.test.js
@@ -28,6 +28,7 @@ const SUBPAGE_HTML = `<html><head><title>Subpage</title></head><body>
 
 const INPUTS_HTML = `<html><head><title>Inputs</title></head><body>
   <input type="text" />
+  <textarea id="multiline" rows="5" cols="30"></textarea>
 </body></html>`;
 
 before(async () => {
@@ -127,6 +128,18 @@ describe('JS Async API', () => {
 
     const value = await vibe.evaluate("document.querySelector('input').value");
     assert.strictEqual(value, '12345', 'Input should have typed value');
+  });
+
+  test('element.type() enters newlines as Enter (#61)', async () => {
+    // A literal newline is not a key. It used to be sent as a key value the
+    // browser ignored, so '123\n456' arrived as '123456'.
+    const vibe = await bro.page();
+    await vibe.go(`${baseURL}/inputs`);
+    const area = await vibe.find('#multiline');
+    await area.type('123\n456');
+
+    const value = await vibe.evaluate("document.querySelector('#multiline').value");
+    assert.strictEqual(value, '123\n456');
   });
 
   test('element.text() returns element text', async () => {


### PR DESCRIPTION
Rebase of @kevinsimler's #61, opened 2026-01-28. The fix is theirs, unchanged; only the surroundings had moved.

A literal newline is not a key. WebDriver addresses Enter through `\uE006`, so typing `"123\n456"` sent `'\n'` as a key value the browser ignored:

```
type "#multiline" "123\n456"   ->  "123456"     before
                               ->  "123\n456"   after
```

## What changed from their PR

Nothing conceptual. Three pieces of scaffolding had moved underneath it in the eight months it was open:

| Their PR | Why it no longer applied |
|---|---|
| `internal/proxy/router.go` | proxy renamed to api in `e61a1ed`; that loop is now `handlers_interaction.go` |
| `${CLICKER}` in tests | binary renamed in `9bc9c17` |
| tests drove `seleniumbase.io` | live external sites stall and wedge the suite |

Tests now use the shared local server, which gains a textarea fixture on `/inputs`. Their two cases are kept as they wrote them: one for a carriage return, one for a newline. Also added `element.type()` in the JS client, which the CLI tests do not reach.

## Verified

Against the unpatched binary, their split turns out to be well chosen:

```
carriage return  ->  passes    Chrome already treats a raw CR as Enter
newline          ->  fails     the actual bug
```

So the CR case is a regression guard for behaviour that already worked, and the newline case is the fix. Mapping only `'\n'` is correct and sufficient.

Full `make test` passes.

Closes #61