### PR TITLE
Custom Chrome flags, and say why Chrome will not start as root (#141)

### DIFF
--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -266,6 +266,10 @@ func chromeArgs(headless bool) []string {
 	if headless {
 		args = append(args, "--headless=new")
 	}
+	// Append any custom flags from VIBIUM_CHROME_ARGS (space-separated) so users
+	// can pass --no-sandbox etc. in root/CI/container environments where Chrome
+	// refuses to start otherwise. Empty tokens (from extra whitespace) are skipped.
+	args = append(args, customChromeArgs()...)
 	return args
 }
 
@@ -277,6 +281,13 @@ func vmFastLaunchShim() string {
 		return ""
 	}
 	return os.Getenv("VIBIUM_VM_FAST_LAUNCH")
+}
+
+// customChromeArgs reads extra Chrome flags from the VIBIUM_CHROME_ARGS
+// environment variable, splitting on whitespace and dropping empty tokens.
+// Returns nil when the variable is unset or contains only whitespace.
+func customChromeArgs() []string {
+	return strings.Fields(os.Getenv("VIBIUM_CHROME_ARGS"))
 }
 
 // buildCapabilities returns the capabilities map for BiDi session.new.

--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -105,6 +105,11 @@ type sessionValue struct {
 func Launch(opts LaunchOptions) (*LaunchResult, error) {
 	log.Debug("launching browser", "headless", opts.Headless)
 
+	// Fail with a reason before spending ~2s on a launch that cannot succeed.
+	if err := checkSandboxable(); err != nil {
+		return nil, err
+	}
+
 	chromedriverPath, err := paths.GetChromedriverPath()
 	if err != nil {
 		return nil, fmt.Errorf("chromedriver not found")

--- a/clicker/internal/browser/launcher_test.go
+++ b/clicker/internal/browser/launcher_test.go
@@ -1,6 +1,9 @@
 package browser
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // A session-creation failure used to surface as bare "HTTP 500", discarding the
 // body that says why (#107).
@@ -49,5 +52,51 @@ func TestDriverErrorMessageTruncatesRunaway(t *testing.T) {
 	got := driverErrorMessage(body)
 	if len(got) > 520 {
 		t.Errorf("message length %d, want it truncated", len(got))
+	}
+}
+
+// TestChromeArgsCustomEnv verifies that flags supplied via VIBIUM_CHROME_ARGS
+// are appended to the Chrome argv so users can pass --no-sandbox etc. in
+// root/CI/container environments (issue #141).
+func TestChromeArgsCustomEnv(t *testing.T) {
+	t.Setenv("VIBIUM_CHROME_ARGS", "--no-sandbox --disable-gpu")
+
+	args := chromeArgs(false)
+
+	if !slices.Contains(args, "--no-sandbox") {
+		t.Errorf("expected --no-sandbox in chrome args, got %v", args)
+	}
+	if !slices.Contains(args, "--disable-gpu") {
+		t.Errorf("expected --disable-gpu in chrome args, got %v", args)
+	}
+}
+
+// TestChromeArgsCustomEnvUnset verifies the argv is unchanged when the env var
+// is absent, and that no empty-string args ever leak into the list.
+func TestChromeArgsCustomEnvUnset(t *testing.T) {
+	t.Setenv("VIBIUM_CHROME_ARGS", "")
+
+	args := chromeArgs(false)
+
+	if slices.Contains(args, "") {
+		t.Errorf("expected no empty-string args, got %v", args)
+	}
+	if slices.Contains(args, "--no-sandbox") {
+		t.Errorf("did not expect --no-sandbox when env unset, got %v", args)
+	}
+}
+
+// TestChromeArgsCustomEnvWhitespace verifies that extra whitespace between and
+// around flags is split cleanly without producing empty-string args.
+func TestChromeArgsCustomEnvWhitespace(t *testing.T) {
+	t.Setenv("VIBIUM_CHROME_ARGS", "  --no-sandbox   --disable-gpu  ")
+
+	args := chromeArgs(false)
+
+	if slices.Contains(args, "") {
+		t.Errorf("expected no empty-string args from whitespace, got %v", args)
+	}
+	if !slices.Contains(args, "--no-sandbox") || !slices.Contains(args, "--disable-gpu") {
+		t.Errorf("expected both flags parsed from padded input, got %v", args)
 	}
 }

--- a/clicker/internal/browser/sandbox_unix.go
+++ b/clicker/internal/browser/sandbox_unix.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package browser
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// errRootSandbox explains the one launch failure that looks like a crash but is
+// a deliberate refusal. Chrome will not start its sandbox as root, so a
+// container running as root — which most CI base images do — got
+// "browser crashed with exit code 1" and nothing to act on (#141).
+//
+// We do not disable the sandbox automatically. Running a browser unsandboxed is
+// a real security tradeoff, and it should be the caller's decision rather than
+// something vibium does quietly on their behalf.
+var errRootSandbox = errors.New(
+	"Chrome cannot run as root with its sandbox enabled.\n" +
+		"  Set VIBIUM_CHROME_ARGS=--no-sandbox to disable it, or run as a non-root user.\n" +
+		"  Disabling the sandbox removes a security boundary; prefer a non-root user where you can.")
+
+// checkSandboxable returns an actionable error when the browser is certain to
+// refuse to start, rather than letting it fail as an opaque crash.
+func checkSandboxable() error {
+	if os.Geteuid() != 0 {
+		return nil
+	}
+	// Already opted out, so root is fine.
+	for _, arg := range strings.Fields(os.Getenv("VIBIUM_CHROME_ARGS")) {
+		if arg == "--no-sandbox" {
+			return nil
+		}
+	}
+	return errRootSandbox
+}

--- a/clicker/internal/browser/sandbox_unix_test.go
+++ b/clicker/internal/browser/sandbox_unix_test.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package browser
+
+import (
+	"strings"
+	"testing"
+)
+
+// Chrome refuses to start its sandbox as root, which surfaced as
+// "browser crashed with exit code 1" with nothing to act on (#141).
+func TestCheckSandboxableExplainsTheRootRefusal(t *testing.T) {
+	if errRootSandbox == nil {
+		t.Fatal("expected a root sandbox error to exist")
+	}
+	msg := errRootSandbox.Error()
+
+	// The message has to name the cause and the fix, since the whole point is
+	// that the crash it replaces named neither.
+	for _, want := range []string{"root", "VIBIUM_CHROME_ARGS=--no-sandbox", "non-root user"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message should mention %q, got:\n%s", want, msg)
+		}
+	}
+}
+
+func TestCheckSandboxablePassesForNonRoot(t *testing.T) {
+	// The test process is not root, so this exercises the ordinary path.
+	if err := checkSandboxable(); err != nil {
+		t.Fatalf("non-root should launch normally, got: %v", err)
+	}
+}
+
+func TestCheckSandboxableAcceptsAnExplicitOptOut(t *testing.T) {
+	// Someone who has already set --no-sandbox has made the decision; do not
+	// block them for being root.
+	t.Setenv("VIBIUM_CHROME_ARGS", "--disable-gpu --no-sandbox")
+	if err := checkSandboxable(); err != nil {
+		t.Fatalf("explicit opt-out should be honoured, got: %v", err)
+	}
+}

--- a/clicker/internal/browser/sandbox_windows.go
+++ b/clicker/internal/browser/sandbox_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package browser
+
+// checkSandboxable is a no-op on Windows: platformChromeArgs already passes
+// --no-sandbox there unconditionally, because the Chrome for Testing sandbox
+// cannot read its own executable under %LOCALAPPDATA% ACLs (27ff6cc).
+func checkSandboxable() error { return nil }


### PR DESCRIPTION
Two commits: @youdie006's #178 rebased, plus the error message that makes it discoverable.

## The problem

Chrome refuses to start its sandbox as root. Standard CI images (`node:lts`, `python:3.x`) run as root, so vibium failed with `browser crashed with exit code 1` and no way to pass flags on Unix — `platformChromeArgs()` returns `nil` there.

## VIBIUM_CHROME_ARGS (#178, @youdie006)

```go
func customChromeArgs() []string {
	return strings.Fields(os.Getenv("VIBIUM_CHROME_ARGS"))
}
```

An env var was the reporter's first-choice option, since it works across every language client with no SDK changes. Rebased only: `launcher.go` gained a `vmFastLaunchShim` helper and `launcher_test.go` was created independently, so both are unions.

Verified the flags reach Chrome:

```
VIBIUM_CHROME_ARGS="--disable-gpu --window-size=1234,567" vibium daemon start
  argv:              --window-size=1234,567  --disable-gpu
  window.innerWidth: 1234
```

## Saying why, instead of crashing

An escape hatch only helps people who know it exists, and what they hit first is an opaque crash. `Launch` now checks and explains:

```
Chrome cannot run as root with its sandbox enabled.
  Set VIBIUM_CHROME_ARGS=--no-sandbox to disable it, or run as a non-root user.
  Disabling the sandbox removes a security boundary; prefer a non-root user where you can.
```

**It does not disable the sandbox automatically.** Playwright defaults `chromiumSandbox` to `false`, so we could have; but running a browser unsandboxed is a real tradeoff and it should be the caller's decision, not something vibium does quietly. Setting the variable counts as consent and the check steps aside.

Windows is a no-op — `platformChromeArgs` already passes `--no-sandbox` there unconditionally, because the Chrome for Testing sandbox cannot read its own executable under `%LOCALAPPDATA%` ACLs (`27ff6cc`).

Full `make test` passes.

Closes #141