### PR TITLE
Remove the storage test's temp dir, not just the files in it

### DIFF
--- a/tests/cli/storage.test.js
+++ b/tests/cli/storage.test.js
@@ -12,7 +12,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { VIBIUM } = require('../helpers');
 
-let serverProcess, baseURL, statePath, legacyPath;
+let serverProcess, baseURL, tmpDir, statePath, legacyPath;
 
 before(async () => {
   serverProcess = spawn('node', [path.join(__dirname, '../helpers/test-server.js')], {
@@ -25,15 +25,13 @@ before(async () => {
   });
   execSync(`${VIBIUM} go ${baseURL}/`, { encoding: 'utf-8', timeout: 30000 });
 
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-storage-'));
-  statePath = path.join(dir, 'state.json');
-  legacyPath = path.join(dir, 'legacy.json');
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-storage-'));
+  statePath = path.join(tmpDir, 'state.json');
+  legacyPath = path.join(tmpDir, 'legacy.json');
 });
 
 after(() => {
-  for (const p of [statePath, legacyPath]) {
-    if (p && fs.existsSync(p)) fs.unlinkSync(p);
-  }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
   if (serverProcess) serverProcess.kill();
 });
 


### PR DESCRIPTION
## Problem

`tests/cli/storage.test.js` created a temp dir with `mkdtempSync`, but its
`after()` hook only unlinked the two files inside it (`state.json`,
`legacy.json`) — never the directory. Every run of this test leaked one empty
`vibium-storage-*` dir into the system temp dir.

Found 18 of them accumulated on a dev box. Harmless individually, but it's an
unbounded accumulation and the fix is trivial.

## Fix

Hoist the dir into the outer scope and `rmSync` it recursively in `after()`,
which removes both files and the directory in one call.

## Verification

- `node --test tests/cli/storage.test.js` — 3/3 pass
- Temp dir count in `$TMPDIR`: 0 before the run, **0 after** (previously the
  run left one behind)

Checked the other 14 `mkdtemp` sites under `tests/`; none of their prefixes
(`vibium-dl-`, `vibium-shot-`, `vibium-pack-`, …) had accumulated on the same
box, so this was the only leaking one.