### PR TITLE
Await event setup before dispatching later commands (#351)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,12 +340,14 @@ test-js-async: build-go
 	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
 		$(JS_ASYNC_ENGINE_TESTS) \
 		tests/js/async/chrome-video.test.js \
-		tests/js/async/browser-installer.test.js
+		tests/js/async/browser-installer.test.js \
+		tests/js/async/event-setup-ordering.test.js
 
 test-js-sync: build-go
 	@echo "--- JS Sync Tests (parallel x$(JS_PARALLEL)) ---"
 	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
-		$(JS_SYNC_ENGINE_TESTS)
+		$(JS_SYNC_ENGINE_TESTS) \
+		tests/js/sync/event-setup-ordering-sync.test.js
 
 test-js-process: build-go
 	@echo "--- JS Process Tests (sequential) ---"

--- a/clicker/internal/api/download_ordering_test.go
+++ b/clicker/internal/api/download_ordering_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Download behavior used to be established in a bare goroutine, so a client
+// whose first command started a download could be served first: the file
+// landed in the browser's own download directory, outside the session's temp
+// dir, where download.saveAs could not find it (#351).
+//
+// OnClientConnect runs before either transport starts reading client messages
+// (server.handleWebSocket, cmd/clicker/pipe.go), which is why session.subscribe
+// is synchronous there. This pins that setupDownloads now shares that
+// guarantee.
+//
+// The proof is the held response, not timing: the fake browser reports when
+// browser.setDownloadBehavior arrives and then answers nothing until the test
+// says so. Only a synchronous setup can still be inside OnClientConnect at
+// that point, so a backgrounded one fails here however the scheduler behaves.
+func TestDownloadBehaviorIsEstablishedDuringConnect(t *testing.T) {
+	arrived := make(chan struct{}) // closed when setDownloadBehavior reaches the browser
+	release := make(chan struct{}) // closed by the test to let it be answered
+
+	upgrader := websocket.Upgrader{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		for {
+			_, raw, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var cmd struct {
+				ID     int64  `json:"id"`
+				Method string `json:"method"`
+			}
+			if json.Unmarshal(raw, &cmd) != nil {
+				continue
+			}
+
+			// ready:false makes the router attach to this endpoint's session
+			// rather than create one, keeping the handshake to one command.
+			result := `{}`
+			if cmd.Method == "session.status" {
+				result = `{"ready":false,"message":"already has session"}`
+			}
+			if cmd.Method == "browser.setDownloadBehavior" {
+				close(arrived)
+				<-release
+			}
+
+			conn.WriteMessage(websocket.TextMessage,
+				[]byte(`{"id":`+strconv.FormatInt(cmd.ID, 10)+`,"type":"success","result":`+result+`}`))
+		}
+	}))
+	defer ts.Close()
+
+	router := NewRouter("chrome", true, "ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+	client := &recordingClient{}
+	t.Cleanup(router.CloseAll)
+
+	connected := make(chan struct{})
+	go func() {
+		router.OnClientConnect(client)
+		close(connected)
+	}()
+
+	select {
+	case <-arrived:
+	case <-time.After(10 * time.Second):
+		close(release)
+		t.Fatal("browser.setDownloadBehavior never reached the browser during connect")
+	}
+
+	// Its response is being held, so connect must still be waiting on it.
+	select {
+	case <-connected:
+		close(release)
+		t.Fatal("OnClientConnect returned while download behavior was still being established; " +
+			"a client command could be served before the browser knows where downloads go")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-connected:
+	case <-time.After(10 * time.Second):
+		t.Fatal("OnClientConnect never returned after download behavior was established")
+	}
+
+	val, ok := router.sessions.Load(client.ID())
+	if !ok {
+		t.Fatal("router has no session for the client")
+	}
+	session := val.(*BrowserSession)
+	session.mu.Lock()
+	dir := session.downloadDir
+	session.mu.Unlock()
+	if dir == "" {
+		t.Fatal("download dir must be set once connect returns")
+	}
+}
+
+// recordingClient is a ClientTransport that keeps whatever the router sends it.
+type recordingClient struct {
+	mu   sync.Mutex
+	sent []string
+}
+
+func (c *recordingClient) ID() uint64 { return 1 }
+
+func (c *recordingClient) Send(msg string) error {
+	c.mu.Lock()
+	c.sent = append(c.sent, msg)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *recordingClient) Close() error { return nil }

--- a/clicker/internal/api/handlers_download.go
+++ b/clicker/internal/api/handlers_download.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // setupDownloads creates a temp dir and tells the browser to save downloads there.
@@ -20,14 +21,14 @@ func (r *Router) setupDownloads(session *BrowserSession) {
 	session.downloadDir = dir
 	session.mu.Unlock()
 
-	_, err = r.sendInternalCommand(session, "browser.setDownloadBehavior", map[string]interface{}{
+	_, err = r.sendInternalCommandWithTimeout(session, "browser.setDownloadBehavior", map[string]interface{}{
 		"downloadBehavior": map[string]interface{}{
 			"type":              "allowed",
 			"destinationFolder": dir,
 		},
-	})
+	}, 10*time.Second)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[router] Failed to set download behavior: %v\n", err)
+		fmt.Fprintf(os.Stderr, "[router] Failed to set download behavior (downloads stay in the browser's default dir; download.saveAs will not find them): %v\n", err)
 	}
 }
 

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -251,7 +251,9 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 	// guarantees no command is served first. Backgrounded, a client whose
 	// first command started a download could beat it, and the file landed in
 	// the browser's own download directory where download.saveAs could not
-	// find it (#351).
+	// find it (#351). Bounded to 10s so a browser that wedges on the command
+	// delays connect by that much at most; on timeout downloads degrade the
+	// same way as any other failure here.
 	r.setupDownloads(session)
 }
 

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -245,9 +245,14 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		fmt.Fprintf(os.Stderr, "[router] Failed to subscribe to events for client %d: %v\n", client.ID(), err)
 	}
 
-	// Download setup is non-critical — run in background so it doesn't
-	// block client commands if Chrome is slow to respond.
-	go r.setupDownloads(session)
+	// Establish download behavior synchronously, for the same reason
+	// session.subscribe above is synchronous: OnClientConnect runs before the
+	// transport starts reading client messages, so finishing here is what
+	// guarantees no command is served first. Backgrounded, a client whose
+	// first command started a download could beat it, and the file landed in
+	// the browser's own download directory where download.saveAs could not
+	// find it (#351).
+	r.setupDownloads(session)
 }
 
 // vibiumHandler is the signature for vibium: extension command handlers.

--- a/clients/javascript/src/bidi/client.ts
+++ b/clients/javascript/src/bidi/client.ts
@@ -6,6 +6,13 @@ export type EventHandler = (event: BiDiEvent) => void;
 
 const DEFAULT_COMMAND_TIMEOUT = 60_000;
 
+// Waiting for event setup would deadlock this one: an open dialog stops the
+// browser answering anything else for that context, including the
+// script.callFunction that installs a WebSocket monitor, and this is the only
+// command that closes the dialog. Mirrors unblocksAnotherCommand in the Go
+// router.
+const NEVER_WAITS = 'browsingContext.handleUserPrompt';
+
 export class BiDiClient {
   private stdin: Writable;
   private rl: ReadlineInterface;
@@ -17,6 +24,17 @@ export class BiDiClient {
   }> = new Map();
   private eventHandlers: EventHandler[] = [];
   private _closed: boolean = false;
+
+  // Event registration (page.onWebSocket, network.addDataCollector) is
+  // triggered from synchronous callback APIs with nothing for the caller to
+  // await, so its command used to be fired and forgotten. The next command,
+  // an eval that opens a socket, could reach the engine first, and the
+  // one-shot event was lost (#351).
+  //
+  // sendSetup() parks a gate here that send() waits on. Settle-only: the gate
+  // sequences commands and nothing more. A failed setup is surfaced by
+  // whoever owns that registration, not injected into an unrelated command.
+  private setupGate: Promise<void> | null = null;
 
   private constructor(stdin: Writable, stdout: Readable) {
     this.stdin = stdin;
@@ -100,6 +118,42 @@ export class BiDiClient {
   }
 
   send<T = unknown>(method: string, params: Record<string, unknown> = {}, timeout: number = DEFAULT_COMMAND_TIMEOUT): Promise<T> {
+    const gate = this.setupGate;
+    if (gate === null || method === NEVER_WAITS) {
+      return this.dispatch<T>(method, params, timeout);
+    }
+    // Chaining directly on the gate keeps issue order: gate reactions run in
+    // registration order, and the reaction that clears setupGate was
+    // registered first (in sendSetup), so a command issued after the gate
+    // opens dispatches strictly later.
+    return gate.then(() => this.dispatch<T>(method, params, timeout));
+  }
+
+  /**
+   * Send a command whose acknowledgement the next command depends on.
+   *
+   * Goes out immediately; commands sent before it is answered wait. For event
+   * registration issued from a synchronous callback API, where the caller has
+   * no promise to await (#351). The returned promise is the registration's;
+   * the caller decides how a failure is surfaced.
+   */
+  sendSetup<T = unknown>(method: string, params: Record<string, unknown> = {}, timeout: number = DEFAULT_COMMAND_TIMEOUT): Promise<T> {
+    const result = this.dispatch<T>(method, params, timeout);
+    const settled = result.then(() => undefined, () => undefined);
+    const gate = this.setupGate === null
+      ? settled
+      : Promise.all([this.setupGate, settled]).then(() => undefined);
+    this.setupGate = gate;
+    void gate.then(() => {
+      // A registration made in the meantime replaced this gate and keeps
+      // commands waiting; only the newest one clears.
+      if (this.setupGate === gate) this.setupGate = null;
+    });
+    return result;
+  }
+
+  /** Write a command and wait for its response, bypassing the setup gate. */
+  private dispatch<T = unknown>(method: string, params: Record<string, unknown>, timeout: number): Promise<T> {
     return new Promise((resolve, reject) => {
       const id = this.nextId++;
       const command: BiDiCommand = { id, method, params };
@@ -140,6 +194,10 @@ export class BiDiClient {
       pending.reject(new Error('Connection closed'));
       this.pendingCommands.delete(id);
     }
+
+    // Rejecting the in-flight setup settles the gate; drop it so a command
+    // racing close() fails on the closed connection instead of waiting.
+    this.setupGate = null;
 
     this.rl.close();
     try { this.stdin.end(); } catch {}

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -203,6 +203,7 @@ export class Page {
   private pendingDownloads: Map<string, Download> = new Map();
   private wsCallbacks: ((ws: WebSocketInfo) => void)[] = [];
   private wsConnections: Map<number, WebSocketInfo> = new Map();
+  private wsSetup: Promise<unknown> | null = null;
   private eventHandler: ((event: BiDiEvent) => void) | null = null;
   private interceptId: string | null = null;
   private dataCollectorId: string | null = null;
@@ -942,13 +943,29 @@ export class Page {
     throw new Error('Not implemented: BiDi does not support WebSocket interception');
   }
 
-  /** Listen for WebSocket connections opened by the page. */
+  /**
+   * Listen for WebSocket connections opened by the page.
+   *
+   * Monitoring is installed in the engine before the next command on this
+   * connection is sent, so a socket opened by the very next call cannot be
+   * missed (#351).
+   */
   onWebSocket(fn: (ws: WebSocketInfo) => void): void {
     const isFirst = this.wsCallbacks.length === 0;
     this.wsCallbacks.push(fn);
     if (isFirst) {
-      this.client.send('vibium:page.onWebSocket', { context: this.contextId }).catch(() => {});
+      this.wsSetup = this.client.sendSetup('vibium:page.onWebSocket', { context: this.contextId });
+      this.wsSetup.catch(err => debug('page.onWebSocket setup failed', { error: String(err) }));
     }
+  }
+
+  /**
+   * @internal Resolve when this page's WebSocket monitor is installed,
+   * rejecting if the install failed. The sync wrapper awaits it so its
+   * blocking onWebSocket() reports a failure the async caller cannot see.
+   */
+  async _whenWebSocketSetup(): Promise<void> {
+    if (this.wsSetup) await this.wsSetup;
   }
 
   // --- Dialog Handling ---
@@ -1013,13 +1030,17 @@ export class Page {
   private ensureDataCollector(): void {
     if (this.dataCollectorId !== null) return;
     this.dataCollectorId = 'pending';
-    this.client.send<{ collector: string }>(
+    // sendSetup, not send: the collector must exist before the request whose
+    // body a route/onResponse handler is about to read (#351).
+    this.client.sendSetup<{ collector: string }>(
       'network.addDataCollector',
       { dataTypes: ['request', 'response'], maxEncodedDataSize: 10 * 1024 * 1024 }
     ).then(result => {
       this.dataCollectorId = result.collector;
-    }).catch(() => {
+    }).catch(err => {
+      // Reset so a later listener retries; bodies are unavailable until then.
       this.dataCollectorId = null;
+      debug('page.ensureDataCollector failed', { error: String(err) });
     });
   }
 

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -951,11 +951,19 @@ export class Page {
    * missed (#351).
    */
   onWebSocket(fn: (ws: WebSocketInfo) => void): void {
-    const isFirst = this.wsCallbacks.length === 0;
     this.wsCallbacks.push(fn);
-    if (isFirst) {
-      this.wsSetup = this.client.sendSetup('vibium:page.onWebSocket', { context: this.contextId });
-      this.wsSetup.catch(err => debug('page.onWebSocket setup failed', { error: String(err) }));
+    // Keyed on the setup state, not the callback count: after a failed
+    // install the callbacks are still registered, and the next registration
+    // must retry the install or they can never fire.
+    if (this.wsSetup === null) {
+      const setup = this.client.sendSetup('vibium:page.onWebSocket', { context: this.contextId });
+      this.wsSetup = setup;
+      setup.catch(err => {
+        // Reset so a later listener retries; sockets are unmonitored until
+        // then. Guarded: a retry made in the meantime owns the state.
+        if (this.wsSetup === setup) this.wsSetup = null;
+        debug('page.onWebSocket setup failed', { error: String(err) });
+      });
     }
   }
 
@@ -965,7 +973,19 @@ export class Page {
    * blocking onWebSocket() reports a failure the async caller cannot see.
    */
   async _whenWebSocketSetup(): Promise<void> {
-    if (this.wsSetup) await this.wsSetup;
+    // Captured before awaiting: a failed install resets wsSetup to null, and
+    // the raise must come from the setup this caller registered under.
+    const setup = this.wsSetup;
+    if (setup) await setup;
+  }
+
+  /**
+   * @internal Remove one registered WebSocket callback. The sync wrapper
+   * unregisters on a failed install so its raised call has no effect.
+   */
+  _removeWebSocketCallback(fn: (ws: WebSocketInfo) => void): void {
+    const i = this.wsCallbacks.indexOf(fn);
+    if (i !== -1) this.wsCallbacks.splice(i, 1);
   }
 
   // --- Dialog Handling ---

--- a/clients/javascript/src/sync/worker.ts
+++ b/clients/javascript/src/sync/worker.ts
@@ -3,6 +3,7 @@ import { browser, Browser } from '../browser';
 import { Page } from '../page';
 import { BrowserContext } from '../context';
 import { Element, SelectorOptions } from '../element';
+import { WebSocketInfo } from '../websocket';
 
 interface WorkerData {
   signal: Int32Array;
@@ -875,7 +876,7 @@ const handlers: Record<string, Handler> = {
     const page = getPage(pageId);
     onWebSocketHandlerIds.set(pageId, handlerId);
     let nextWsId = 0;
-    page.onWebSocket((ws) => {
+    const callback = (ws: WebSocketInfo) => {
       const hid = onWebSocketHandlerIds.get(pageId);
       if (!hid) return;
       const wsId = nextWsId++;
@@ -901,11 +902,19 @@ const handlers: Record<string, Handler> = {
           data: { type: 'close', wsId, code, reason },
         });
       });
-    });
+    };
+    page.onWebSocket(callback);
     // The sync caller has no promise to await, so hold the blocking bridge
     // call until the engine has acknowledged the install, and let a failed
     // install raise here, the only place a sync caller can see it (#351).
-    await page._whenWebSocketSetup();
+    // A raised call must have no effect, so unregister before rethrowing;
+    // a retry then registers once and re-sends the install.
+    try {
+      await page._whenWebSocketSetup();
+    } catch (err) {
+      page._removeWebSocketCallback(callback);
+      throw err;
+    }
     return { success: true };
   },
 

--- a/clients/javascript/src/sync/worker.ts
+++ b/clients/javascript/src/sync/worker.ts
@@ -902,6 +902,10 @@ const handlers: Record<string, Handler> = {
         });
       });
     });
+    // The sync caller has no promise to await, so hold the blocking bridge
+    // call until the engine has acknowledged the install, and let a failed
+    // install raise here, the only place a sync caller can see it (#351).
+    await page._whenWebSocketSetup();
     return { success: true };
   },
 

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import fnmatch
+import logging
 import re
 from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
@@ -22,6 +23,8 @@ from .websocket_info import WebSocketInfo
 if TYPE_CHECKING:
     from ..client import BiDiClient
     from .context import BrowserContext as BrowserContextType
+
+logger = logging.getLogger("vibium")
 
 
 def _match_pattern(pattern: str, url: str) -> bool:
@@ -116,7 +119,7 @@ class Page:
         self._pending_downloads: Dict[str, Download] = {}
         self._ws_callbacks: List[Callable] = []
         self._ws_connections: Dict[int, WebSocketInfo] = {}
-        self._ws_setup: Optional[Any] = None
+        self._ws_setup: Optional[asyncio.Future] = None
         self._intercept_id: Optional[str] = None
         self._data_collector_id: Optional[str] = None
 
@@ -782,12 +785,31 @@ class Page:
         connection is sent, so a socket opened by the very next call cannot be
         missed (#351).
         """
-        is_first = len(self._ws_callbacks) == 0
         self._ws_callbacks.append(fn)
-        if is_first:
-            self._ws_setup = self._client.send_setup(
+        # Keyed on the setup state, not the callback count: after a failed
+        # install the callbacks are still registered, and the next
+        # registration must retry the install or they can never fire.
+        if self._ws_setup is None:
+            setup = self._client.send_setup(
                 "vibium:page.onWebSocket", {"context": self._context_id}
             )
+            self._ws_setup = setup
+
+            def _reset(finished: asyncio.Future) -> None:
+                if finished.cancelled():
+                    if self._ws_setup is setup:
+                        self._ws_setup = None
+                elif finished.exception() is not None:
+                    # Reset so a later listener retries; sockets are
+                    # unmonitored until then. Guarded: a retry made in the
+                    # meantime owns the state.
+                    if self._ws_setup is setup:
+                        self._ws_setup = None
+                    logger.debug(
+                        "page.on_web_socket setup failed: %s", finished.exception()
+                    )
+
+            setup.add_done_callback(_reset)
 
     async def _when_web_socket_setup(self) -> None:
         """Wait until this page's WebSocket monitor is installed.
@@ -796,8 +818,12 @@ class Page:
         blocking on_web_socket() reports a failure the async caller cannot
         see.
         """
-        if self._ws_setup is not None:
-            await self._ws_setup
+        # Captured before awaiting: a failed install resets _ws_setup to
+        # None, and the raise must come from the setup this caller
+        # registered under.
+        setup = self._ws_setup
+        if setup is not None:
+            await setup
 
 
     # --- Dialog Handling ---
@@ -893,6 +919,10 @@ class Page:
                 # Reset so a later listener retries; bodies are unavailable
                 # until then.
                 self._data_collector_id = None
+                if not finished.cancelled():
+                    logger.debug(
+                        "page._ensure_data_collector failed: %s", finished.exception()
+                    )
                 return
             self._data_collector_id = (finished.result() or {}).get("collector")
 

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -116,6 +116,7 @@ class Page:
         self._pending_downloads: Dict[str, Download] = {}
         self._ws_callbacks: List[Callable] = []
         self._ws_connections: Dict[int, WebSocketInfo] = {}
+        self._ws_setup: Optional[Any] = None
         self._intercept_id: Optional[str] = None
         self._data_collector_id: Optional[str] = None
 
@@ -775,14 +776,28 @@ class Page:
         })
 
     def on_web_socket(self, fn: Callable[[WebSocketInfo], None]) -> None:
-        """Listen for WebSocket connections opened by the page."""
+        """Listen for WebSocket connections opened by the page.
+
+        Monitoring is installed in the engine before the next command on this
+        connection is sent, so a socket opened by the very next call cannot be
+        missed (#351).
+        """
         is_first = len(self._ws_callbacks) == 0
         self._ws_callbacks.append(fn)
         if is_first:
-            import asyncio
-            asyncio.ensure_future(
-                self._client.send("vibium:page.onWebSocket", {"context": self._context_id})
+            self._ws_setup = self._client.send_setup(
+                "vibium:page.onWebSocket", {"context": self._context_id}
             )
+
+    async def _when_web_socket_setup(self) -> None:
+        """Wait until this page's WebSocket monitor is installed.
+
+        Raises if the install failed. The sync wrapper awaits this so its
+        blocking on_web_socket() reports a failure the async caller cannot
+        see.
+        """
+        if self._ws_setup is not None:
+            await self._ws_setup
 
 
     # --- Dialog Handling ---
@@ -864,19 +879,24 @@ class Page:
         if self._data_collector_id is not None:
             return
         self._data_collector_id = "pending"
-        import asyncio
 
-        async def _setup() -> None:
-            try:
-                result = await self._client.send(
-                    "network.addDataCollector",
-                    {"dataTypes": ["request", "response"], "maxEncodedDataSize": 10 * 1024 * 1024},
-                )
-                self._data_collector_id = result["collector"]
-            except Exception:
+        # send_setup, not ensure_future(send): the collector must exist before
+        # the request whose body a route/on_response handler is about to read
+        # (#351).
+        task = self._client.send_setup(
+            "network.addDataCollector",
+            {"dataTypes": ["request", "response"], "maxEncodedDataSize": 10 * 1024 * 1024},
+        )
+
+        def _store(finished: Any) -> None:
+            if finished.cancelled() or finished.exception() is not None:
+                # Reset so a later listener retries; bodies are unavailable
+                # until then.
                 self._data_collector_id = None
+                return
+            self._data_collector_id = (finished.result() or {}).get("collector")
 
-        asyncio.ensure_future(_setup())
+        task.add_done_callback(_store)
 
     def _teardown_data_collector(self) -> None:
         cid = self._data_collector_id

--- a/clients/python/src/vibium/client.py
+++ b/clients/python/src/vibium/client.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING
 
 from . import errors
 from .errors import BiDiError
 
 if TYPE_CHECKING:
     from .binary import VibiumProcess
+
+
+# Waiting for event setup would deadlock this one: an open dialog stops the
+# browser answering anything else for that context, including the
+# script.callFunction that installs a WebSocket monitor, and this is the only
+# command that closes the dialog. Mirrors unblocksAnotherCommand in the Go
+# router.
+_NEVER_WAITS = "browsingContext.handleUserPrompt"
 
 
 class BiDiClient:
@@ -27,6 +35,23 @@ class BiDiClient:
         self._pending: Dict[int, asyncio.Future] = {}
         self._receiver_task: Optional[asyncio.Task] = None
         self._event_handlers: List[Callable[[Dict[str, Any]], None]] = []
+        # Once the connection is gone nothing will ever resolve a response
+        # future, so a command must fail rather than wait out its timeout.
+        # The setup gate below makes this reachable: a command parked behind
+        # setup can resume after close() has already drained the pending map.
+        self._closed = False
+
+        # Event registration (page.on_web_socket, network.addDataCollector) is
+        # triggered from synchronous callback APIs with nothing for the caller
+        # to await, so its command used to be handed to ensure_future and
+        # forgotten. The next command, an evaluate that opens a socket, could
+        # reach the engine first, and the one-shot event was lost (#351).
+        #
+        # send_setup() registers a task here that send() waits for.
+        # Settle-only: this sequences commands and nothing more. A failed
+        # setup is surfaced by whoever owns that registration, not injected
+        # into an unrelated command.
+        self._pending_setups: Set[asyncio.Future] = set()
 
     @classmethod
     async def connect(cls, process: VibiumProcess) -> BiDiClient:
@@ -83,12 +108,55 @@ class BiDiClient:
         except (asyncio.CancelledError, OSError):
             pass
         finally:
+            self._closed = True
             for future in self._pending.values():
                 if not future.done():
                     future.set_exception(errors.ConnectionError("Connection closed"))
 
     async def send(self, method: str, params: Optional[Dict[str, Any]] = None, timeout: float = 60) -> Any:
-        """Send a command and wait for the response."""
+        """Send a command and wait for the response.
+
+        Waits first for any event registration still being acknowledged, so a
+        command cannot overtake the setup it depends on (#351).
+        """
+        if self._pending_setups and method != _NEVER_WAITS:
+            # wait(), not gather(): a failed registration is reported by its
+            # owner, not raised out of an unrelated command.
+            await asyncio.wait(set(self._pending_setups))
+        return await self._send(method, params, timeout)
+
+    def send_setup(
+        self,
+        method: str,
+        params: Optional[Dict[str, Any]] = None,
+        timeout: float = 60,
+    ) -> asyncio.Future:
+        """Send a command whose acknowledgement the next command depends on.
+
+        For event registration issued from a synchronous callback API, where
+        the caller has no coroutine to await (#351). Returns the task, so
+        whoever owns the registration can await it and surface a failure.
+        """
+        task = asyncio.ensure_future(self._send(method, params, timeout))
+        self._pending_setups.add(task)
+
+        def _done(finished: asyncio.Future) -> None:
+            self._pending_setups.discard(finished)
+            if not finished.cancelled():
+                # Retrieve it here so a failure the async caller cannot see is
+                # not reported as "exception was never retrieved". Awaiting
+                # the task later still raises, which is how the sync wrapper
+                # reports.
+                finished.exception()
+
+        task.add_done_callback(_done)
+        return task
+
+    async def _send(self, method: str, params: Optional[Dict[str, Any]] = None, timeout: float = 60) -> Any:
+        """Write a command and wait for its response, bypassing the setup gate."""
+        if self._closed:
+            raise errors.ConnectionError("Connection closed")
+
         msg_id = self._next_id
         self._next_id += 1
 
@@ -125,6 +193,15 @@ class BiDiClient:
 
     async def close(self) -> None:
         """Close the pipe connection."""
+        self._closed = True
+
+        # Cancelling the receiver leaves the setup tasks unresolved; drop
+        # them so a command racing close() fails on the closed connection
+        # rather than waiting for setup nobody will finish.
+        for task in list(self._pending_setups):
+            task.cancel()
+        self._pending_setups.clear()
+
         if self._receiver_task:
             self._receiver_task.cancel()
             try:

--- a/clients/python/src/vibium/sync_api/page.py
+++ b/clients/python/src/vibium/sync_api/page.py
@@ -498,11 +498,17 @@ class Page:
         """Listen for WebSocket connections opened by the page.
 
         fn receives a WebSocketInfo object with sync methods: url(), on_message(), on_close(), is_closed().
+
+        Blocks until the engine has acknowledged the monitor install, and
+        raises if it failed, the only place a sync caller can see it (#351).
         """
-        # Must run via loop thread: on_web_socket() uses asyncio.ensure_future()
-        # internally and needs a running event loop.
+        # Must run via loop thread: on_web_socket() schedules the setup
+        # command and needs a running event loop. Awaiting it here cannot
+        # deadlock: the coroutine runs on the loop thread, which stays free
+        # to run the receive loop that resolves it.
         async def _register() -> None:
             self._async.on_web_socket(fn)
+            await self._async._when_web_socket_setup()
         self._loop.run(_register())
 
     def remove_all_listeners(self, event: Optional[str] = None) -> None:

--- a/clients/python/src/vibium/sync_api/page.py
+++ b/clients/python/src/vibium/sync_api/page.py
@@ -508,7 +508,14 @@ class Page:
         # to run the receive loop that resolves it.
         async def _register() -> None:
             self._async.on_web_socket(fn)
-            await self._async._when_web_socket_setup()
+            try:
+                await self._async._when_web_socket_setup()
+            except BaseException:
+                # A raised call must have no effect: unregister so a retry
+                # registers once and re-sends the install.
+                if fn in self._async._ws_callbacks:
+                    self._async._ws_callbacks.remove(fn)
+                raise
         self._loop.run(_register())
 
     def remove_all_listeners(self, event: Optional[str] = None) -> None:

--- a/docs/tutorials/downloads-python.md
+++ b/docs/tutorials/downloads-python.md
@@ -164,12 +164,12 @@ vibe.go(base_url)
 downloads = []
 vibe.on_download(lambda dl: downloads.append(dl))
 
-# The subscription activates in the background, so a click right after
-# subscribing can go untracked. Click again until the download appears.
+vibe.find("#dl-link").click()
+
+# The download event arrives asynchronously; poll briefly for it.
 deadline = time.time() + 15
 while not downloads and time.time() < deadline:
-    vibe.find("#dl-link").click()
-    time.sleep(0.5)
+    time.sleep(0.1)
 
 assert len(downloads) >= 1
 assert downloads[0].suggested_filename() == "hello.txt"

--- a/tests/js/async/engine/websocket.test.js
+++ b/tests/js/async/engine/websocket.test.js
@@ -14,11 +14,6 @@ const { WebSocketServer } = require('ws');
 const { browser } = require('../../../../clients/javascript/dist');
 const { withTimeout } = require('../../helpers/wait');
 
-// onWebSocket() is sync (fire-and-forget under the hood, see page.ts:945).
-// Server-side preload-script install races with the next client command.
-// 200ms is the hedge until onWebSocket becomes properly async.
-const INSTALL_BARRIER_MS = 200;
-
 // --- Local test servers ---
 
 let httpServer;
@@ -90,7 +85,6 @@ describe('WebSocket Monitoring: page.onWebSocket', () => {
     const vibe = await freshPage();
     try {
       const wsCreated = new Promise((resolve) => vibe.onWebSocket(() => resolve()));
-      await vibe.wait(INSTALL_BARRIER_MS);
       await vibe.evaluate(`window.createWS('${wsURL}')`);
       await withTimeout(wsCreated, 5000, 'onWebSocket to fire');
     } finally {
@@ -108,7 +102,6 @@ describe('WebSocket Monitoring: page.onWebSocket', () => {
           resolve();
         }),
       );
-      await vibe.wait(INSTALL_BARRIER_MS);
       await vibe.evaluate(`window.createWS('${wsURL}')`);
       await withTimeout(gotUrl, 5000, 'WS URL to be captured');
 
@@ -130,8 +123,6 @@ describe('WebSocket Monitoring: page.onWebSocket', () => {
           });
         }),
       );
-
-      await vibe.wait(INSTALL_BARRIER_MS);
       await vibe.evaluate(`
         const ws = window.createWS('${wsURL}');
         ws.onopen = () => ws.send('hello');
@@ -158,8 +149,6 @@ describe('WebSocket Monitoring: page.onWebSocket', () => {
           });
         }),
       );
-
-      await vibe.wait(INSTALL_BARRIER_MS);
       await vibe.evaluate(`
         const ws = window.createWS('${wsURL}');
         ws.onopen = () => ws.send('echo-me');
@@ -186,8 +175,6 @@ describe('WebSocket Monitoring: page.onWebSocket', () => {
           });
         }),
       );
-
-      await vibe.wait(INSTALL_BARRIER_MS);
       await vibe.evaluate(`
         const ws = window.createWS('${wsURL}');
         ws.onopen = () => ws.close(1000, 'done');
@@ -210,8 +197,6 @@ describe('WebSocket Monitoring: page.onWebSocket', () => {
           ws.onClose(() => resolve());
         }),
       );
-
-      await vibe.wait(INSTALL_BARRIER_MS);
       await vibe.evaluate(`
         const ws = window.createWS('${wsURL}');
         ws.onopen = () => ws.close();
@@ -244,8 +229,6 @@ describe('WebSocket Monitoring: page.onWebSocket', () => {
       });
       const nextWs = () => new Promise((resolve) => wsWaiters.push(resolve));
 
-      await vibe.wait(INSTALL_BARRIER_MS);
-
       // Create WS on first page
       const firstSeen = nextWs();
       await vibe.evaluate(`window.createWS('${wsURL}')`);
@@ -274,8 +257,6 @@ describe('WebSocket Monitoring: page.onWebSocket', () => {
           resolve();
         }),
       );
-
-      await vibe.wait(INSTALL_BARRIER_MS);
       await vibe.evaluate(`window.createWS('${wsURL}')`);
       await withTimeout(firstSeen, 5000, 'first WS captured');
       assert.strictEqual(wsCount, 1);

--- a/tests/js/async/event-setup-ordering.test.js
+++ b/tests/js/async/event-setup-ordering.test.js
@@ -1,0 +1,77 @@
+/**
+ * JS Library Tests: event-setup ordering (#351)
+ *
+ * page.onWebSocket() is a void callback API, so its install command had
+ * nothing for the caller to await. A socket opened by the very next command
+ * could beat the install and its one-shot event was lost.
+ *
+ * helpers/fake-engine.js stands in for the binary: it installs slowly and
+ * only reports a socket once the install is answered, so these tests assert
+ * ordering rather than how fast a browser happens to be.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+const { browser } = require('../../../clients/javascript/dist');
+
+const FAKE_ENGINE = path.join(__dirname, '..', 'helpers', 'fake-engine.js');
+
+// The stand-in is a shebang script, which Windows cannot spawn as a binary.
+const describeFn = process.platform === 'win32' ? describe.skip : describe;
+
+async function withFakeEngine(fn) {
+  const bro = await browser.start({ headless: true, executablePath: FAKE_ENGINE });
+  try {
+    await fn(await bro.page());
+  } finally {
+    await bro.stop();
+  }
+}
+
+describeFn('Event setup ordering: page.onWebSocket', () => {
+  test('a socket opened by the very next command is still seen', async () => {
+    await withFakeEngine(async (vibe) => {
+      const seen = [];
+      vibe.onWebSocket((ws) => seen.push(ws.url()));
+      // No await in between: the exact shape that used to lose the event.
+      await vibe.evaluate('openSocket()');
+
+      assert.deepStrictEqual(seen, ['ws://127.0.0.1:1/live'],
+        'the command overtook the monitor install, so its socket went unseen');
+    });
+  });
+
+  test('registering twice installs the monitor once', async () => {
+    await withFakeEngine(async (vibe) => {
+      const seen = [];
+      vibe.onWebSocket(() => seen.push('a'));
+      vibe.onWebSocket(() => seen.push('b'));
+      await vibe.evaluate('openSocket()');
+
+      // A second install would have re-armed the gate and restarted the delay.
+      assert.deepStrictEqual(seen, ['a', 'b']);
+    });
+  });
+
+  test('a command parked behind setup fails when the connection closes', async () => {
+    // Closing the client directly rather than via stop() is the point: stop()
+    // itself goes through the gate, so it cannot close the connection while a
+    // command is still parked behind setup. That window is what this covers.
+    const bro = await browser.start({ headless: true, executablePath: FAKE_ENGINE });
+    try {
+      const vibe = await bro.page();
+      vibe.onWebSocket(() => {});
+      const held = vibe.evaluate('1');
+      held.catch(() => {});
+
+      await vibe.client.close();
+
+      await assert.rejects(held, /Connection closed/,
+        'a command parked behind setup must fail once the connection is gone');
+    } finally {
+      await bro.stop().catch(() => {});
+    }
+  });
+});

--- a/tests/js/async/event-setup-ordering.test.js
+++ b/tests/js/async/event-setup-ordering.test.js
@@ -50,9 +50,33 @@ describeFn('Event setup ordering: page.onWebSocket', () => {
       vibe.onWebSocket(() => seen.push('b'));
       await vibe.evaluate('openSocket()');
 
-      // A second install would have re-armed the gate and restarted the delay.
       assert.deepStrictEqual(seen, ['a', 'b']);
+      assert.strictEqual(await vibe.evaluate('__installCount'), 1,
+        'a second registration re-sent the install command');
     });
+  });
+
+  test('a failed install is retried by the next registration', async () => {
+    // The stand-in reads this at startup, so set it before launching. Safe to
+    // mutate here: node --test gives each test file its own process.
+    process.env.FAKE_ENGINE_FAIL_SETUP = 'once';
+    try {
+      await withFakeEngine(async (vibe) => {
+        const seen = [];
+        vibe.onWebSocket(() => seen.push('a'));
+        // Wait for the failure to land; the async API only debug-logs it.
+        await vibe._whenWebSocketSetup().catch(() => {});
+        vibe.onWebSocket(() => seen.push('b'));
+        await vibe.evaluate('openSocket()');
+
+        assert.deepStrictEqual(seen, ['a', 'b'],
+          'the second registration must retry the install, healing the first callback too');
+        assert.strictEqual(await vibe.evaluate('__installCount'), 2,
+          'the retry must re-send the install command');
+      });
+    } finally {
+      delete process.env.FAKE_ENGINE_FAIL_SETUP;
+    }
   });
 
   test('a command parked behind setup fails when the connection closes', async () => {

--- a/tests/js/helpers/fake-engine.js
+++ b/tests/js/helpers/fake-engine.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * A stand-in for the vibium binary, for tests that assert command ordering
+ * rather than browser behavior.
+ *
+ * It answers vibium:page.onWebSocket after a delay and reports a socket only
+ * once that install has been answered, like the real router, which replies
+ * after subscribing and injecting the monitor. A client that fires the install
+ * and moves on loses the event its next command produces (#351).
+ *
+ * Point a client at it with browser.start({ executablePath }).
+ * FAKE_ENGINE_SETUP_DELAY_MS adjusts the install delay (default 300).
+ * FAKE_ENGINE_FAIL_SETUP=1 makes the install fail.
+ */
+
+const readline = require('readline');
+
+const SETUP_DELAY_MS = Number(process.env.FAKE_ENGINE_SETUP_DELAY_MS || 300);
+const FAIL_SETUP = process.env.FAKE_ENGINE_FAIL_SETUP === '1';
+
+// The clients run `vibium is-installed` before launching.
+if (process.argv[2] === 'is-installed') process.exit(0);
+
+let monitorInstalled = false;
+const write = (msg) => process.stdout.write(JSON.stringify(msg) + '\n');
+const ok = (id, result = {}) => write({ id, type: 'success', result });
+
+write({ method: 'vibium:lifecycle.ready', params: {} });
+
+readline.createInterface({ input: process.stdin, crlfDelay: Infinity }).on('line', (line) => {
+  if (!line.trim()) return;
+  const { id, method, params = {} } = JSON.parse(line);
+
+  switch (method) {
+    case 'vibium:browser.page':
+    case 'vibium:browser.newPage':
+      return ok(id, { context: 'ctx-1', userContext: 'default' });
+
+    case 'vibium:page.onWebSocket':
+      return setTimeout(() => {
+        if (FAIL_SETUP) {
+          return write({ id, type: 'error', error: 'unsupported operation', message: 'no preload scripts here' });
+        }
+        monitorInstalled = true;
+        ok(id);
+      }, SETUP_DELAY_MS);
+
+    case 'vibium:page.eval':
+      // Stands in for `new WebSocket(...)`: only a live monitor sees it.
+      if (monitorInstalled && String(params.expression || '').includes('openSocket')) {
+        write({ method: 'vibium:ws.created', params: { context: 'ctx-1', id: 1, url: 'ws://127.0.0.1:1/live' } });
+      }
+      return ok(id, { value: null });
+
+    default:
+      return ok(id);
+  }
+});

--- a/tests/js/helpers/fake-engine.js
+++ b/tests/js/helpers/fake-engine.js
@@ -10,18 +10,20 @@
  *
  * Point a client at it with browser.start({ executablePath }).
  * FAKE_ENGINE_SETUP_DELAY_MS adjusts the install delay (default 300).
- * FAKE_ENGINE_FAIL_SETUP=1 makes the install fail.
+ * FAKE_ENGINE_FAIL_SETUP=1 makes every install fail; =once fails only the
+ * first, so tests can pin that a failed install is retried.
  */
 
 const readline = require('readline');
 
 const SETUP_DELAY_MS = Number(process.env.FAKE_ENGINE_SETUP_DELAY_MS || 300);
-const FAIL_SETUP = process.env.FAKE_ENGINE_FAIL_SETUP === '1';
+const FAIL_SETUP = process.env.FAKE_ENGINE_FAIL_SETUP || '';
 
 // The clients run `vibium is-installed` before launching.
 if (process.argv[2] === 'is-installed') process.exit(0);
 
 let monitorInstalled = false;
+let installCount = 0;
 const write = (msg) => process.stdout.write(JSON.stringify(msg) + '\n');
 const ok = (id, result = {}) => write({ id, type: 'success', result });
 
@@ -36,16 +38,27 @@ readline.createInterface({ input: process.stdin, crlfDelay: Infinity }).on('line
     case 'vibium:browser.newPage':
       return ok(id, { context: 'ctx-1', userContext: 'default' });
 
-    case 'vibium:page.onWebSocket':
+    case 'vibium:page.onWebSocket': {
+      // Counted before deciding failure, so __installCount below includes
+      // failed attempts and a test can pin that a retry re-sent the install.
+      installCount++;
+      const fail = FAIL_SETUP === '1' || (FAIL_SETUP === 'once' && installCount === 1);
       return setTimeout(() => {
-        if (FAIL_SETUP) {
+        if (fail) {
           return write({ id, type: 'error', error: 'unsupported operation', message: 'no preload scripts here' });
         }
         monitorInstalled = true;
         ok(id);
       }, SETUP_DELAY_MS);
+    }
 
     case 'vibium:page.eval':
+      // Test back-channel, not protocol behavior: reports how many installs
+      // this engine was sent. Race-free because the eval goes through the
+      // gate, so any pending install is answered before this is.
+      if (String(params.expression || '') === '__installCount') {
+        return ok(id, { value: installCount });
+      }
       // Stands in for `new WebSocket(...)`: only a live monitor sees it.
       if (monitorInstalled && String(params.expression || '').includes('openSocket')) {
         write({ method: 'vibium:ws.created', params: { context: 'ctx-1', id: 1, url: 'ws://127.0.0.1:1/live' } });

--- a/tests/js/sync/engine/websocket-sync.test.js
+++ b/tests/js/sync/engine/websocket-sync.test.js
@@ -63,7 +63,6 @@ describe('Sync API: onWebSocket', () => {
       wsCreated = true;
     });
 
-    vibe.wait(200);
     vibe.evaluate(`window.createWS('${wsURL}')`);
     vibe.wait(1000);
 
@@ -79,7 +78,6 @@ describe('Sync API: onWebSocket', () => {
       capturedUrl = ws.url();
     });
 
-    vibe.wait(200);
     vibe.evaluate(`window.createWS('${wsURL}')`);
     vibe.wait(1000);
 
@@ -97,7 +95,6 @@ describe('Sync API: onWebSocket', () => {
       });
     });
 
-    vibe.wait(200);
     vibe.evaluate(`
       const ws = window.createWS('${wsURL}');
       ws.onopen = () => ws.send('hello');
@@ -120,7 +117,6 @@ describe('Sync API: onWebSocket', () => {
       });
     });
 
-    vibe.wait(200);
     vibe.evaluate(`
       const ws = window.createWS('${wsURL}');
       ws.onopen = () => ws.send('echo-me');
@@ -145,7 +141,6 @@ describe('Sync API: onWebSocket', () => {
       });
     });
 
-    vibe.wait(200);
     vibe.evaluate(`
       const ws = window.createWS('${wsURL}');
       ws.onopen = () => ws.close(1000, 'done');
@@ -166,7 +161,6 @@ describe('Sync API: onWebSocket', () => {
       ws.onClose(() => {});
     });
 
-    vibe.wait(200);
     vibe.evaluate(`
       const ws = window.createWS('${wsURL}');
       ws.onopen = () => ws.close();
@@ -186,7 +180,6 @@ describe('Sync API: onWebSocket', () => {
       wsCount++;
     });
 
-    vibe.wait(200);
     vibe.evaluate(`window.createWS('${wsURL}')`);
     vibe.wait(1000);
     assert.strictEqual(wsCount, 1);

--- a/tests/js/sync/event-setup-ordering-sync.test.js
+++ b/tests/js/sync/event-setup-ordering-sync.test.js
@@ -54,4 +54,27 @@ describeFn('Sync event setup ordering: page.onWebSocket', () => {
       delete process.env.FAKE_ENGINE_FAIL_SETUP;
     }
   });
+
+  test('catching a rejected install and retrying works', () => {
+    process.env.FAKE_ENGINE_FAIL_SETUP = 'once';
+    try {
+      withFakeEngine((vibe) => {
+        const seen = [];
+        const callback = (ws) => seen.push(ws.url());
+        assert.throws(() => vibe.onWebSocket(callback), /no preload scripts here/);
+        vibe.onWebSocket(callback);
+        vibe.evaluate('openSocket()');
+        // Drain: the event reached the worker with the response above.
+        vibe.evaluate('1');
+
+        // Exactly once: the retry re-sent the install, and the raised call
+        // left no duplicate registration behind.
+        assert.deepStrictEqual(seen, ['ws://127.0.0.1:1/live']);
+        assert.strictEqual(vibe.evaluate('__installCount'), 2,
+          'the retry must re-send the install command');
+      });
+    } finally {
+      delete process.env.FAKE_ENGINE_FAIL_SETUP;
+    }
+  });
 });

--- a/tests/js/sync/event-setup-ordering-sync.test.js
+++ b/tests/js/sync/event-setup-ordering-sync.test.js
@@ -1,0 +1,57 @@
+/**
+ * Sync JS Library Tests: event-setup ordering (#351)
+ *
+ * The sync API has no promise for the caller to hold, so its blocking
+ * onWebSocket() must not return until the engine has acknowledged the
+ * install, and must raise if the install was rejected, the only place a
+ * sync caller can see it. See ../helpers/fake-engine.js.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+const { browser } = require('../../../clients/javascript/dist/sync');
+
+const FAKE_ENGINE = path.join(__dirname, '..', 'helpers', 'fake-engine.js');
+
+// The stand-in is a shebang script, which Windows cannot spawn as a binary.
+const describeFn = process.platform === 'win32' ? describe.skip : describe;
+
+function withFakeEngine(fn) {
+  const bro = browser.start({ headless: true, executablePath: FAKE_ENGINE });
+  try {
+    fn(bro.page());
+  } finally {
+    bro.stop();
+  }
+}
+
+describeFn('Sync event setup ordering: page.onWebSocket', () => {
+  test('a socket opened by the very next call is still seen', () => {
+    withFakeEngine((vibe) => {
+      const seen = [];
+      vibe.onWebSocket((ws) => seen.push(ws.url()));
+      vibe.evaluate('openSocket()');
+      // Drain: the event reached the worker with the response above.
+      vibe.evaluate('1');
+
+      assert.deepStrictEqual(seen, ['ws://127.0.0.1:1/live'],
+        'onWebSocket returned before the install was acknowledged, so the socket went unseen');
+    });
+  });
+
+  test('a rejected install raises from onWebSocket', () => {
+    // The stand-in reads this at startup, so set it before launching. Safe to
+    // mutate here: node --test gives each test file its own process.
+    process.env.FAKE_ENGINE_FAIL_SETUP = '1';
+    try {
+      withFakeEngine((vibe) => {
+        assert.throws(() => vibe.onWebSocket(() => {}), /no preload scripts here/,
+          'a rejected install must reach the sync caller instead of being swallowed');
+      });
+    } finally {
+      delete process.env.FAKE_ENGINE_FAIL_SETUP;
+    }
+  });
+});

--- a/tests/py/engine/test_sync_websocket.py
+++ b/tests/py/engine/test_sync_websocket.py
@@ -54,7 +54,6 @@ def test_fires(sync_browser, test_server, sync_ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    vibe.wait(500)
 
     vibe.evaluate(f"createWS('{sync_ws_echo_server}')")
     vibe.wait(1000)
@@ -68,7 +67,6 @@ def test_url(sync_browser, test_server, sync_ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    vibe.wait(500)
 
     vibe.evaluate(f"createWS('{sync_ws_echo_server}')")
     vibe.wait(1000)
@@ -83,7 +81,6 @@ def test_on_message_sent(sync_browser, test_server, sync_ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    vibe.wait(500)
 
     vibe.evaluate(f"window.__ws = createWS('{sync_ws_echo_server}')")
     vibe.wait(1000)
@@ -108,7 +105,6 @@ def test_on_close(sync_browser, test_server, sync_ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    vibe.wait(500)
 
     vibe.evaluate(f"window.__ws = createWS('{sync_ws_echo_server}')")
     vibe.wait(1000)
@@ -129,7 +125,6 @@ def test_is_closed(sync_browser, test_server, sync_ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    vibe.wait(500)
 
     vibe.evaluate(f"window.__ws = createWS('{sync_ws_echo_server}')")
     vibe.wait(1000)

--- a/tests/py/engine/test_websocket.py
+++ b/tests/py/engine/test_websocket.py
@@ -13,24 +13,6 @@ async def _wait_for(vibe, condition, timeout_ms=15000):
         waited += 100
 
 
-async def _subscribed(vibe, ws_echo_server, ws_connections):
-    """Prove the onWebSocket subscription is active before the real test runs.
-
-    The client sends the subscribe command without awaiting it, so an early
-    createWS can race it, and the one-shot created event is then lost for
-    good. Probe with throwaway sockets until one is tracked, then drain
-    stragglers and reset.
-    """
-    for _ in range(100):
-        await vibe.evaluate(f"createWS('{ws_echo_server}').close()")
-        await _wait_for(vibe, lambda: ws_connections, timeout_ms=200)
-        if ws_connections:
-            await vibe.wait(300)
-            ws_connections.clear()
-            return
-    raise AssertionError("onWebSocket subscription never became active")
-
-
 async def _ws_open(vibe):
     """Wait for window.__ws to reach OPEN; send() on CONNECTING throws."""
     for _ in range(150):
@@ -47,7 +29,6 @@ async def test_fires(fresh_async_browser, test_server, ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    await _subscribed(vibe, ws_echo_server, ws_connections)
 
     await vibe.evaluate(f"createWS('{ws_echo_server}')")
     await _wait_for(vibe, lambda: ws_connections)
@@ -61,7 +42,6 @@ async def test_url(fresh_async_browser, test_server, ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    await _subscribed(vibe, ws_echo_server, ws_connections)
 
     await vibe.evaluate(f"createWS('{ws_echo_server}')")
     await _wait_for(vibe, lambda: ws_connections)
@@ -76,7 +56,6 @@ async def test_on_message_sent(fresh_async_browser, test_server, ws_echo_server)
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    await _subscribed(vibe, ws_echo_server, ws_connections)
 
     await vibe.evaluate(f"window.__ws = createWS('{ws_echo_server}')")
     await _wait_for(vibe, lambda: ws_connections)
@@ -100,7 +79,6 @@ async def test_on_message_received(fresh_async_browser, test_server, ws_echo_ser
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    await _subscribed(vibe, ws_echo_server, ws_connections)
 
     await vibe.evaluate(f"window.__ws = createWS('{ws_echo_server}')")
     await _wait_for(vibe, lambda: ws_connections)
@@ -124,7 +102,6 @@ async def test_on_close(fresh_async_browser, test_server, ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    await _subscribed(vibe, ws_echo_server, ws_connections)
 
     await vibe.evaluate(f"window.__ws = createWS('{ws_echo_server}')")
     await _wait_for(vibe, lambda: ws_connections)
@@ -145,7 +122,6 @@ async def test_is_closed(fresh_async_browser, test_server, ws_echo_server):
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    await _subscribed(vibe, ws_echo_server, ws_connections)
 
     await vibe.evaluate(f"window.__ws = createWS('{ws_echo_server}')")
     await _wait_for(vibe, lambda: ws_connections)
@@ -164,7 +140,6 @@ async def test_survives_navigation(fresh_async_browser, test_server, ws_echo_ser
 
     ws_connections = []
     vibe.on_web_socket(lambda ws: ws_connections.append(ws))
-    await _subscribed(vibe, ws_echo_server, ws_connections)
 
     await vibe.evaluate(f"createWS('{ws_echo_server}')")
     await _wait_for(vibe, lambda: ws_connections)

--- a/tests/py/helpers/fake_engine.py
+++ b/tests/py/helpers/fake_engine.py
@@ -9,7 +9,8 @@ and moves on loses the event its next command produces (#351).
 
 Point a client at it with browser.start(executable_path=...).
 FAKE_ENGINE_SETUP_DELAY_MS adjusts the install delay (default 300).
-FAKE_ENGINE_FAIL_SETUP=1 makes the install fail.
+FAKE_ENGINE_FAIL_SETUP=1 makes every install fail; =once fails only the
+first, so tests can pin that a failed install is retried.
 """
 
 import json
@@ -18,7 +19,7 @@ import sys
 import threading
 
 SETUP_DELAY_S = float(os.environ.get("FAKE_ENGINE_SETUP_DELAY_MS", "300")) / 1000
-FAIL_SETUP = os.environ.get("FAKE_ENGINE_FAIL_SETUP") == "1"
+FAIL_SETUP = os.environ.get("FAKE_ENGINE_FAIL_SETUP", "")
 
 # The clients run `vibium is-installed` before launching.
 if len(sys.argv) > 1 and sys.argv[1] == "is-installed":
@@ -26,6 +27,7 @@ if len(sys.argv) > 1 and sys.argv[1] == "is-installed":
 
 _lock = threading.Lock()
 _monitor_installed = False
+_install_count = 0
 
 
 def write(msg):
@@ -38,9 +40,9 @@ def ok(cmd_id, result=None):
     write({"id": cmd_id, "type": "success", "result": result or {}})
 
 
-def install_monitor(cmd_id):
+def install_monitor(cmd_id, fail):
     global _monitor_installed
-    if FAIL_SETUP:
+    if fail:
         write({"id": cmd_id, "type": "error", "error": "unsupported operation",
                "message": "no preload scripts here"})
         return
@@ -59,12 +61,22 @@ for line in sys.stdin:
     if method in ("vibium:browser.page", "vibium:browser.newPage"):
         ok(cmd_id, {"context": "ctx-1", "userContext": "default"})
     elif method == "vibium:page.onWebSocket":
-        threading.Timer(SETUP_DELAY_S, install_monitor, [cmd_id]).start()
+        # Counted before deciding failure, so __installCount below includes
+        # failed attempts and a test can pin that a retry re-sent the install.
+        _install_count += 1
+        fail = FAIL_SETUP == "1" or (FAIL_SETUP == "once" and _install_count == 1)
+        threading.Timer(SETUP_DELAY_S, install_monitor, [cmd_id, fail]).start()
     elif method == "vibium:page.eval":
-        # Stands in for `new WebSocket(...)`: only a live monitor sees it.
-        if _monitor_installed and "openSocket" in str(params.get("expression", "")):
-            write({"method": "vibium:ws.created",
-                   "params": {"context": "ctx-1", "id": 1, "url": "ws://127.0.0.1:1/live"}})
-        ok(cmd_id, {"value": None})
+        # Test back-channel, not protocol behavior: reports how many installs
+        # this engine was sent. Race-free because the eval goes through the
+        # gate, so any pending install is answered before this is.
+        if str(params.get("expression", "")) == "__installCount":
+            ok(cmd_id, {"value": _install_count})
+        else:
+            # Stands in for `new WebSocket(...)`: only a live monitor sees it.
+            if _monitor_installed and "openSocket" in str(params.get("expression", "")):
+                write({"method": "vibium:ws.created",
+                       "params": {"context": "ctx-1", "id": 1, "url": "ws://127.0.0.1:1/live"}})
+            ok(cmd_id, {"value": None})
     else:
         ok(cmd_id)

--- a/tests/py/helpers/fake_engine.py
+++ b/tests/py/helpers/fake_engine.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""A stand-in for the vibium binary, for tests that assert command ordering
+rather than browser behavior.
+
+It answers vibium:page.onWebSocket after a delay and reports a socket only
+once that install has been answered, like the real router, which replies
+after subscribing and injecting the monitor. A client that fires the install
+and moves on loses the event its next command produces (#351).
+
+Point a client at it with browser.start(executable_path=...).
+FAKE_ENGINE_SETUP_DELAY_MS adjusts the install delay (default 300).
+FAKE_ENGINE_FAIL_SETUP=1 makes the install fail.
+"""
+
+import json
+import os
+import sys
+import threading
+
+SETUP_DELAY_S = float(os.environ.get("FAKE_ENGINE_SETUP_DELAY_MS", "300")) / 1000
+FAIL_SETUP = os.environ.get("FAKE_ENGINE_FAIL_SETUP") == "1"
+
+# The clients run `vibium is-installed` before launching.
+if len(sys.argv) > 1 and sys.argv[1] == "is-installed":
+    sys.exit(0)
+
+_lock = threading.Lock()
+_monitor_installed = False
+
+
+def write(msg):
+    with _lock:
+        sys.stdout.write(json.dumps(msg) + "\n")
+        sys.stdout.flush()
+
+
+def ok(cmd_id, result=None):
+    write({"id": cmd_id, "type": "success", "result": result or {}})
+
+
+def install_monitor(cmd_id):
+    global _monitor_installed
+    if FAIL_SETUP:
+        write({"id": cmd_id, "type": "error", "error": "unsupported operation",
+               "message": "no preload scripts here"})
+        return
+    _monitor_installed = True
+    ok(cmd_id)
+
+
+write({"method": "vibium:lifecycle.ready", "params": {}})
+
+for line in sys.stdin:
+    if not line.strip():
+        continue
+    cmd = json.loads(line)
+    cmd_id, method, params = cmd.get("id"), cmd.get("method"), cmd.get("params") or {}
+
+    if method in ("vibium:browser.page", "vibium:browser.newPage"):
+        ok(cmd_id, {"context": "ctx-1", "userContext": "default"})
+    elif method == "vibium:page.onWebSocket":
+        threading.Timer(SETUP_DELAY_S, install_monitor, [cmd_id]).start()
+    elif method == "vibium:page.eval":
+        # Stands in for `new WebSocket(...)`: only a live monitor sees it.
+        if _monitor_installed and "openSocket" in str(params.get("expression", "")):
+            write({"method": "vibium:ws.created",
+                   "params": {"context": "ctx-1", "id": 1, "url": "ws://127.0.0.1:1/live"}})
+        ok(cmd_id, {"value": None})
+    else:
+        ok(cmd_id)

--- a/tests/py/test_event_setup_ordering.py
+++ b/tests/py/test_event_setup_ordering.py
@@ -58,8 +58,39 @@ async def test_registering_twice_installs_the_monitor_once(page):
     page.on_web_socket(lambda ws: seen.append("b"))
     await page.evaluate("openSocket()")
 
-    # A second install would have re-armed the gate and restarted the delay.
     assert seen == ["a", "b"]
+    assert await page.evaluate("__installCount") == 1, (
+        "a second registration re-sent the install command"
+    )
+
+
+async def test_failed_install_is_retried_by_the_next_registration(monkeypatch):
+    # The stand-in reads this at startup, so set it before launching.
+    monkeypatch.setenv("FAKE_ENGINE_FAIL_SETUP", "once")
+    from vibium.async_api import browser
+
+    bro = await browser.start(headless=True, executable_path=FAKE_ENGINE)
+    try:
+        page = await bro.page()
+        seen = []
+        page.on_web_socket(lambda ws: seen.append("a"))
+        # Wait for the failure to land; the async API only debug-logs it.
+        try:
+            await page._when_web_socket_setup()
+        except Exception:
+            pass
+        page.on_web_socket(lambda ws: seen.append("b"))
+        await page.evaluate("openSocket()")
+
+        assert seen == ["a", "b"], (
+            "the second registration must retry the install, "
+            "healing the first callback too"
+        )
+        assert await page.evaluate("__installCount") == 2, (
+            "the retry must re-send the install command"
+        )
+    finally:
+        await bro.stop()
 
 
 async def test_command_parked_behind_setup_fails_when_the_connection_closes(page):

--- a/tests/py/test_event_setup_ordering.py
+++ b/tests/py/test_event_setup_ordering.py
@@ -1,0 +1,78 @@
+"""Event-setup ordering tests (#351).
+
+page.on_web_socket() is a void callback API, so its install command had
+nothing for the caller to await. A socket opened by the very next command
+could beat the install and its one-shot event was lost.
+
+helpers/fake_engine.py stands in for the binary: it installs slowly and only
+reports a socket once the install is answered, so these tests assert ordering
+rather than how fast a browser happens to be.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+import pytest_asyncio
+
+FAKE_ENGINE = os.path.join(os.path.dirname(__file__), "helpers", "fake_engine.py")
+
+pytestmark = [
+    # The stand-in is a shebang script, which Windows cannot spawn as a binary.
+    pytest.mark.skipif(
+        sys.platform == "win32", reason="shebang script not spawnable on Windows"
+    ),
+    # Tests default to the module-scoped loop (pytest.ini), but the fixture
+    # below runs on a function-scoped one. Everything must share a loop or
+    # the receiver resolves futures the test loop never wakes up for.
+    pytest.mark.asyncio(loop_scope="function"),
+]
+
+
+@pytest_asyncio.fixture
+async def page():
+    from vibium.async_api import browser
+
+    bro = await browser.start(headless=True, executable_path=FAKE_ENGINE)
+    try:
+        yield await bro.page()
+    finally:
+        await bro.stop()
+
+
+async def test_socket_opened_by_next_command_is_still_seen(page):
+    seen = []
+    page.on_web_socket(lambda ws: seen.append(ws.url()))
+    # No await in between: the exact shape that used to lose the event.
+    await page.evaluate("openSocket()")
+
+    assert seen == ["ws://127.0.0.1:1/live"], (
+        "the command overtook the monitor install, so its socket went unseen"
+    )
+
+
+async def test_registering_twice_installs_the_monitor_once(page):
+    seen = []
+    page.on_web_socket(lambda ws: seen.append("a"))
+    page.on_web_socket(lambda ws: seen.append("b"))
+    await page.evaluate("openSocket()")
+
+    # A second install would have re-armed the gate and restarted the delay.
+    assert seen == ["a", "b"]
+
+
+async def test_command_parked_behind_setup_fails_when_the_connection_closes(page):
+    # Closing the client directly rather than via stop() is the point: stop()
+    # itself goes through the gate, so it cannot close the connection while a
+    # command is still parked behind setup. That window is what this covers.
+    from vibium import errors
+
+    page.on_web_socket(lambda ws: None)
+    held = asyncio.ensure_future(page.evaluate("1"))
+    await asyncio.sleep(0)  # let it reach the gate
+
+    await page._client.close()
+
+    with pytest.raises(errors.ConnectionError):
+        await asyncio.wait_for(held, timeout=5)

--- a/tests/py/test_sync_event_setup_ordering.py
+++ b/tests/py/test_sync_event_setup_ordering.py
@@ -54,3 +54,29 @@ def test_rejected_install_raises_from_on_web_socket(monkeypatch):
             bro.page().on_web_socket(lambda ws: None)
     finally:
         bro.stop()
+
+
+def test_catching_a_rejected_install_and_retrying_works(monkeypatch):
+    monkeypatch.setenv("FAKE_ENGINE_FAIL_SETUP", "once")
+    from vibium import browser
+
+    bro = browser.start(headless=True, executable_path=FAKE_ENGINE)
+    try:
+        page = bro.page()
+        seen = []
+        callback = lambda ws: seen.append(ws.url())  # noqa: E731
+        with pytest.raises(Exception, match="no preload scripts here"):
+            page.on_web_socket(callback)
+        page.on_web_socket(callback)
+        page.evaluate("openSocket()")
+        # Drain: the event reached the loop thread with the response above.
+        page.evaluate("1")
+
+        # Exactly once: the retry re-sent the install, and the raised call
+        # left no duplicate registration behind.
+        assert seen == ["ws://127.0.0.1:1/live"]
+        assert page.evaluate("__installCount") == 2, (
+            "the retry must re-send the install command"
+        )
+    finally:
+        bro.stop()

--- a/tests/py/test_sync_event_setup_ordering.py
+++ b/tests/py/test_sync_event_setup_ordering.py
@@ -1,0 +1,56 @@
+"""Sync event-setup ordering tests (#351).
+
+The sync API has no coroutine for the caller to await, so its blocking
+on_web_socket() must not return until the engine has acknowledged the
+install, and must raise if the install was rejected, the only place a sync
+caller can see it. See helpers/fake_engine.py.
+"""
+
+import os
+import sys
+
+import pytest
+
+FAKE_ENGINE = os.path.join(os.path.dirname(__file__), "helpers", "fake_engine.py")
+
+# The stand-in is a shebang script, which Windows cannot spawn as a binary.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="shebang script not spawnable on Windows"
+)
+
+
+@pytest.fixture
+def sync_page():
+    from vibium import browser
+
+    bro = browser.start(headless=True, executable_path=FAKE_ENGINE)
+    try:
+        yield bro.page()
+    finally:
+        bro.stop()
+
+
+def test_socket_opened_by_next_call_is_still_seen(sync_page):
+    seen = []
+    sync_page.on_web_socket(lambda ws: seen.append(ws.url()))
+    sync_page.evaluate("openSocket()")
+    # Drain: the event reached the loop thread with the response above.
+    sync_page.evaluate("1")
+
+    assert seen == ["ws://127.0.0.1:1/live"], (
+        "on_web_socket returned before the install was acknowledged, "
+        "so the socket went unseen"
+    )
+
+
+def test_rejected_install_raises_from_on_web_socket(monkeypatch):
+    # The stand-in reads this at startup, so set it before launching.
+    monkeypatch.setenv("FAKE_ENGINE_FAIL_SETUP", "1")
+    from vibium import browser
+
+    bro = browser.start(headless=True, executable_path=FAKE_ENGINE)
+    try:
+        with pytest.raises(Exception, match="no preload scripts here"):
+            bro.page().on_web_socket(lambda ws: None)
+    finally:
+        bro.stop()


### PR DESCRIPTION
Fixes #351.

Event setup commands were sent without awaiting acknowledgment, so a user action issued right after registering a listener could beat the setup and the one-shot event was lost. Three sends had the problem: the JS client's `onWebSocket`, the Python client's `on_web_socket`, and the router's `setupDownloads` goroutine.

## What changed

- Both clients now route event registration through a setup gate in the BiDi client's send funnel. Registration methods stay synchronous and void; the next command on the connection waits until the registration is acknowledged. The data-collector install used by `onRequest`/`onResponse`/`route` had the identical fire-and-forget shape and goes through the same gate.
- The dialog-unblock command (`browsingContext.handleUserPrompt`) bypasses the gate. An open dialog blocks the monitor install for that context, so a gated unblock could never dispatch. This mirrors `unblocksAnotherCommand` in the router.
- If the connection closes while a command is parked behind the gate, the command fails fast with the connection-closed error instead of waiting out its timeout.
- Setup failure is recoverable and visible. Both async callback APIs debug-log a failed install (JS via `debug`, Python via the stdlib `vibium` logger; their signatures stay void), and a failed install resets the setup state so the next registration retries it, healing callbacks that were already registered. The blocking sync APIs raise the failure, the only place a sync caller can see it, and unregister the callback they added before raising, so catching the error and retrying registers once instead of delivering twice.
- The router now establishes download behavior synchronously inside `OnClientConnect`, before either transport starts reading client messages, the same guarantee `session.subscribe` already relied on. The command is bounded to 10 seconds, so a browser that wedges on it delays connect by that much at most; the failure outcome is the same at any timeout (downloads land in the browser's default directory), and the error log now states that consequence.
- The four workarounds are gone: the Python websocket probe helper (which had a residual straggler race of its own), the JS `INSTALL_BARRIER_MS` hedge, the fixed post-registration waits in both sync websocket suites, and the click loop in the downloads tutorial, which is back to a single click.

## Not changed

The retry loop in `prompt-blocked.test.js` stays. That click's response is blocked by the open alert by design; it is a different mechanism, not a subscription race.

## Notes for review

- The gate is per BiDi client, so a setup on one page briefly gates commands to other pages on the same connection. Intentional: one round trip at most, and it keeps the mechanism in one place.
- Python's `send` snapshots the pending-setup set once rather than looping until empty. A setup registered after a command was issued creates no ordering dependency for that command.
- The Java client's `onWebSocket` only stores a local listener and never sends the install command; websocket delivery there is an unimplemented feature, not this race. Follow-up issue material.

## Tests

- New deterministic ordering tests run both clients against a stand-in engine binary that installs the monitor slowly and only reports a socket once the install is answered. They fail on main and pass here, without a browser. The Python close-while-gated case and the sync rejected-install case are covered the same way.
- The stand-in engines count install commands and report the count through a test back-channel eval, so the registering-twice tests assert exactly one install was sent rather than inferring it. A fail-once mode covers the retry path in all four suites: the async tests prove a later registration re-sends the install and heals earlier callbacks, and the sync tests prove catch-and-retry delivers exactly once. The retry tests were verified to fail without the retry change.
- A router test connects to a fake remote BiDi endpoint, holds the `setDownloadBehavior` response, and asserts `OnClientConnect` has not returned. Proof by held response, not timing; unaffected by the 10s bound and verified under the race detector.
- The existing websocket suites now run barrier-free; verified locally under the CI parallelism shape.

## Credit

PR #354 independently arrived at the same gate design first, and this PR adopts its dialog bypass, close handling, and stand-in-engine test approach, rewritten on top of the #344 layout (capability audit, glob discovery, engine test paths) and extended with the probe deletion and the tutorial revert that #351 asks for.