### PR TITLE
Skip CI for documentation-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,53 @@ name: Test
 on:
   push:
     branches: [main]
+    paths-ignore:
+      # Documentation that nothing builds or tests reads. Deliberately NOT
+      # docs/tutorials/**: tests/py and tests/js extract code from those and
+      # run it, so editing one can break the suite. Also not skills/**, whose
+      # SKILL.md is copied into the binary by build-go.
+      - 'docs/explanation/**'
+      - 'docs/how-to-guides/**'
+      - 'docs/images/**'
+      - 'docs/plans/**'
+      - 'docs/reference/**'
+      - 'docs/specs/**'
+      - 'docs/trackers/**'
+      - 'docs/updates/**'
+      - 'docs/README.md'
+      # Root docs named individually. A bare glob's treatment of / is
+      # not worth guessing at here: if it matched recursively it would
+      # silently skip CI for skills/vibe-check/SKILL.md, which build-go
+      # compiles in, and for the tutorials, which tests execute.
+      - 'CLAUDE.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'ROADMAP.md'
   pull_request:
+    paths-ignore:
+      # Documentation that nothing builds or tests reads. Deliberately NOT
+      # docs/tutorials/**: tests/py and tests/js extract code from those and
+      # run it, so editing one can break the suite. Also not skills/**, whose
+      # SKILL.md is copied into the binary by build-go.
+      - 'docs/explanation/**'
+      - 'docs/how-to-guides/**'
+      - 'docs/images/**'
+      - 'docs/plans/**'
+      - 'docs/reference/**'
+      - 'docs/specs/**'
+      - 'docs/trackers/**'
+      - 'docs/updates/**'
+      - 'docs/README.md'
+      # Root docs named individually. A bare glob's treatment of / is
+      # not worth guessing at here: if it matched recursively it would
+      # silently skip CI for skills/vibe-check/SKILL.md, which build-go
+      # compiles in, and for the tutorials, which tests execute.
+      - 'CLAUDE.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'ROADMAP.md'
 
 # CI only reads the repo. Keeps the job's GITHUB_TOKEN read-only even if
 # the repo default is ever write.


### PR DESCRIPTION
A markdown edit runs the full Go, JS, Python, and Java suite for about six minutes. Roughly one commit in eight touches only documentation, and iterating on a single doc can burn several runs.

Two paths are deliberately **not** in the ignore list:

| Path | Why it must still trigger CI |
|---|---|
| `docs/tutorials/**` | `tests/py` and `tests/js` extract the code blocks from those files and execute them, so editing one can turn the suite red |
| `skills/**` | `build-go` copies `SKILL.md` into the binary |

Root docs are named individually rather than matched with a glob. Whether a bare `'*.md'` crosses a `/` is not documented clearly, and if it matched recursively it would silently skip CI for both of the above — a skipped run looks the same as a passing one.

`.github/**` is also absent, so this PR runs CI itself.