### PR TITLE
Report video dimensions from the encoded WebM instead of 0x0 (#358)

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -400,17 +400,8 @@ func (h *Handlers) queryViewport() map[string]interface{} {
 	if context == "" {
 		return nil
 	}
-	result, err := api.EvalSimpleScript(h.newSession(), context, "() => window.innerWidth + ',' + window.innerHeight")
-	if err != nil {
-		return nil
-	}
-	parts := strings.SplitN(result, ",", 2)
-	if len(parts) != 2 {
-		return nil
-	}
-	w, err1 := strconv.Atoi(parts[0])
-	h2, err2 := strconv.Atoi(parts[1])
-	if err1 != nil || err2 != nil {
+	w, h2, ok := api.QueryViewport(h.newSession(), context)
+	if !ok {
 		return nil
 	}
 	return map[string]interface{}{"width": w, "height": h2}

--- a/clicker/internal/api/handlers_recording.go
+++ b/clicker/internal/api/handlers_recording.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/vibium/clicker/internal/log"
@@ -480,17 +478,8 @@ func (r *Router) queryViewport(session *BrowserSession) map[string]interface{} {
 	if err != nil {
 		return nil
 	}
-	result, err := r.evalSimpleScript(session, context, "() => window.innerWidth + ',' + window.innerHeight")
-	if err != nil {
-		return nil
-	}
-	parts := strings.SplitN(result, ",", 2)
-	if len(parts) != 2 {
-		return nil
-	}
-	w, err1 := strconv.Atoi(parts[0])
-	h, err2 := strconv.Atoi(parts[1])
-	if err1 != nil || err2 != nil {
+	w, h, ok := QueryViewport(NewAPISession(r, session, context), context)
+	if !ok {
 		return nil
 	}
 	return map[string]interface{}{"width": w, "height": h}

--- a/clicker/internal/api/helpers.go
+++ b/clicker/internal/api/helpers.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/vibium/clicker/internal/bidi"
+	"github.com/vibium/clicker/internal/log"
 )
 
 // resolveContext extracts the "context" param or returns the first context from getTree.
@@ -315,6 +318,28 @@ func EvalSimpleScript(s Session, context, fn string) (string, error) {
 	}
 
 	return parseScriptResult(resp)
+}
+
+// QueryViewport asks the page for its viewport size. ok is false when the
+// page cannot answer — e.g. Firefox refuses script evaluation on its
+// privileged initial page until the first navigation (#358), so a viewport
+// unknown here may become answerable later in the session.
+func QueryViewport(s Session, context string) (width, height int, ok bool) {
+	result, err := EvalSimpleScript(s, context, "() => window.innerWidth + ',' + window.innerHeight")
+	if err != nil {
+		log.Debug("viewport query failed", "context", context, "error", err)
+		return 0, 0, false
+	}
+	parts := strings.SplitN(result, ",", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	w, err1 := strconv.Atoi(parts[0])
+	h, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return w, h, true
 }
 
 // CallScript runs a script.callFunction with arguments via the Session and

--- a/clicker/internal/api/recording.go
+++ b/clicker/internal/api/recording.go
@@ -49,7 +49,8 @@ const (
 
 // VideoOptions is the recording's video track configuration. Dimensions
 // default to the viewport; explicit dimensions that mismatch the window
-// aspect are letterboxed by the engine.
+// aspect are letterboxed by the engine. The dimensions reported at stop
+// describe the encoded stream, read from the WebM itself at packaging.
 type VideoOptions struct {
 	Mode      VideoMode
 	Width     int
@@ -144,9 +145,11 @@ type VideoTrack struct {
 	// the video timeline with trace event timestamps.
 	OffsetMs   float64
 	DurationMs int64
-	Width      int
-	Height     int
-	Error      string // engine failure; the zip still delivers, video absent or partial
+	// Width/Height describe the encoded stream once the engine file is read
+	// at packaging; until then they hold the requested or viewport size.
+	Width  int
+	Height int
+	Error  string // engine failure; the zip still delivers, video absent or partial
 }
 
 // VideoSummary is one entry of the videos array in the recording.stop result.
@@ -1382,6 +1385,18 @@ func (t *Recorder) writeVideoEntriesLocked(zw *zip.Writer, now time.Time, includ
 
 	entry := map[string]interface{}{"context": context}
 	if includeVideo {
+		var data []byte
+		var readErr error
+		if !t.video.Remote && t.video.EnginePath != "" {
+			data, readErr = os.ReadFile(t.video.EnginePath)
+			// The encoded stream is the authoritative dimension source: the
+			// start-time value is the viewport, which the screencast surface
+			// need not match (#358). Read before reporting so the manifest
+			// and the stop summary both describe the actual video.
+			if w, h, ok := webmDimensions(data); ok {
+				t.video.Width, t.video.Height = w, h
+			}
+		}
 		entry["startedAt"] = t.video.StartedAt
 		entry["offsetMs"] = t.video.OffsetMs
 		entry["width"] = t.video.Width
@@ -1399,8 +1414,7 @@ func (t *Recorder) writeVideoEntriesLocked(zw *zip.Writer, now time.Time, includ
 			// empty engine file (the browser died before its first flush)
 			// is no video at all — record why instead of embedding junk.
 			name := "video/" + context + ".webm"
-			data, err := os.ReadFile(t.video.EnginePath)
-			if err == nil && len(data) > 0 {
+			if readErr == nil && len(data) > 0 {
 				vw, werr := zw.CreateHeader(&zip.FileHeader{
 					Name:     name,
 					Method:   zip.Store,
@@ -1412,8 +1426,8 @@ func (t *Recorder) writeVideoEntriesLocked(zw *zip.Writer, now time.Time, includ
 				vw.Write(data)
 				entry["file"] = name
 			} else if t.video.Error == "" {
-				if err != nil {
-					entry["error"] = "video file unreadable: " + err.Error()
+				if readErr != nil {
+					entry["error"] = "video file unreadable: " + readErr.Error()
 				} else {
 					entry["error"] = "video file empty: the engine wrote no frames"
 				}

--- a/clicker/internal/api/recording.go
+++ b/clicker/internal/api/recording.go
@@ -393,6 +393,22 @@ func (t *Recorder) ActiveVideo() *VideoTrack {
 	return &v
 }
 
+// SetVideoDimensions fills in video track dimensions that were unknown at
+// start. Known values are never overwritten and zero values never written.
+func (t *Recorder) SetVideoDimensions(width, height int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.video == nil {
+		return
+	}
+	if t.video.Width == 0 && width > 0 {
+		t.video.Width = width
+	}
+	if t.video.Height == 0 && height > 0 {
+		t.video.Height = height
+	}
+}
+
 // FinishVideo marks the screencast stopped. enginePath, when non-empty,
 // is where the engine finalized the file. errMsg records a stop failure;
 // the engine path is kept so a partial live-muxed video still delivers.

--- a/clicker/internal/api/recording_video.go
+++ b/clicker/internal/api/recording_video.go
@@ -80,12 +80,20 @@ func StartRecordingVideo(s Session, recorder *Recorder, opts RecordingStartOptio
 		return fail(fmt.Errorf("unexpected startScreencast response"))
 	}
 
+	// Dimensions not set by the caller fall back to the viewport, which is
+	// best-effort: the query fails on pages that refuse script evaluation
+	// (e.g. Firefox's privileged initial page), leaving them 0 here. Stop
+	// retries the query once the page has navigated somewhere answerable.
 	width, height := opts.Video.Width, opts.Video.Height
 	if width == 0 {
-		width, _ = viewport["width"].(int)
+		if w, ok := viewport["width"].(int); ok {
+			width = w
+		}
 	}
 	if height == 0 {
-		height, _ = viewport["height"].(int)
+		if h, ok := viewport["height"].(int); ok {
+			height = h
+		}
 	}
 	recorder.SetVideoTrack(&VideoTrack{
 		Context:    context,
@@ -107,6 +115,15 @@ func StopRecordingVideo(s Session, recorder *Recorder) {
 	track := recorder.ActiveVideo()
 	if track == nil || track.ID == "" {
 		return
+	}
+
+	// Dimensions the start-time viewport query could not provide (#358) are
+	// usually answerable now: the refusal came from the pre-navigation
+	// privileged page, and the recorded context has since navigated.
+	if track.Width == 0 || track.Height == 0 {
+		if w, h, ok := QueryViewport(s, track.Context); ok {
+			recorder.SetVideoDimensions(w, h)
+		}
 	}
 
 	resp, err := s.SendBidiCommandWithTimeout("browsingContext.stopScreencast", map[string]interface{}{

--- a/clicker/internal/api/recording_webm.go
+++ b/clicker/internal/api/recording_webm.go
@@ -1,0 +1,146 @@
+package api
+
+import "math/bits"
+
+// webmDimensions extracts the video track dimensions from a WebM file's
+// Tracks element, so the recording reports what the encoder actually
+// produced rather than the viewport it was asked for (#358). ok is false
+// when the header cannot be parsed.
+//
+// The walk descends only the masters on the path to the dimensions —
+// Segment, Tracks, TrackEntry, Video — and skips unknown siblings
+// (SeekHead, Void, Info) by their declared size. Firefox live-muxes, so
+// the Segment usually declares an unknown size; such masters are entered
+// and taken to run to the end of the scan window. The scan stops at the
+// first Cluster: media data never precedes the track header.
+func webmDimensions(data []byte) (width, height int, ok bool) {
+	const scanLimit = 64 * 1024
+	if len(data) > scanLimit {
+		data = data[:scanLimit]
+	}
+	if len(data) < 4 || data[0] != 0x1A || data[1] != 0x45 || data[2] != 0xDF || data[3] != 0xA3 {
+		return 0, 0, false
+	}
+
+	descend := map[uint64]bool{
+		0x18538067: true, // Segment
+		0x1654AE6B: true, // Tracks
+		0xAE:       true, // TrackEntry
+		0xE0:       true, // Video
+	}
+
+	// PixelWidth/PixelHeight describe the encoded stream; DisplayWidth/
+	// DisplayHeight are the fallback when a muxer omits them. The first
+	// video track wins.
+	var pw, ph, dw, dh uint64
+
+	var walk func(buf []byte)
+	walk = func(buf []byte) {
+		for len(buf) > 0 {
+			id, idn := readEBMLID(buf)
+			if idn == 0 {
+				return
+			}
+			size, sn, unknown := readEBMLSize(buf[idn:])
+			if sn == 0 {
+				return
+			}
+			if id == 0x1F43B675 { // Cluster
+				return
+			}
+			body := buf[idn+sn:]
+			if descend[id] {
+				if unknown || uint64(len(body)) <= size {
+					// Unknown-size or truncated master: its children run to
+					// the end of the window, and nothing follows it there.
+					walk(body)
+					return
+				}
+				walk(body[:size])
+				buf = body[size:]
+				continue
+			}
+			if unknown || uint64(len(body)) < size {
+				return
+			}
+			switch id {
+			case 0xB0: // PixelWidth
+				if pw == 0 {
+					pw = readEBMLUint(body, size)
+				}
+			case 0xBA: // PixelHeight
+				if ph == 0 {
+					ph = readEBMLUint(body, size)
+				}
+			case 0x54B0: // DisplayWidth
+				if dw == 0 {
+					dw = readEBMLUint(body, size)
+				}
+			case 0x54BA: // DisplayHeight
+				if dh == 0 {
+					dh = readEBMLUint(body, size)
+				}
+			}
+			buf = body[size:]
+		}
+	}
+	walk(data)
+
+	if pw > 0 && ph > 0 {
+		return int(pw), int(ph), true
+	}
+	if dw > 0 && dh > 0 {
+		return int(dw), int(dh), true
+	}
+	return 0, 0, false
+}
+
+// readEBMLID reads an EBML element ID, marker bits included, returning the
+// bytes consumed. n is 0 when the buffer does not hold a valid ID.
+func readEBMLID(buf []byte) (id uint64, n int) {
+	if len(buf) == 0 {
+		return 0, 0
+	}
+	n = bits.LeadingZeros8(buf[0]) + 1
+	if n > 4 || len(buf) < n {
+		return 0, 0
+	}
+	for i := 0; i < n; i++ {
+		id = id<<8 | uint64(buf[i])
+	}
+	return id, n
+}
+
+// readEBMLSize reads an EBML size vint, returning the bytes consumed and
+// whether the size is the reserved "unknown" value (all value bits set).
+// n is 0 when the buffer does not hold a valid size.
+func readEBMLSize(buf []byte) (size uint64, n int, unknown bool) {
+	if len(buf) == 0 {
+		return 0, 0, false
+	}
+	n = bits.LeadingZeros8(buf[0]) + 1
+	if n > 8 || len(buf) < n {
+		return 0, 0, false
+	}
+	size = uint64(buf[0]) & (0xFF >> n)
+	allOnes := size == uint64(0xFF)>>n
+	for i := 1; i < n; i++ {
+		size = size<<8 | uint64(buf[i])
+		if buf[i] != 0xFF {
+			allOnes = false
+		}
+	}
+	return size, n, allOnes
+}
+
+// readEBMLUint reads a big-endian EBML unsigned integer payload.
+func readEBMLUint(buf []byte, size uint64) uint64 {
+	if size == 0 || size > 8 || uint64(len(buf)) < size {
+		return 0
+	}
+	var v uint64
+	for i := uint64(0); i < size; i++ {
+		v = v<<8 | uint64(buf[i])
+	}
+	return v
+}

--- a/clicker/internal/api/recording_webm_test.go
+++ b/clicker/internal/api/recording_webm_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+)
+
+// ebml builds an element from raw ID bytes, an explicitly encoded size, and
+// a payload, so fixtures stay byte-exact.
+func ebml(id []byte, size []byte, payload []byte) []byte {
+	var b bytes.Buffer
+	b.Write(id)
+	b.Write(size)
+	b.Write(payload)
+	return b.Bytes()
+}
+
+// sized builds an element with a 1-byte encoded size for payloads < 127.
+func sized(id []byte, payload []byte) []byte {
+	return ebml(id, []byte{0x80 | byte(len(payload))}, payload)
+}
+
+var (
+	idEBMLHeader  = []byte{0x1A, 0x45, 0xDF, 0xA3}
+	idSegment     = []byte{0x18, 0x53, 0x80, 0x67}
+	idSeekHead    = []byte{0x11, 0x4D, 0x9B, 0x74}
+	idInfo        = []byte{0x15, 0x49, 0xA9, 0x66}
+	idTracks      = []byte{0x16, 0x54, 0xAE, 0x6B}
+	idCluster     = []byte{0x1F, 0x43, 0xB6, 0x75}
+	idTrackEntry  = []byte{0xAE}
+	idVideo       = []byte{0xE0}
+	idPixelWidth  = []byte{0xB0}
+	idPixelHeight = []byte{0xBA}
+	idDispWidth   = []byte{0x54, 0xB0}
+	idDispHeight  = []byte{0x54, 0xBA}
+	unknownSize   = []byte{0xFF}
+)
+
+func videoElement(dims ...[]byte) []byte {
+	var payload []byte
+	for _, d := range dims {
+		payload = append(payload, d...)
+	}
+	return sized(idVideo, payload)
+}
+
+func tracksFor(video []byte) []byte {
+	return sized(idTracks, sized(idTrackEntry, video))
+}
+
+func TestWebmDimensionsKnownSizeSegment(t *testing.T) {
+	video := videoElement(
+		sized(idPixelWidth, []byte{0x05, 0x00}),  // 1280
+		sized(idPixelHeight, []byte{0x03, 0x72}), // 882
+	)
+	tracks := tracksFor(video)
+	segment := ebml(idSegment, []byte{0x80 | byte(len(tracks))}, tracks)
+	file := append(sized(idEBMLHeader, nil), segment...)
+
+	w, h, ok := webmDimensions(file)
+	if !ok || w != 1280 || h != 882 {
+		t.Fatalf("webmDimensions() = %d, %d, %v, want 1280, 882, true", w, h, ok)
+	}
+}
+
+// Firefox live-muxes: the Segment declares an unknown size, and SeekHead and
+// Info precede Tracks. The walker must enter the unknown-size master and
+// skip the unknown siblings by their declared sizes.
+func TestWebmDimensionsLiveMuxedSegment(t *testing.T) {
+	video := videoElement(
+		sized(idPixelWidth, []byte{0x05, 0x00}),
+		sized(idPixelHeight, []byte{0x02, 0xD0}), // 720
+	)
+	var segmentBody []byte
+	segmentBody = append(segmentBody, sized(idSeekHead, bytes.Repeat([]byte{0x00}, 12))...)
+	segmentBody = append(segmentBody, sized(idInfo, bytes.Repeat([]byte{0x00}, 8))...)
+	segmentBody = append(segmentBody, tracksFor(video)...)
+	segmentBody = append(segmentBody, ebml(idCluster, unknownSize, []byte{0xDE, 0xAD})...)
+
+	file := append(sized(idEBMLHeader, nil), ebml(idSegment, unknownSize, segmentBody)...)
+
+	w, h, ok := webmDimensions(file)
+	if !ok || w != 1280 || h != 720 {
+		t.Fatalf("webmDimensions() = %d, %d, %v, want 1280, 720, true", w, h, ok)
+	}
+}
+
+func TestWebmDimensionsDisplayFallback(t *testing.T) {
+	video := videoElement(
+		sized(idDispWidth, []byte{0x02, 0x80}),  // 640
+		sized(idDispHeight, []byte{0x01, 0xE0}), // 480
+	)
+	file := append(sized(idEBMLHeader, nil), ebml(idSegment, unknownSize, tracksFor(video))...)
+
+	w, h, ok := webmDimensions(file)
+	if !ok || w != 640 || h != 480 {
+		t.Fatalf("webmDimensions() = %d, %d, %v, want 640, 480, true", w, h, ok)
+	}
+}
+
+func TestWebmDimensionsPixelWinsOverDisplay(t *testing.T) {
+	video := videoElement(
+		sized(idPixelWidth, []byte{0x05, 0x00}),
+		sized(idPixelHeight, []byte{0x03, 0x72}),
+		sized(idDispWidth, []byte{0x02, 0x80}),
+		sized(idDispHeight, []byte{0x01, 0xE0}),
+	)
+	file := append(sized(idEBMLHeader, nil), ebml(idSegment, unknownSize, tracksFor(video))...)
+
+	w, h, ok := webmDimensions(file)
+	if !ok || w != 1280 || h != 882 {
+		t.Fatalf("webmDimensions() = %d, %d, %v, want 1280, 882, true", w, h, ok)
+	}
+}
+
+func TestWebmDimensionsTruncatedBeforeTracks(t *testing.T) {
+	var segmentBody []byte
+	segmentBody = append(segmentBody, sized(idSeekHead, bytes.Repeat([]byte{0x00}, 12))...)
+	file := append(sized(idEBMLHeader, nil), ebml(idSegment, unknownSize, segmentBody)...)
+
+	if _, _, ok := webmDimensions(file); ok {
+		t.Fatal("webmDimensions() ok = true for a file truncated before Tracks")
+	}
+}
+
+func TestWebmDimensionsGarbage(t *testing.T) {
+	if _, _, ok := webmDimensions([]byte("not a webm file at all")); ok {
+		t.Fatal("webmDimensions() ok = true for garbage input")
+	}
+	if _, _, ok := webmDimensions(nil); ok {
+		t.Fatal("webmDimensions() ok = true for empty input")
+	}
+}

--- a/clicker/internal/bidi/script.go
+++ b/clicker/internal/bidi/script.go
@@ -103,12 +103,21 @@ func ParseScriptResult(raw json.RawMessage) (*ScriptResult, error) {
 
 // ParseScriptResponse decodes a full BiDi response envelope, { "result": ... },
 // as returned by the proxy's internal command path. See ParseScriptResult.
+// A BiDi error envelope is surfaced with the browser's own error and message
+// — it also has no result member, and reporting it as such hid errors like
+// Firefox refusing script evaluation on its privileged initial page (#358).
 func ParseScriptResponse(raw json.RawMessage) (*ScriptResult, error) {
 	var env struct {
-		Result json.RawMessage `json:"result"`
+		Type    string          `json:"type"`
+		Error   string          `json:"error"`
+		Message string          `json:"message"`
+		Result  json.RawMessage `json:"result"`
 	}
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return nil, fmt.Errorf("failed to parse script result: %w", err)
+	}
+	if env.Type == "error" {
+		return nil, fmt.Errorf("%s: %s", env.Error, env.Message)
 	}
 	if len(env.Result) == 0 {
 		return nil, fmt.Errorf("failed to parse script result: no result member")

--- a/clicker/internal/bidi/script_result_test.go
+++ b/clicker/internal/bidi/script_result_test.go
@@ -107,6 +107,22 @@ func TestParseScriptResponseMissingResult(t *testing.T) {
 	}
 }
 
+// A BiDi error envelope also has no result member; the browser's own error
+// must come through, not a generic parse complaint (#358: Firefox refusing
+// script evaluation on its initial page was reported as "no result member").
+func TestParseScriptResponseErrorEnvelope(t *testing.T) {
+	raw := json.RawMessage(`{"type":"error","id":7,"error":"unsupported operation",` +
+		`"message":"script.callFunction is not supported for parent process browsing contexts: 11"}`)
+	_, err := ParseScriptResponse(raw)
+	if err == nil {
+		t.Fatal("ParseScriptResponse() returned nil error for a BiDi error envelope")
+	}
+	want := "unsupported operation: script.callFunction is not supported for parent process browsing contexts: 11"
+	if err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
 // Nested arrays must survive the round trip — the JS-client page.evaluate path
 // previously unwrapped only one level, leaving inner elements as typed objects
 // (issue #124).

--- a/tests/js/async/firefox.test.js
+++ b/tests/js/async/firefox.test.js
@@ -152,6 +152,44 @@ describe('JS Firefox', () => {
     }
   });
 
+  // #358: recording.start before the first navigation reported 0x0 video
+  // dimensions — Firefox refuses the viewport script on its privileged
+  // initial page, and the failure was silently swallowed.
+  test('video dimensions are reported when recording starts before navigation', async (t) => {
+    if (!haveFirefox) return skipOrFail(t, 'Firefox not installed');
+
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-firefox-dims-'));
+    const zipPath = path.join(outDir, 'run.zip');
+    const bro = await firefox.start({ headless: true });
+    try {
+      const vibe = await bro.page();
+      await vibe.setViewport({ width: 1280, height: 720 });
+
+      // Start on the fresh pre-navigation page, like the issue repro.
+      if (!(await startVideoRecordingOrSkip(t, vibe, { path: zipPath }))) return;
+
+      await vibe.go(baseURL);
+      const result = await vibe.context.recording.stop();
+
+      assert.strictEqual(result.videos.length, 1, 'Result should report the video track');
+      const video = result.videos[0];
+      assert.ok(video.width > 0, `Video width should be reported, got ${video.width}`);
+      assert.ok(video.height > 0, `Video height should be reported, got ${video.height}`);
+
+      const { extractedDir, cleanup } = unzipRecording(fs.readFileSync(zipPath));
+      try {
+        const index = JSON.parse(fs.readFileSync(path.join(extractedDir, 'video', 'index.json'), 'utf-8'));
+        assert.strictEqual(index.videos[0].width, video.width, 'Manifest width should match the stop result');
+        assert.strictEqual(index.videos[0].height, video.height, 'Manifest height should match the stop result');
+      } finally {
+        cleanup();
+      }
+    } finally {
+      await bro.stop();
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
   test('unknown browser is rejected with a clear error', (t) => {
     const bin = process.env.VIBIUM_BIN_PATH;
     if (!bin) return skipOrFail(t, 'VIBIUM_BIN_PATH not set');

--- a/tests/js/async/firefox.test.js
+++ b/tests/js/async/firefox.test.js
@@ -57,6 +57,64 @@ async function startVideoRecordingOrSkip(t, vibe, options) {
   }
 }
 
+// Minimal EBML scan for the video track's PixelWidth/PixelHeight — an
+// independent oracle for what the encoder actually produced, so the test
+// does not trust the daemon's own reporting.
+function webmPixelDimensions(buf) {
+  const DESCEND = new Set([0x18538067, 0x1654ae6b, 0xae, 0xe0]); // Segment, Tracks, TrackEntry, Video
+  const CLUSTER = 0x1f43b675;
+  let pw = 0;
+  let ph = 0;
+
+  function leadingZeros(byte) {
+    for (let i = 7; i >= 0; i--) if (byte & (1 << i)) return 7 - i;
+    return 8;
+  }
+
+  function walk(start, end) {
+    let pos = start;
+    while (pos < end && !(pw && ph)) {
+      const idLen = leadingZeros(buf[pos]) + 1;
+      if (idLen > 4 || pos + idLen > end) return;
+      let id = 0;
+      for (let i = 0; i < idLen; i++) id = id * 256 + buf[pos + i];
+      pos += idLen;
+
+      const sizeLen = leadingZeros(buf[pos]) + 1;
+      if (sizeLen > 8 || pos + sizeLen > end) return;
+      let size = buf[pos] & (0xff >> sizeLen);
+      let unknown = size === 0xff >> sizeLen;
+      for (let i = 1; i < sizeLen; i++) {
+        size = size * 256 + buf[pos + i];
+        if (buf[pos + i] !== 0xff) unknown = false;
+      }
+      pos += sizeLen;
+
+      if (id === CLUSTER) return;
+      if (DESCEND.has(id)) {
+        if (unknown || pos + size > end) {
+          walk(pos, end);
+          return;
+        }
+        walk(pos, pos + size);
+        pos += size;
+        continue;
+      }
+      if (unknown || pos + size > end) return;
+      if (id === 0xb0 || id === 0xba) {
+        let v = 0;
+        for (let i = 0; i < size; i++) v = v * 256 + buf[pos + i];
+        if (id === 0xb0 && !pw) pw = v;
+        if (id === 0xba && !ph) ph = v;
+      }
+      pos += size;
+    }
+  }
+
+  walk(0, Math.min(buf.length, 64 * 1024));
+  return { width: pw, height: ph };
+}
+
 // Unzip a recording buffer and return { extractedDir, cleanup }.
 function unzipRecording(zipBuffer) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-firefox-rec-'));
@@ -181,6 +239,13 @@ describe('JS Firefox', () => {
         const index = JSON.parse(fs.readFileSync(path.join(extractedDir, 'video', 'index.json'), 'utf-8'));
         assert.strictEqual(index.videos[0].width, video.width, 'Manifest width should match the stop result');
         assert.strictEqual(index.videos[0].height, video.height, 'Manifest height should match the stop result');
+
+        // The reported dimensions must describe the encoded stream, not the
+        // viewport the recording was asked for (#358).
+        const webm = fs.readFileSync(path.join(extractedDir, index.videos[0].file));
+        const encoded = webmPixelDimensions(webm);
+        assert.strictEqual(video.width, encoded.width, 'Reported width should match the encoded stream');
+        assert.strictEqual(video.height, encoded.height, 'Reported height should match the encoded stream');
       } finally {
         cleanup();
       }


### PR DESCRIPTION
Fixes #358.
Closes #336.

Recording with video before the page's first navigation always reported 0x0. Firefox refuses `script.callFunction` on its privileged initial page, so the start-time viewport query returned nil and the discarded type assertions in `StartRecordingVideo` turned that into silent zeros. The refusal was invisible too: a BiDi error envelope has no `result` member, so it surfaced as a generic parse error.

Fixing only the nil would still report the wrong number. The screencast surface does not have to match the viewport (the issue shows 1280x882 against a 1280x720 viewport), so `recording.stop()` and `video/index.json` now report the dimensions of the encoded stream, read from the WebM at packaging time.

## What changed

- `webmDimensions`, a small EBML walker, reads PixelWidth/PixelHeight (Display* as fallback) from the Tracks element. No dependencies, 64KB bound, stops at the first Cluster. Verified against real Firefox live-muxed files, including a 217-byte force-killed partial, so the offline finalize path reports real dimensions too.
- Packaging writes the parsed values onto the track. Both `recording.stop()` and `video/index.json` read the same fields, so one write covers every surface. No client changes.
- `ParseScriptResponse` surfaces BiDi error envelopes with the browser's error and message.
- The duplicated viewport query is now a shared `api.QueryViewport` that reports failure explicitly. `StartRecordingVideo` checks its assertions and `StopRecordingVideo` backfills what start could not answer, so remote-keep and unreadable videos report the viewport instead of 0x0.

Each commit stands alone in that order.

Verified:

- E2e repro records before first navigation and asserts the reported dimensions equal an independent EBML scan of the extracted WebM. Fails on main with `got 0`, fails with only the viewport fix (1280x720 vs encoded 1280x832), passes here. Self-skips below Firefox 154.
- Parser unit tests: known-size and unknown-size Segment, unknown siblings, Display-only, Pixel-over-Display precedence, truncation, garbage.
- Unit test for the BiDi error envelope.
- Full `make test` green with Firefox beta.