### PR TITLE
Always run Java tests instead of letting Gradle skip them as up-to-date

### DIFF
--- a/clients/java/build.gradle.kts
+++ b/clients/java/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // Integration tests drive the vibium binary and a live browser — neither is
+    // a Gradle input, so never let cached results skip the run.
+    outputs.upToDateWhen { false }
     // Pass VIBIUM_BIN_PATH to tests if set
     environment("VIBIUM_BIN_PATH", System.getenv("VIBIUM_BIN_PATH") ?: "")
     // Each fork is a JVM with its own Chrome (~16s/launch on macOS). Default


### PR DESCRIPTION
Gradle's up-to-date check skipped the :test task whenever Java sources and classpath were unchanged — `make test-java` reported green in under a second with zero tests executed. The vibium binary and the browser aren't declared Gradle inputs, so even a fresh Go build wouldn't invalidate the cache.

Fix: `outputs.upToDateWhen { false }` on the test task, matching how the JS and Python suites always rerun. Compilation stays incremental.

Verified locally: `make test-java` now runs 63 tests (0 failures, 1 skipped) in ~23s.