### PR TITLE
Pin the Firefox version with VIBIUM_FIREFOX_VERSION

### DIFF
--- a/clicker/internal/browser/installer_firefox.go
+++ b/clicker/internal/browser/installer_firefox.go
@@ -41,7 +41,7 @@ func InstallFirefox() (string, error) {
 	}
 
 	channel := paths.FirefoxChannel()
-	version, err := fetchLatestFirefoxVersion(channel)
+	version, err := resolveFirefoxVersion(channel)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch Firefox version info: %w", err)
 	}
@@ -98,6 +98,18 @@ func IsFirefoxInstalled() bool {
 	}
 	_, err = os.Stat(p)
 	return err == nil
+}
+
+// resolveFirefoxVersion returns the Firefox version to install:
+// VIBIUM_FIREFOX_VERSION when set, otherwise the channel's current version
+// from Mozilla's product-details JSON. The pin exists because "latest"
+// changes out from under CI and fleets (a beta pin silently jumped 154 to
+// 155 the day 154 reached release); it also skips the network round-trip.
+func resolveFirefoxVersion(channel string) (string, error) {
+	if v := os.Getenv("VIBIUM_FIREFOX_VERSION"); v != "" {
+		return v, nil
+	}
+	return fetchLatestFirefoxVersion(channel)
 }
 
 // fetchLatestFirefoxVersion resolves the current version for a channel from

--- a/clicker/internal/browser/installer_firefox_pin_test.go
+++ b/clicker/internal/browser/installer_firefox_pin_test.go
@@ -1,0 +1,18 @@
+package browser
+
+import "testing"
+
+// A pinned version must not consult the network: resolution returns the pin
+// as-is, for any channel (#326).
+func TestResolveFirefoxVersionHonorsPin(t *testing.T) {
+	t.Setenv("VIBIUM_FIREFOX_VERSION", "153.0.4")
+	for _, channel := range []string{"release", "beta"} {
+		v, err := resolveFirefoxVersion(channel)
+		if err != nil {
+			t.Fatalf("resolveFirefoxVersion(%s) error = %v", channel, err)
+		}
+		if v != "153.0.4" {
+			t.Errorf("resolveFirefoxVersion(%s) = %q, want the pinned 153.0.4", channel, v)
+		}
+	}
+}

--- a/clicker/internal/paths/firefox_pin_test.go
+++ b/clicker/internal/paths/firefox_pin_test.go
@@ -1,0 +1,81 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// fakeFirefoxInstall lays out a cache entry the way Mozilla's archives
+// unpack, so executable resolution finds it.
+func fakeFirefoxInstall(t *testing.T, cacheDir, channel, version string) {
+	t.Helper()
+	versionDir := filepath.Join(cacheDir, "firefox", channel, version)
+	exe := FirefoxPathInVersion(versionDir)
+	if err := os.MkdirAll(filepath.Dir(exe), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// VIBIUM_FIREFOX_VERSION pins which cached version launches: newest-cached
+// would silently run a different Firefox than the pin installed (#326).
+func TestFirefoxExecutablePinnedVersionWins(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cache layout test uses unix permissions")
+	}
+	cacheDir := t.TempDir()
+	t.Setenv("VIBIUM_CACHE_DIR", cacheDir)
+	t.Setenv("VIBIUM_FIREFOX_PATH", "")
+	t.Setenv("VIBIUM_FIREFOX_CHANNEL", "")
+	fakeFirefoxInstall(t, cacheDir, "release", "153.0.4")
+	fakeFirefoxInstall(t, cacheDir, "release", "154.0")
+
+	t.Setenv("VIBIUM_FIREFOX_VERSION", "153.0.4")
+	got, err := GetFirefoxExecutable()
+	if err != nil {
+		t.Fatalf("GetFirefoxExecutable() error = %v", err)
+	}
+	want := FirefoxPathInVersion(filepath.Join(cacheDir, "firefox", "release", "153.0.4"))
+	if got != want {
+		t.Errorf("GetFirefoxExecutable() = %q, want the pinned %q", got, want)
+	}
+}
+
+// A pin that is not in the cache is an error, not a fallback: install will
+// fetch exactly that version, and launching anything else defeats the pin.
+func TestFirefoxExecutableMissingPinnedVersionErrors(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("VIBIUM_CACHE_DIR", cacheDir)
+	t.Setenv("VIBIUM_FIREFOX_PATH", "")
+	t.Setenv("VIBIUM_FIREFOX_CHANNEL", "")
+	fakeFirefoxInstall(t, cacheDir, "release", "154.0")
+
+	t.Setenv("VIBIUM_FIREFOX_VERSION", "153.0.4")
+	if _, err := GetFirefoxExecutable(); err == nil {
+		t.Fatal("GetFirefoxExecutable() should error when the pinned version is not cached")
+	}
+}
+
+// Without a pin the newest cached version wins, as before.
+func TestFirefoxExecutableUnpinnedPicksNewest(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("VIBIUM_CACHE_DIR", cacheDir)
+	t.Setenv("VIBIUM_FIREFOX_PATH", "")
+	t.Setenv("VIBIUM_FIREFOX_CHANNEL", "")
+	t.Setenv("VIBIUM_FIREFOX_VERSION", "")
+	fakeFirefoxInstall(t, cacheDir, "release", "153.0.4")
+	fakeFirefoxInstall(t, cacheDir, "release", "154.0")
+
+	got, err := GetFirefoxExecutable()
+	if err != nil {
+		t.Fatalf("GetFirefoxExecutable() error = %v", err)
+	}
+	want := FirefoxPathInVersion(filepath.Join(cacheDir, "firefox", "release", "154.0"))
+	if got != want {
+		t.Errorf("GetFirefoxExecutable() = %q, want the newest %q", got, want)
+	}
+}

--- a/clicker/internal/paths/paths.go
+++ b/clicker/internal/paths/paths.go
@@ -227,10 +227,21 @@ func GetFirefoxExecutableForChannel(channel string) (string, error) {
 
 // resolveFirefoxVersionDir returns the newest cached Firefox version
 // directory containing the executable, mirroring resolveVersionDir.
+// VIBIUM_FIREFOX_VERSION pins the choice: the pinned version must also be
+// what launches, or newest-cached would silently run a different Firefox
+// than the pin installed.
 func resolveFirefoxVersionDir(channel string) (string, error) {
 	ffDir, err := GetFirefoxDirForChannel(channel)
 	if err != nil {
 		return "", err
+	}
+
+	if v := os.Getenv("VIBIUM_FIREFOX_VERSION"); v != "" {
+		dir := filepath.Join(ffDir, v)
+		if _, err := os.Stat(FirefoxPathInVersion(dir)); err != nil {
+			return "", err
+		}
+		return dir, nil
 	}
 
 	entries, err := os.ReadDir(ffDir)

--- a/docs/how-to-guides/using-firefox.md
+++ b/docs/how-to-guides/using-firefox.md
@@ -104,6 +104,7 @@ currently requires Firefox, while PDF output may differ between engines.
 | `VIBIUM_ENGINE` | Default engine (`chrome` or `firefox`) when `--engine` is not given |
 | `VIBIUM_FIREFOX_PATH` | Use this Firefox executable instead of the vibium cache; when set, channel selection does not apply |
 | `VIBIUM_FIREFOX_CHANNEL` | Channel to install and run: `release` (default) or `beta`; same as `--firefox-channel` or the clients' `channel` option |
+| `VIBIUM_FIREFOX_VERSION` | Pin the exact version to install and run (e.g. `153.0.4`) instead of the channel's latest; keeps CI and fleets on one version until you move the pin |
 
 ## Feature notes
 


### PR DESCRIPTION
Fixes VibiumDev#326.

The installer always resolved the channel's latest version from Mozilla's product-details JSON, so different machines silently drift apart over time. CI's beta pin jumped from Firefox 154 to 155.0b1 the day 154 reached release.

`VIBIUM_FIREFOX_VERSION` pins an exact version, following the existing env-var pattern. With it set:

- `vibium install` fetches exactly that version and skips the product-details lookup
- executable resolution launches exactly that cached version. A pin that is not cached is an error, not a fallback to newest, since launching anything else defeats the pin
- is-installed answers for the pinned version

The issue left the choice open between this and Chrome-style in-repo pinning. The env var is the smaller commitment: CI gets a real pin without version-bump PRs on every Firefox release, and an in-repo pin can be added later by setting the var from a checked-in file.

Verified:

- Tests cover pin resolution without network, pinned selection over a newer cached version, the missing-pin error, and unpinned newest-wins staying intact
- Live: pinned install resolves the cached version without a fetch; is-installed exits 1 for an absent pinned version