### PR TITLE
Test the Firefox release channel now that 154 shipped

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,9 +143,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # Firefox 154 is beta until 2026-08-18. Remove this pin with #322 once
-      # release is the default channel exercised by installation and tests.
-      VIBIUM_FIREFOX_CHANNEL: beta
       VIBIUM_REQUIRE_FIREFOX: 1
 
     steps:

--- a/clicker/internal/api/recording_video.go
+++ b/clicker/internal/api/recording_video.go
@@ -193,19 +193,23 @@ func RecordingSavedSentence(path string, s RecordingSummary) string {
 	return msg
 }
 
-// videoSupportError turns the browser's "unknown command" on startScreencast
-// into something the user can act on. Only that case is rewritten: a browser
-// that has the command but refuses an option already names the problem, and
+// videoSupportError turns the browser's refusal of startScreencast itself
+// into something the user can act on. Chrome has said "unknown command"
+// and, since 152, "Method browsingContext.startScreencast is not
+// implemented." Only the command-missing case is rewritten: a browser that
+// has the command but refuses an option already names the problem, and
 // replacing its message would hide it.
 func videoSupportError(err error) error {
-	if strings.Contains(err.Error(), "unknown command") {
+	msg := err.Error()
+	if strings.Contains(msg, "unknown command") ||
+		(strings.Contains(msg, "startScreencast") && strings.Contains(msg, "not implemented")) {
 		return fmt.Errorf("video recording is not supported by this browser yet " +
 			"(Chrome: not implemented; Firefox: requires 154+). " +
 			"Install it with `vibium install --engine firefox` and launch with browser \"firefox\", " +
 			"or record without video for a trace with screenshots")
 	}
-	if strings.Contains(err.Error(), "NS_ERROR_FAILURE") &&
-		strings.Contains(err.Error(), "nsIProperties.get") {
+	if strings.Contains(msg, "NS_ERROR_FAILURE") &&
+		strings.Contains(msg, "nsIProperties.get") {
 		return fmt.Errorf("Firefox could not resolve its screencast output directory")
 	}
 	return err

--- a/clicker/internal/api/recording_video_test.go
+++ b/clicker/internal/api/recording_video_test.go
@@ -35,6 +35,17 @@ func TestVideoSupportErrorExplainsFirefoxOutputFailure(t *testing.T) {
 	}
 }
 
+// Chrome 152 changed its startScreencast refusal from "unknown command" to
+// this message; both mean the command does not exist and both must rewrite.
+func TestVideoSupportErrorRecognizesChromeNotImplemented(t *testing.T) {
+	err := videoSupportError(errors.New(
+		`unsupported operation: Method browsingContext.startScreencast is not implemented.`,
+	))
+	if !strings.Contains(err.Error(), "vibium install --engine firefox") {
+		t.Fatalf("error should name the install command, got: %v", err)
+	}
+}
+
 func TestVideoSupportErrorNamesTheInstallCommand(t *testing.T) {
 	err := videoSupportError(errors.New(`unknown command: browsingContext.startScreencast`))
 	if !strings.Contains(err.Error(), "vibium install --engine firefox") {

--- a/docs/how-to-guides/record-video.md
+++ b/docs/how-to-guides/record-video.md
@@ -30,17 +30,17 @@ snapshots, groups, chunks, the viewer), start with the
 
 ## Browser support
 
-Video requires Firefox 154, which is the current Firefox beta. It reaches regular Firefox on 2026-08-18; from then on a plain `firefox.start()` is enough. Until then, pass `channel: 'beta'` when starting the browser, as in the examples below. The channel applies at install and at launch: it picks which Firefox to download and which one to run, so a plain `firefox.start()` still launches stable Firefox even after the beta is installed.
+Video requires Firefox 154 or newer, which regular Firefox ships since 2026-08-18. A plain `firefox.start()` is enough: it installs and launches the release channel.
 
-On macOS and Linux, the clients install the selected channel automatically on
+On macOS and Linux, the clients install Firefox automatically on
 first use. Windows users must install Firefox themselves and set
 `VIBIUM_FIREFOX_PATH`. To install it ahead of time on a supported platform:
 
 ```
-vibium install --engine firefox --firefox-channel beta
+vibium install --engine firefox
 ```
 
-The `VIBIUM_FIREFOX_CHANNEL` env var does the same as the flag and option, for cases where you cannot change the code.
+To record against the Firefox beta instead, select the channel with `--firefox-channel beta`, the clients' `channel` option, or the `VIBIUM_FIREFOX_CHANNEL` env var; see [Using Firefox](using-firefox.md#release-channels).
 
 Chrome has not implemented the BiDi screencast command yet. The same code will work on Chrome when it does; today `video: true` fails there with an error saying so, and an omitted `video` records the trace without a video track.
 
@@ -76,8 +76,7 @@ See [Using Firefox](using-firefox.md) for installing and selecting Firefox in ge
 ```js
 const { firefox } = require('vibium');
 
-// channel: 'beta' is needed until Firefox 154 reaches stable on 2026-08-18
-const bro = await firefox.start({ channel: 'beta' });
+const bro = await firefox.start();
 const vibe = await bro.page();
 
 await vibe.context.recording.start({ video: true, path: 'runs/login.zip' });
@@ -100,8 +99,7 @@ carries the zip itself.
 ```python
 from vibium import firefox
 
-# channel="beta" is needed until Firefox 154 reaches stable on 2026-08-18
-bro = firefox.start(channel="beta")
+bro = firefox.start()
 vibe = bro.page()
 
 vibe.context.recording.start(video=True, path="runs/login.zip")

--- a/docs/how-to-guides/using-firefox.md
+++ b/docs/how-to-guides/using-firefox.md
@@ -35,7 +35,7 @@ Browser bro = Vibium.start(
 );
 ```
 
-The main use today is [video recording](record-video.md), which needs Firefox 154 while it is still in beta.
+The release channel covers everything vibium supports, including [video recording](record-video.md) (Firefox 154+); the beta is for trying upcoming Firefox changes early.
 
 ## Launch
 


### PR DESCRIPTION
Fixes VibiumDev#322.

Firefox 154 reached the release channel on 2026-08-18, so the job-wide beta pin comes off: the firefox CI job now installs and tests the release channel, which is what a plain `firefox.start()` launches for users. Channel selection (`--firefox-channel`, `VIBIUM_FIREFOX_CHANNEL`, the clients' `channel` option) is shipped surface and stays; the beta is opt-in for trying upcoming Firefox changes early.

This also unblocks the red firefox job on VibiumDev#359 and the other open PRs. The pin had started resolving 155.0b1 (beta moved past 154 on release day), and Firefox 155 gates `browsingContext.activate` behind a new `-remote-allow-system-access` flag and refuses it outright on privileged pre-navigation pages. Those 155 issues need fixing before 155 ships in about six weeks, but they belong to their own issue; reruns of the red jobs pick this change up through the merge ref once it lands.

Docs updated per the issue comment: the record-video guide and its examples no longer pin beta (a plain `firefox.start()` suffices, with a pointer to channel selection), and the using-firefox channel section describes the beta as early access rather than the way to get video. The optional non-blocking beta canary lane is deliberately left out as its own follow-up decision, though the pin's last week made the case for one: it caught both Firefox 155 regressions before any user did.

Verified:

- Clean release install resolves 154.0
- Full firefox JS test file green on release with VIBIUM_REQUIRE_FIREFOX=1, video tests self-activated with no skips
- make test-firefox-capabilities green on release 154, the exact step that was red on 155.0b1