### PR TITLE
Write user.js prefs in sorted order

### DIFF
--- a/clicker/internal/browser/launcher_firefox.go
+++ b/clicker/internal/browser/launcher_firefox.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -209,11 +210,17 @@ func connectFirefoxBidi(wsURL string, timeout time.Duration) (*bidi.Connection, 
 	return nil, fmt.Errorf("timeout waiting for firefox BiDi endpoint: %w", lastErr)
 }
 
-// writeFirefoxPrefs writes user.js into the profile directory.
+// writeFirefoxPrefs writes user.js into the profile directory. Keys are
+// sorted so the file is identical run to run and diffs stay readable.
 func writeFirefoxPrefs(profileDir string) error {
+	keys := make([]string, 0, len(firefoxPrefs))
+	for k := range firefoxPrefs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 	var b []byte
-	for k, v := range firefoxPrefs {
-		b = append(b, []byte(fmt.Sprintf("user_pref(%q, %s);\n", k, prefValue(v)))...)
+	for _, k := range keys {
+		b = append(b, []byte(fmt.Sprintf("user_pref(%q, %s);\n", k, prefValue(firefoxPrefs[k])))...)
 	}
 	return os.WriteFile(filepath.Join(profileDir, "user.js"), b, 0644)
 }

--- a/clicker/internal/browser/launcher_firefox_test.go
+++ b/clicker/internal/browser/launcher_firefox_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -34,5 +35,38 @@ func TestReplaceEnv(t *testing.T) {
 	want := []string{"A=1", "B=2", "XDG_CONFIG_HOME=new"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("replaceEnv() = %v, want %v", got, want)
+	}
+}
+
+// user.js must come out identical run to run: map iteration order previously
+// made every launch write the prefs in a different order (#318).
+func TestWriteFirefoxPrefsSortedAndDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFirefoxPrefs(dir); err != nil {
+		t.Fatalf("writeFirefoxPrefs() error = %v", err)
+	}
+	first, err := os.ReadFile(filepath.Join(dir, "user.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(strings.TrimRight(string(first), "\n"), "\n")
+	if len(lines) != len(firefoxPrefs) {
+		t.Fatalf("user.js has %d lines, want %d", len(lines), len(firefoxPrefs))
+	}
+	if !sort.StringsAreSorted(lines) {
+		t.Errorf("user.js lines are not sorted:\n%s", string(first))
+	}
+
+	dir2 := t.TempDir()
+	if err := writeFirefoxPrefs(dir2); err != nil {
+		t.Fatalf("writeFirefoxPrefs() error = %v", err)
+	}
+	second, err := os.ReadFile(filepath.Join(dir2, "user.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Error("two writes produced different user.js contents")
 	}
 }


### PR DESCRIPTION
Fixes VibiumDev#318.

`writeFirefoxPrefs` ranged over a Go map, so every launch wrote `user.js` with the prefs in a different order. The keys are now sorted, so the file is identical run to run and two profiles from the same build diff clean.

Verified:

- New test writes the file twice and asserts sorted lines and byte-identical contents
- Firefox launches with the sorted file and navigate, click, and screenshot all work locally