### PR TITLE
Test firefoxDownloadURL shapes and the videoSupportError passthrough

### DIFF
--- a/clicker/internal/api/recording_video_test.go
+++ b/clicker/internal/api/recording_video_test.go
@@ -42,6 +42,15 @@ func TestVideoSupportErrorNamesTheInstallCommand(t *testing.T) {
 	}
 }
 
+// A browser that has the command but refuses an option already names the
+// problem; rewriting would hide it, so the error must pass through unchanged.
+func TestVideoSupportErrorPassesThroughSpecificRefusals(t *testing.T) {
+	orig := errors.New(`invalid argument: The audio track is not supported`)
+	if err := videoSupportError(orig); err != orig {
+		t.Fatalf("videoSupportError() = %v, want the original error unchanged", err)
+	}
+}
+
 func TestRequiredVideoOnRemoteConnectionFailsClearly(t *testing.T) {
 	client := &recordingTestClient{}
 	router := NewRouter("firefox", true, "ws://remote.example/session", nil)

--- a/clicker/internal/browser/installer_firefox.go
+++ b/clicker/internal/browser/installer_firefox.go
@@ -140,13 +140,17 @@ func fetchLatestFirefoxVersion(channel string) (string, error) {
 // firefoxDownloadURL returns the Mozilla archive URL for this platform.
 // Betas live under the same releases/ tree as stable versions.
 func firefoxDownloadURL(version string) string {
+	return firefoxDownloadURLFor(runtime.GOOS, runtime.GOARCH, version)
+}
+
+func firefoxDownloadURLFor(goos, goarch, version string) string {
 	base := "https://ftp.mozilla.org/pub/firefox/releases/" + version
-	switch runtime.GOOS {
+	switch goos {
 	case "darwin":
 		return base + "/mac/en-US/" + url.PathEscape("Firefox "+version+".dmg")
 	default: // linux
 		arch := "linux-x86_64"
-		if runtime.GOARCH == "arm64" {
+		if goarch == "arm64" {
 			arch = "linux-aarch64"
 		}
 		return base + "/" + arch + "/en-US/firefox-" + version + ".tar.xz"

--- a/clicker/internal/browser/installer_firefox_test.go
+++ b/clicker/internal/browser/installer_firefox_test.go
@@ -1,0 +1,41 @@
+package browser
+
+import "testing"
+
+// The per-OS/arch URL shape is exactly what breaks silently when Mozilla
+// changes their archive layout, so it is pinned here (#320). The mac DMG
+// name contains a space, which must arrive percent-encoded.
+func TestFirefoxDownloadURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		goos    string
+		goarch  string
+		version string
+		want    string
+	}{
+		{
+			name: "mac dmg with escaped space", goos: "darwin", goarch: "arm64", version: "153.0.4",
+			want: "https://ftp.mozilla.org/pub/firefox/releases/153.0.4/mac/en-US/Firefox%20153.0.4.dmg",
+		},
+		{
+			name: "linux x86_64 tarball", goos: "linux", goarch: "amd64", version: "153.0.4",
+			want: "https://ftp.mozilla.org/pub/firefox/releases/153.0.4/linux-x86_64/en-US/firefox-153.0.4.tar.xz",
+		},
+		{
+			name: "linux arm64 tarball", goos: "linux", goarch: "arm64", version: "153.0.4",
+			want: "https://ftp.mozilla.org/pub/firefox/releases/153.0.4/linux-aarch64/en-US/firefox-153.0.4.tar.xz",
+		},
+		{
+			name: "beta lives under the same releases tree", goos: "linux", goarch: "amd64", version: "154.0b6",
+			want: "https://ftp.mozilla.org/pub/firefox/releases/154.0b6/linux-x86_64/en-US/firefox-154.0b6.tar.xz",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := firefoxDownloadURLFor(tc.goos, tc.goarch, tc.version); got != tc.want {
+				t.Errorf("firefoxDownloadURLFor(%s, %s, %s) = %q, want %q",
+					tc.goos, tc.goarch, tc.version, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes VibiumDev#320.

`firefoxDownloadURL` now delegates to `firefoxDownloadURLFor(goos, goarch, version)`, which takes the platform as arguments instead of reading `runtime.GOOS`/`GOARCH`. Behavior is unchanged, but every URL shape can be tested from one machine: the mac DMG with its percent-encoded space, the linux x86_64 and aarch64 tarballs, and a beta version under the same `releases/` tree. The per-platform shape is what breaks silently when Mozilla changes their archive layout.

The second half of the issue is mostly done already: `screencastSupportError` is now `videoSupportError` and its two rewrite branches have tests. What was missing is the passthrough case, where a specific refusal like Firefox's "The audio track is not supported" must come through unchanged. That test is added.

Verified:

- go test on internal/browser and internal/api green