### PR TITLE
Move CI to Node 24 and drop the per-file timeout workaround

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 # Opens PRs that bump the SHA-pinned actions in workflows, so the pins
-# stay current (the pinned majors target the deprecated Node 20 runtime).
+# stay current. The Node 20 runtime deprecation that prompted this was
+# cleared in #287.
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          # Node 20 reached end of life in March 2026; 24 is the active LTS.
+          node-version: '24'
           cache: npm
 
       - name: Set up Python
@@ -78,10 +79,11 @@ jobs:
         run: make
 
       # xvfb: the Python suite's headed tests need a display.
-      # NODE_TEST_TIMEOUT: on Node 20, --test-timeout limits each test file,
-      # not each test, and the slowest file needs ~150s.
+      # The NODE_TEST_TIMEOUT override is gone with Node 20: --test-timeout is
+      # per test now, not per file, so the Makefile's 30s default applies and a
+      # hung test surfaces in 30s rather than 300s.
       - name: Test
-        run: xvfb-run --auto-servernum make test NODE_TEST_TIMEOUT=300000
+        run: xvfb-run --auto-servernum make test
 
       # In case the job is interrupted before make test's own cleanup runs.
       - name: Clean up zombie processes

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ endif
 # page navigation"). 30s gives headroom while making a hung test surface
 # in 30s instead of 2 minutes — so a flake takes ~30s × N_stuck_tests to
 # trip the phase wrapper instead of ~120s × N.
-# On Node 20, --test-timeout limits each test FILE, not each test; CI
-# overrides this to file scale (see .github/workflows/test.yml).
+# --test-timeout is per test, not per file. That was reversed on Node 20,
+# which CI used to work around with a file-scale override; both are gone.
 NODE_TEST_TIMEOUT ?= 30000
 TEST_FLAGS := --test-timeout=$(NODE_TEST_TIMEOUT) --test-force-exit
 


### PR DESCRIPTION
GitHub Actions is warning that Node 20 is deprecated. It reached end of life in March 2026; **24 is the active LTS** (22 left maintenance in July, 26 is Current and not LTS).

```diff
-          node-version: '20'
+          node-version: '24'
```

## The workaround goes with it

Line 81 carried a Node 20 quirk:

> NODE_TEST_TIMEOUT: on Node 20, `--test-timeout` limits each test file, not each test, and the slowest file needs ~150s.

That is why CI overrode the timeout to `300000`. It is per test again, verified against a file of fast/slow/fast with `--test-timeout=1000`:

```
✔ fast test           (55ms)
✖ slow test           (1004ms)   'test timed out after 1000ms'
✔ another fast test   (51ms)
```

Only the slow test was cancelled; the file kept running. So the Makefile's 30s default applies per test and CI no longer needs the override — **a hung test now surfaces in 30s instead of 300s**, which is what that default was written for. Full `make test` passes without it.

Also refreshes the `dependabot.yml` comment, which still cited the Node 20 runtime deprecation that #287 cleared.

## Not changed

The platform packages declare `"engines": { "node": ">=18" }`, and Node 18 is EOL too. Bumping that is a user-facing compatibility decision rather than housekeeping, and it overlaps with #17 (clearer errors on an unsupported Node), so I left it alone.