### PR TITLE
Validate --firefox-channel at the CLI

### DIFF
--- a/clicker/cmd/clicker/main.go
+++ b/clicker/cmd/clicker/main.go
@@ -73,6 +73,9 @@ func main() {
 			if engineName != "chrome" && engineName != "firefox" {
 				return fmt.Errorf("unsupported engine %q (supported: chrome, firefox)", engineName)
 			}
+			if firefoxChannel != "" && firefoxChannel != "release" && firefoxChannel != "beta" {
+				return fmt.Errorf("unsupported Firefox channel %q (supported: release, beta)", firefoxChannel)
+			}
 			// Bridge the flag to the env var, like --session: the paths
 			// package resolves the channel from the environment at both
 			// install and launch time, and a daemon child process spawned

--- a/tests/js/async/firefox.test.js
+++ b/tests/js/async/firefox.test.js
@@ -163,19 +163,37 @@ describe('JS Firefox', () => {
     );
   });
 
-  test('--firefox-channel selects a separate install', (t) => {
+  test('--firefox-channel rejects an unknown channel at the CLI', (t) => {
     const bin = process.env.VIBIUM_BIN_PATH;
     if (!bin) return skipOrFail(t, 'VIBIUM_BIN_PATH not set');
 
-    // Channels live in separate cache directories, so a channel that was
-    // never installed must report not-installed (exit 1) — even on machines
-    // where another channel is present. Purely a local directory check.
+    // Validated up front so a typo names the real problem instead of
+    // surfacing later as "Firefox not found" from the launcher (#314).
     assert.throws(
       () => execFileSync(bin,
         ['is-installed', '--engine', 'firefox', '--firefox-channel', 'no-such-channel'],
-        { stdio: 'ignore' }),
-      (err) => err.status === 1,
-      'A never-installed channel should report not-installed'
+        { stdio: 'pipe' }),
+      (err) => /unsupported Firefox channel/.test(err.stderr.toString()),
+      'An unknown channel should be rejected by CLI validation'
     );
+  });
+
+  test('--firefox-channel accepts the valid channels', (t) => {
+    const bin = process.env.VIBIUM_BIN_PATH;
+    if (!bin) return skipOrFail(t, 'VIBIUM_BIN_PATH not set');
+
+    // is-installed may exit 0 or 1 depending on what this machine has in
+    // its cache; the only wrong outcome is the validation error.
+    for (const channel of ['release', 'beta']) {
+      let stderr = '';
+      try {
+        execFileSync(bin, ['is-installed', '--engine', 'firefox', '--firefox-channel', channel],
+          { stdio: 'pipe' });
+      } catch (err) {
+        stderr = err.stderr.toString();
+      }
+      assert.ok(!/unsupported Firefox channel/.test(stderr),
+        `Channel "${channel}" should pass CLI validation`);
+    }
   });
 });


### PR DESCRIPTION
Fixes VibiumDev#314.

A misspelled channel (`--firefox-channel betta`) reached the launcher and reported "Firefox not found: run vibium install..." instead of naming the problem. The check now sits in `PersistentPreRunE` next to the engine validation and fails immediately with `unsupported Firefox channel "betta" (supported: release, beta)`. VIBIUM_FIREFOX_CHANNEL is covered too, since the flag defaults from it. The MCP schema and daemon launch path already validated the same enum.

The old no-such-channel CLI test relied on an invalid channel reaching the cache lookup, which validation now intercepts, so it asserts the validation error instead.

Verified:

- CLI test asserts the new error for an unknown channel
- Both valid channels still pass validation and reach the is-installed check
- Manual run shows the new message and exits 1