### PR TITLE
Resize the window over BiDi so it survives page closes (#346)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ CLI_CORE_TESTS := \
 	tests/cli/page-context.test.js \
 	tests/cli/find-refs.test.js \
 	tests/cli/storage.test.js \
-	tests/cli/recording-latency.test.js
+	tests/cli/recording-latency.test.js \
+	tests/cli/viewport-window.test.js
 CLI_SHARED_TESTS := $(CLI_CORE_TESTS)
 ifeq ($(ENGINE),chrome)
   CLI_SHARED_TESTS += tests/cli/prompt-blocked.test.js

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -3721,16 +3721,6 @@ func (h *Handlers) browserSetWindow(args map[string]interface{}) (*ToolsCallResu
 		return nil, err
 	}
 
-	if h.launchResult == nil {
-		return &ToolsCallResult{
-			Content: []Content{{
-				Type: "text",
-				Text: "Not supported for remote browsers",
-			}},
-			IsError: true,
-		}, nil
-	}
-
 	state, _ := args["state"].(string)
 	width, hasWidth := argFloat(args, "width")
 	height, hasHeight := argFloat(args, "height")
@@ -3755,7 +3745,7 @@ func (h *Handlers) browserSetWindow(args map[string]interface{}) (*ToolsCallResu
 		opts.Y = &yv
 	}
 
-	if err := api.SetWindow(h.launchResult.Port, h.launchResult.SessionID, opts); err != nil {
+	if err := api.SetWindow(h.newSession(), opts); err != nil {
 		return nil, err
 	}
 

--- a/clicker/internal/api/handlers_emulation.go
+++ b/clicker/internal/api/handlers_emulation.go
@@ -1,11 +1,8 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 )
 
 // handlePageSetViewport handles vibium:page.setViewport — sets the viewport size.
@@ -246,7 +243,7 @@ func (r *Router) handlePageSetWindow(session *BrowserSession, cmd bidiCommand) {
 		opts.Y = &yv
 	}
 
-	if err := SetWindow(session.LaunchResult.Port, session.LaunchResult.SessionID, opts); err != nil {
+	if err := SetWindow(NewAPISession(r, session, ""), opts); err != nil {
 		r.sendError(session, cmd.ID, err)
 		return
 	}
@@ -302,28 +299,6 @@ func (r *Router) handlePageSetGeolocation(session *BrowserSession, cmd bidiComma
 // Exported standalone functions — usable from both proxy and MCP.
 // ---------------------------------------------------------------------------
 
-// ChromedriverPost sends a POST request to a chromedriver classic WebDriver endpoint.
-func ChromedriverPost(url string, body map[string]interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return fmt.Errorf("failed to marshal request: %w", err)
-	}
-
-	resp, err := http.Post(url, "application/json", bytes.NewReader(data))
-	if err != nil {
-		return fmt.Errorf("chromedriver request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, _ := io.ReadAll(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("chromedriver error (status %d): %s", resp.StatusCode, string(respBody))
-	}
-
-	return nil
-}
-
 // WindowInfo holds OS browser window state and dimensions.
 type WindowInfo struct {
 	State  string `json:"state"`
@@ -336,27 +311,45 @@ type WindowInfo struct {
 // GetWindow returns the current OS browser window state and dimensions.
 // Uses BiDi browser.getClientWindows.
 func GetWindow(s Session) (*WindowInfo, error) {
+	win, _, err := activeClientWindow(s)
+	return win, err
+}
+
+// activeClientWindow returns the focused client window (or the first one when
+// none reports focus) along with its BiDi client window id.
+func activeClientWindow(s Session) (*WindowInfo, string, error) {
 	resp, err := s.SendBidiCommand("browser.getClientWindows", map[string]interface{}{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get window: %w", err)
+		return nil, "", fmt.Errorf("failed to get window: %w", err)
 	}
 	if bidiErr := checkBidiError(resp); bidiErr != nil {
-		return nil, bidiErr
+		return nil, "", bidiErr
 	}
 
 	var getResult struct {
 		Result struct {
-			ClientWindows []WindowInfo `json:"clientWindows"`
+			ClientWindows []struct {
+				WindowInfo
+				ClientWindow string `json:"clientWindow"`
+				Active       bool   `json:"active"`
+			} `json:"clientWindows"`
 		} `json:"result"`
 	}
 	if err := json.Unmarshal(resp, &getResult); err != nil {
-		return nil, fmt.Errorf("failed to parse getClientWindows: %w", err)
+		return nil, "", fmt.Errorf("failed to parse getClientWindows: %w", err)
 	}
-	if len(getResult.Result.ClientWindows) == 0 {
-		return nil, fmt.Errorf("no client windows available")
+	windows := getResult.Result.ClientWindows
+	if len(windows) == 0 {
+		return nil, "", fmt.Errorf("no client windows available")
 	}
-
-	return &getResult.Result.ClientWindows[0], nil
+	chosen := windows[0]
+	for _, win := range windows {
+		if win.Active {
+			chosen = win
+			break
+		}
+	}
+	return &chosen.WindowInfo, chosen.ClientWindow, nil
 }
 
 // SetWindowOpts specifies the desired window state and/or dimensions.
@@ -369,41 +362,42 @@ type SetWindowOpts struct {
 }
 
 // SetWindow sets the OS browser window size, position, or state.
-// Uses chromedriver's classic WebDriver HTTP API.
-func SetWindow(port int, sessionID string, opts SetWindowOpts) error {
-	baseURL := fmt.Sprintf("http://localhost:%d/session/%s/window", port, sessionID)
+// Uses BiDi browser.setClientWindowState: the classic WebDriver endpoint
+// operates on the session's current window handle, which goes stale once
+// the page it points at is closed.
+func SetWindow(s Session, opts SetWindowOpts) error {
+	_, id, err := activeClientWindow(s)
+	if err != nil {
+		return err
+	}
 
-	// Handle named states via dedicated endpoints
-	if opts.State != "" && opts.State != "normal" {
-		endpoint := ""
-		switch opts.State {
-		case "maximized":
-			endpoint = baseURL + "/maximize"
-		case "minimized":
-			endpoint = baseURL + "/minimize"
-		case "fullscreen":
-			endpoint = baseURL + "/fullscreen"
-		default:
-			return fmt.Errorf("unsupported window state: %s", opts.State)
+	params := map[string]interface{}{"clientWindow": id}
+	switch opts.State {
+	case "maximized", "minimized", "fullscreen":
+		params["state"] = opts.State
+	case "", "normal":
+		params["state"] = "normal"
+		if opts.Width != nil {
+			params["width"] = *opts.Width
 		}
-		return ChromedriverPost(endpoint, map[string]interface{}{})
+		if opts.Height != nil {
+			params["height"] = *opts.Height
+		}
+		if opts.X != nil {
+			params["x"] = *opts.X
+		}
+		if opts.Y != nil {
+			params["y"] = *opts.Y
+		}
+	default:
+		return fmt.Errorf("unsupported window state: %s", opts.State)
 	}
 
-	// For "normal" state or dimension changes, use /window/rect
-	rect := map[string]interface{}{}
-	if opts.Width != nil {
-		rect["width"] = *opts.Width
+	resp, err := s.SendBidiCommand("browser.setClientWindowState", params)
+	if err != nil {
+		return fmt.Errorf("failed to set window: %w", err)
 	}
-	if opts.Height != nil {
-		rect["height"] = *opts.Height
-	}
-	if opts.X != nil {
-		rect["x"] = *opts.X
-	}
-	if opts.Y != nil {
-		rect["y"] = *opts.Y
-	}
-	return ChromedriverPost(baseURL+"/rect", rect)
+	return checkBidiError(resp)
 }
 
 // geolocationScript is the JS that overrides navigator.geolocation.

--- a/tests/cli/viewport-window.test.js
+++ b/tests/cli/viewport-window.test.js
@@ -56,4 +56,21 @@ describe('CLI: Viewport & Window Commands', () => {
     assert.strictEqual(win.width, 900);
     assert.strictEqual(win.height, 700);
   });
+
+  test('window resize survives closing the active page (#346)', () => {
+    execSync(`${VIBIUM} page new`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} page switch 0`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} page close`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} window 910 710`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const result = execSync(`${VIBIUM} window`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const win = JSON.parse(result);
+    assert.strictEqual(win.width, 910);
+    assert.strictEqual(win.height, 710);
+  });
 });

--- a/tests/daemon/connect.test.js
+++ b/tests/daemon/connect.test.js
@@ -1,7 +1,7 @@
 /**
  * Remote Browser Connect Tests
  * Tests vibium start [url], stop, VIBIUM_CONNECT_URL env var,
- * and window error for remote browsers.
+ * and window control for remote browsers.
  */
 
 const { test, describe, before, after } = require('node:test');
@@ -223,14 +223,12 @@ describe('Daemon: Remote browser connect', () => {
     assert.ok(result.result.includes('/example'), 'Should confirm navigation');
   });
 
-  test('window set returns error for remote browsers', () => {
+  test('window set works for remote browsers', () => {
     const result = clickerJSONSafe('window 800 600');
-    assert.strictEqual(result.ok, false, 'window set should fail for remote browsers');
-    assert.ok(
-      result.error.toLowerCase().includes('not supported') ||
-      result.error.toLowerCase().includes('remote'),
-      'Should mention remote browser limitation'
-    );
+    assert.strictEqual(result.ok, true, 'window set should succeed over a remote connection');
+    const win = JSON.parse(clickerJSON('window').result);
+    assert.strictEqual(win.width, 800);
+    assert.strictEqual(win.height, 600);
   });
 
   test('vibium stop stops daemon', () => {


### PR DESCRIPTION
Fixes VibiumDev#346.

Setting the window size used the classic WebDriver `window/rect` endpoint, which acts on the driver session's current window handle. That handle never moves off the first window: BiDi page switches and closes do not resync it, so closing the original page broke every later resize while `vibium window` reads kept working over BiDi. Resize now sends `browser.setClientWindowState`, matching the read path, and picks the focused client window.

Reading the window also prefers the focused client window now instead of always the first one, since both paths share `activeClientWindow`.

With the classic dependency gone, the remote-browser guard is removed too, so resize works in connect mode; the daemon connect test now asserts success instead of the old error. `ChromedriverPost` had no remaining callers and is deleted.

`tests/cli/viewport-window.test.js` was never referenced by the Makefile and had never run in CI. It is added to `CLI_CORE_TESTS` with a new regression test for the close-then-resize sequence.

Verified:

- Regression test fails on main, passes with the fix
- CLI repro from the issue passes on Chrome and Firefox locally
- Full `make test` green on Chrome (7m27s)
- Full `viewport-window.test.js` green under `ENGINE=firefox` locally