### PR TITLE
Fall back to per-event subscription when a batched subscribe is rejected - #19

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -801,15 +801,13 @@ func (h *Handlers) startPromptTracking() {
 		return
 	}
 
-	client.SendCommand("session.subscribe", map[string]interface{}{
-		"events": []string{
-			"browsingContext.userPromptOpened",
-			"browsingContext.userPromptClosed",
-			"browsingContext.navigationStarted",
-			"browsingContext.navigationFailed",
-			"browsingContext.navigationAborted",
-			"browsingContext.load",
-		},
+	subscribeEvents(client, []string{
+		"browsingContext.userPromptOpened",
+		"browsingContext.userPromptClosed",
+		"browsingContext.navigationStarted",
+		"browsingContext.navigationFailed",
+		"browsingContext.navigationAborted",
+		"browsingContext.load",
 	})
 	client.SetEventHandler(h.handleBidiEvent)
 }
@@ -4077,21 +4075,19 @@ func (h *Handlers) browserRecordStart(args map[string]interface{}) (*ToolsCallRe
 	h.recorder = recorder
 
 	// Subscribe to events and feed them to the recorder
-	h.client.SendCommand("session.subscribe", map[string]interface{}{
-		"events": []string{
-			"network.beforeRequestSent",
-			"network.responseCompleted",
-			"network.fetchError",
-			"log.entryAdded",
-			"browsingContext.userPromptOpened",
-			"browsingContext.downloadWillBegin",
-			"browsingContext.load",
-			"browsingContext.navigationStarted",
-			"browsingContext.navigationFailed",
-			"browsingContext.navigationAborted",
-			"browsingContext.fragmentNavigated",
-			"browsingContext.historyUpdated",
-		},
+	subscribeEvents(h.client, []string{
+		"network.beforeRequestSent",
+		"network.responseCompleted",
+		"network.fetchError",
+		"log.entryAdded",
+		"browsingContext.userPromptOpened",
+		"browsingContext.downloadWillBegin",
+		"browsingContext.load",
+		"browsingContext.navigationStarted",
+		"browsingContext.navigationFailed",
+		"browsingContext.navigationAborted",
+		"browsingContext.fragmentNavigated",
+		"browsingContext.historyUpdated",
 	})
 	h.recordDropBase = h.client.DroppedEvents()
 	// handleBidiEvent already forwards to the recorder; replacing the handler

--- a/clicker/internal/agent/subscribe.go
+++ b/clicker/internal/agent/subscribe.go
@@ -1,0 +1,16 @@
+package agent
+
+import (
+	"github.com/vibium/clicker/internal/bidi"
+)
+
+// subscribeEvents batch-subscribes with per-event fallback so an event name
+// the engine does not implement cannot silence the rest (bidi.SubscribeEvents).
+func subscribeEvents(client *bidi.Client, events []string) {
+	bidi.SubscribeEvents(func(evs []string) error {
+		_, err := client.SendCommand("session.subscribe", map[string]interface{}{
+			"events": evs,
+		})
+		return err
+	}, events)
+}

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -216,34 +216,41 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 	go r.routeBrowserToClient(session)
 
 	// Subscribe to events synchronously — must complete before client commands
-	// so Chrome delivers events (contextCreated, beforeRequestSent, etc.) from
-	// the very first navigation. Without this, a fast client could send commands
-	// before Chrome knows to forward events, causing missed events or hangs.
-	_, err = r.sendInternalCommand(session, "session.subscribe", map[string]interface{}{
-		"events": []string{
-			"browsingContext.contextCreated",
-			"network.beforeRequestSent",
-			"network.responseCompleted",
-			"browsingContext.userPromptOpened",
-			"browsingContext.userPromptClosed",
-			"log.entryAdded",
-			"browsingContext.downloadWillBegin",
-			"browsingContext.downloadEnd",
-			"browsingContext.load",
-			// navigationStarted/Failed/Aborted bracket an in-flight navigation, so
-			// a filmstrip capture can wait it out instead of timing out (#289).
-			"browsingContext.navigationStarted",
-			"browsingContext.navigationFailed",
-			"browsingContext.navigationAborted",
-			"browsingContext.fragmentNavigated",
-			// SPA routing via history.pushState/replaceState changes the URL
-			// without a load or fragment event (#126).
-			"browsingContext.historyUpdated",
-		},
+	// so the browser delivers events (contextCreated, beforeRequestSent, etc.)
+	// from the very first navigation. Without this, a fast client could send
+	// commands before the browser knows to forward events, causing missed
+	// events or hangs. SubscribeEvents falls back to per-event subscription
+	// when the batch fails: Firefox rejects the whole batch over the one name
+	// it does not implement (navigationAborted), which used to silence every
+	// event on the Firefox path (#348).
+	bidi.SubscribeEvents(func(events []string) error {
+		resp, err := r.sendInternalCommand(session, "session.subscribe", map[string]interface{}{
+			"events": events,
+		})
+		if err != nil {
+			return err
+		}
+		return checkBidiError(resp)
+	}, []string{
+		"browsingContext.contextCreated",
+		"network.beforeRequestSent",
+		"network.responseCompleted",
+		"browsingContext.userPromptOpened",
+		"browsingContext.userPromptClosed",
+		"log.entryAdded",
+		"browsingContext.downloadWillBegin",
+		"browsingContext.downloadEnd",
+		"browsingContext.load",
+		// navigationStarted/Failed/Aborted bracket an in-flight navigation, so
+		// a filmstrip capture can wait it out instead of timing out (#289).
+		"browsingContext.navigationStarted",
+		"browsingContext.navigationFailed",
+		"browsingContext.navigationAborted",
+		"browsingContext.fragmentNavigated",
+		// SPA routing via history.pushState/replaceState changes the URL
+		// without a load or fragment event (#126).
+		"browsingContext.historyUpdated",
 	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[router] Failed to subscribe to events for client %d: %v\n", client.ID(), err)
-	}
 
 	// Establish download behavior synchronously, for the same reason
 	// session.subscribe above is synchronous: OnClientConnect runs before the

--- a/clicker/internal/api/subscribe_fallback_test.go
+++ b/clicker/internal/api/subscribe_fallback_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// Firefox does not implement browsingContext.navigationAborted and rejects
+// any session.subscribe batch containing it with "invalid argument". The
+// router batches all its events into one subscribe, so that one name used to
+// take down every subscription: no console, download, popup, dialog, network,
+// or navigation events ever arrived on the Firefox path (#348, #323, #324).
+// This pins the fallback: after a rejected batch, every event the browser
+// does accept must still get subscribed individually.
+func TestSubscribeFallsBackWhenBatchIsRejected(t *testing.T) {
+	var mu sync.Mutex
+	subscribed := map[string]bool{}
+
+	upgrader := websocket.Upgrader{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		for {
+			_, raw, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var cmd struct {
+				ID     int64  `json:"id"`
+				Method string `json:"method"`
+				Params struct {
+					Events []string `json:"events"`
+				} `json:"params"`
+			}
+			if json.Unmarshal(raw, &cmd) != nil {
+				continue
+			}
+
+			// ready:false makes the router attach to this endpoint's session
+			// rather than create one, keeping the handshake to one command.
+			result := `{}`
+			reject := false
+			if cmd.Method == "session.status" {
+				result = `{"ready":false,"message":"already has session"}`
+			}
+			if cmd.Method == "session.subscribe" {
+				for _, ev := range cmd.Params.Events {
+					if ev == "browsingContext.navigationAborted" {
+						reject = true
+					}
+				}
+				if !reject {
+					mu.Lock()
+					for _, ev := range cmd.Params.Events {
+						subscribed[ev] = true
+					}
+					mu.Unlock()
+				}
+			}
+
+			id := strconv.FormatInt(cmd.ID, 10)
+			if reject {
+				conn.WriteMessage(websocket.TextMessage,
+					[]byte(`{"id":`+id+`,"type":"error","error":"invalid argument","message":"browsingContext.navigationAborted is not a valid event name"}`))
+				continue
+			}
+			conn.WriteMessage(websocket.TextMessage,
+				[]byte(`{"id":`+id+`,"type":"success","result":`+result+`}`))
+		}
+	}))
+	defer ts.Close()
+
+	router := NewRouter("firefox", true, "ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+	client := &recordingClient{}
+	t.Cleanup(router.CloseAll)
+
+	router.OnClientConnect(client)
+
+	if _, ok := router.sessions.Load(client.ID()); !ok {
+		t.Fatal("router has no session for the client")
+	}
+
+	wanted := []string{
+		"browsingContext.contextCreated",
+		"network.beforeRequestSent",
+		"network.responseCompleted",
+		"browsingContext.userPromptOpened",
+		"browsingContext.userPromptClosed",
+		"log.entryAdded",
+		"browsingContext.downloadWillBegin",
+		"browsingContext.downloadEnd",
+		"browsingContext.load",
+		"browsingContext.navigationStarted",
+		"browsingContext.navigationFailed",
+		"browsingContext.fragmentNavigated",
+		"browsingContext.historyUpdated",
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ev := range wanted {
+		if !subscribed[ev] {
+			t.Errorf("event %s was never subscribed after the batch was rejected", ev)
+		}
+	}
+	if subscribed["browsingContext.navigationAborted"] {
+		t.Error("browser recorded a subscription for the event it rejects")
+	}
+}

--- a/clicker/internal/bidi/subscribe.go
+++ b/clicker/internal/bidi/subscribe.go
@@ -7,15 +7,24 @@ import (
 )
 
 // SubscribeEvents subscribes to the given event names in one batch. An engine
-// that does not recognise a single name rejects the whole batch — Firefox does
-// this for browsingContext.navigationAborted — which would leave every event
+// that does not recognise a single name rejects the whole batch (Firefox does
+// this for browsingContext.navigationAborted), which would leave every event
 // undelivered. On batch failure each event is subscribed individually so an
 // unknown name costs only itself. Returns the names the browser rejected.
+//
+// The per-event pass is serial round trips, but it runs only when the batch
+// was rejected; an engine that accepts the batch pays a single round trip.
+// If the retries ever matter, cache the rejected set per engine after the
+// first connect.
 //
 // subscribe sends one session.subscribe for the given events and returns an
 // error for both transport failures and BiDi error responses.
 func SubscribeEvents(subscribe func(events []string) error, events []string) []string {
-	if len(events) == 0 || subscribe(events) == nil {
+	if len(events) == 0 {
+		return nil
+	}
+	batchErr := subscribe(events)
+	if batchErr == nil {
 		return nil
 	}
 
@@ -26,9 +35,14 @@ func SubscribeEvents(subscribe func(events []string) error, events []string) []s
 		}
 	}
 
-	if len(rejected) > 0 {
-		// Directly on stderr: the default log level discards Warn, and a
-		// feature silently losing its events must stay visible (#348).
+	// Directly on stderr: the default log level discards Warn, and a feature
+	// silently losing its events must stay visible (#348). When nothing
+	// subscribed at all, the cause is whatever failed the batch (a dead
+	// connection, a timeout), so report that error rather than blaming
+	// every event name.
+	if len(rejected) == len(events) {
+		fmt.Fprintf(os.Stderr, "vibium: event subscription failed: %v\n", batchErr)
+	} else if len(rejected) > 0 {
 		fmt.Fprintf(os.Stderr, "vibium: browser rejected event subscription for %s; features relying on these events are degraded\n",
 			strings.Join(rejected, ", "))
 	}

--- a/clicker/internal/bidi/subscribe.go
+++ b/clicker/internal/bidi/subscribe.go
@@ -1,0 +1,36 @@
+package bidi
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SubscribeEvents subscribes to the given event names in one batch. An engine
+// that does not recognise a single name rejects the whole batch — Firefox does
+// this for browsingContext.navigationAborted — which would leave every event
+// undelivered. On batch failure each event is subscribed individually so an
+// unknown name costs only itself. Returns the names the browser rejected.
+//
+// subscribe sends one session.subscribe for the given events and returns an
+// error for both transport failures and BiDi error responses.
+func SubscribeEvents(subscribe func(events []string) error, events []string) []string {
+	if len(events) == 0 || subscribe(events) == nil {
+		return nil
+	}
+
+	var rejected []string
+	for _, ev := range events {
+		if subscribe([]string{ev}) != nil {
+			rejected = append(rejected, ev)
+		}
+	}
+
+	if len(rejected) > 0 {
+		// Directly on stderr: the default log level discards Warn, and a
+		// feature silently losing its events must stay visible (#348).
+		fmt.Fprintf(os.Stderr, "vibium: browser rejected event subscription for %s; features relying on these events are degraded\n",
+			strings.Join(rejected, ", "))
+	}
+	return rejected
+}

--- a/clicker/internal/bidi/subscribe_test.go
+++ b/clicker/internal/bidi/subscribe_test.go
@@ -2,7 +2,10 @@ package bidi
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -48,6 +51,37 @@ func TestSubscribeEventsFallsBackPerEvent(t *testing.T) {
 	}
 	if subscribed["bad"] {
 		t.Fatal("rejected event must not be recorded as subscribed")
+	}
+}
+
+// A dead connection fails the batch and every per-event retry. The warning
+// must then carry the transport error, not blame the event names.
+// Swaps os.Stderr to capture the warning, so it must never run in parallel.
+func TestSubscribeEventsTransportFailureReportsBatchError(t *testing.T) {
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	rejected := SubscribeEvents(func([]string) error {
+		return fmt.Errorf("connection lost waiting for response to session.subscribe")
+	}, []string{"a", "b"})
+
+	w.Close()
+	os.Stderr = origStderr
+	out, _ := io.ReadAll(r)
+
+	if !reflect.DeepEqual(rejected, []string{"a", "b"}) {
+		t.Fatalf("rejected = %v, want all events", rejected)
+	}
+	if !strings.Contains(string(out), "connection lost") {
+		t.Fatalf("warning must carry the batch error, got: %q", out)
+	}
+	if strings.Contains(string(out), "rejected event subscription for") {
+		t.Fatalf("transport failure must not be reported as rejected names, got: %q", out)
 	}
 }
 

--- a/clicker/internal/bidi/subscribe_test.go
+++ b/clicker/internal/bidi/subscribe_test.go
@@ -1,0 +1,62 @@
+package bidi
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestSubscribeEventsBatchSuccess(t *testing.T) {
+	var calls [][]string
+	rejected := SubscribeEvents(func(events []string) error {
+		calls = append(calls, events)
+		return nil
+	}, []string{"a", "b", "c"})
+
+	if rejected != nil {
+		t.Fatalf("no event should be rejected, got %v", rejected)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("an accepted batch must subscribe exactly once, got %d calls", len(calls))
+	}
+}
+
+// An engine that does not know one event name rejects the whole batch, the
+// way Firefox rejects any batch containing browsingContext.navigationAborted.
+// The fallback must keep every name the engine does accept.
+func TestSubscribeEventsFallsBackPerEvent(t *testing.T) {
+	subscribed := map[string]bool{}
+	rejected := SubscribeEvents(func(events []string) error {
+		for _, ev := range events {
+			if ev == "bad" {
+				return fmt.Errorf("invalid argument: bad is not a valid event name")
+			}
+		}
+		for _, ev := range events {
+			subscribed[ev] = true
+		}
+		return nil
+	}, []string{"a", "bad", "c"})
+
+	if !reflect.DeepEqual(rejected, []string{"bad"}) {
+		t.Fatalf("rejected = %v, want [bad]", rejected)
+	}
+	for _, ev := range []string{"a", "c"} {
+		if !subscribed[ev] {
+			t.Fatalf("valid event %q was not subscribed after batch failure", ev)
+		}
+	}
+	if subscribed["bad"] {
+		t.Fatal("rejected event must not be recorded as subscribed")
+	}
+}
+
+func TestSubscribeEventsEmptyList(t *testing.T) {
+	called := false
+	if rejected := SubscribeEvents(func([]string) error { called = true; return nil }, nil); rejected != nil {
+		t.Fatalf("rejected = %v, want nil", rejected)
+	}
+	if called {
+		t.Fatal("no subscribe call expected for an empty event list")
+	}
+}


### PR DESCRIPTION
Fixes VibiumDev#365.

Root cause of VibiumDev#348 and the event delivery behind VibiumDev#323 and VibiumDev#324.

The router subscribes to all fourteen BiDi events in one `session.subscribe`. Firefox does not implement `browsingContext.navigationAborted` and rejects the whole batch over that one name, so the Firefox path received no events at all: no console, download, popup, dialog, network, or navigation events. The error was logged to stderr and the session carried on silently.

`bidi.SubscribeEvents` sends the batch first and, when the browser rejects it, subscribes each event individually, so an unknown name costs only itself. Rejected names print as one warning line on stderr, following the existing must-stay-visible-in-quiet-mode pattern, so the next engine gap is diagnosable from normal output. Losing `navigationAborted` on Firefox costs nothing: `NavigationTracker` uses it only as a navigation-settled signal, and Firefox reports aborts as `navigationFailed`.

## What changed

- `bidi.SubscribeEvents` implements the batch-then-per-event fallback and returns the rejected names
- All three batched subscribe sites use it: the router connect path, and the agent's prompt tracking and recording start. The fourth `session.subscribe` in the codebase sends the single spec-standard `script.message` and cannot partially fail, so it is unchanged
- No capability flips here; those follow per family once each suite is green on Firefox

Verified:

- Unit tests: an accepted batch subscribes once; a rejected batch subscribes the valid names individually; an empty list sends nothing
- Router test against a fake browser that rejects any batch containing `navigationAborted` the way Firefox 154 does; fails on main, passes here
- Live on Firefox 154: `page.onConsole` delivers a console.log from a locally served page, and the warning line names the one rejected event
- Full `make test` green
