### PR TITLE
Enable console, download, popup, and navigation capture on Firefox

### DIFF
--- a/docs/how-to-guides/using-firefox.md
+++ b/docs/how-to-guides/using-firefox.md
@@ -115,10 +115,10 @@ currently requires Firefox, while PDF output may differ between engines.
 | Dialog callbacks and `capture.dialog()` | Supported | Not supported reliably by Vibium's native Firefox path yet |
 | Network events and request interception | Supported | Not supported reliably by Vibium's native Firefox path yet |
 | PDF printing (`page.pdf`) | Supported | Output and support may differ |
-| Console and page error events (`onConsole`, `onError`) | Supported | Not delivered by Vibium's native Firefox path yet |
-| Download events (`onDownload`, `capture.download()`) | Supported | Not delivered by Vibium's native Firefox path yet |
-| New tab and popup events (`onPage`, `onPopup`) | Supported | Not delivered by Vibium's native Firefox path yet |
-| Navigation capture (`capture.navigation()`) | Supported | Not delivered by Vibium's native Firefox path yet |
+| Console and page error events (`onConsole`, `onError`) | Supported | Supported and covered by the cross-engine suites |
+| Download events (`onDownload`, `capture.download()`) | Supported | Supported and covered by the cross-engine suites |
+| New tab and popup events (`onPage`, `onPopup`) | Supported | Supported and covered by the cross-engine suites |
+| Navigation capture (`capture.navigation()`) | Supported | Supported and covered by the cross-engine suites |
 
 CI runs the full suite on Chrome. A separate Firefox job runs capability-selected
 CLI and client tests plus focused installation, launch, channel, and video coverage.

--- a/tests/capabilities.json
+++ b/tests/capabilities.json
@@ -5,8 +5,8 @@
   "pdf": ["chrome"],
   "prompt-blocking": ["chrome"],
   "audio": [],
-  "console": ["chrome"],
-  "downloads": ["chrome"],
-  "popups": ["chrome"],
-  "navigation-capture": ["chrome"]
+  "console": ["chrome", "firefox"],
+  "downloads": ["chrome", "firefox"],
+  "popups": ["chrome", "firefox"],
+  "navigation-capture": ["chrome", "firefox"]
 }

--- a/tests/js/sync/engine/download-sync.test.js
+++ b/tests/js/sync/engine/download-sync.test.js
@@ -60,7 +60,9 @@ describe('Sync API: onDownload', () => {
 
   test('download has url and suggestedFilename', () => {
     const vibe = bro.newPage();
-    vibe.go(`${baseURL}/download`);
+    // Own filename: the session's earlier tests already downloaded test.txt,
+    // and Firefox reports a repeated name deduplicated ("test(1).txt").
+    vibe.go(`${baseURL}/download?name=named.txt`);
 
     const downloads = [];
     vibe.onDownload((dl) => {
@@ -72,7 +74,7 @@ describe('Sync API: onDownload', () => {
 
     assert.ok(downloads.length >= 1);
     assert.ok(downloads[0].url.includes('/download-file'), `URL should contain /download-file, got: ${downloads[0].url}`);
-    assert.strictEqual(downloads[0].suggestedFilename, 'test.txt');
+    assert.strictEqual(downloads[0].suggestedFilename, 'named.txt');
   });
 
   test('removeAllListeners("download") stops onDownload callbacks', () => {
@@ -110,14 +112,15 @@ describe('Sync API: onDownload', () => {
 
   test('capture.download returns path and supports saveAs', () => {
     const vibe = bro.newPage();
-    vibe.go(`${baseURL}/download`);
+    // Own filename, same reason as the suggestedFilename test above.
+    vibe.go(`${baseURL}/download?name=captured.txt`);
 
     const result = vibe.capture.download(() => {
       vibe.find('#download-link').click();
     });
 
     assert.ok(result.url.includes('/download-file'));
-    assert.strictEqual(result.suggestedFilename, 'test.txt');
+    assert.strictEqual(result.suggestedFilename, 'captured.txt');
     assert.ok(result.path, 'path should be set after capture.download');
 
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-dl-'));

--- a/tests/js/sync/engine/sync-api.test.js
+++ b/tests/js/sync/engine/sync-api.test.js
@@ -698,6 +698,9 @@ describe.requires('popups')('Sync API: onPage/onPopup', () => {
       const popups = [];
       bro.onPopup((p) => popups.push(p));
       const page = bro.page();
+      // Firefox's initial page is a privileged parent-process context that
+      // rejects script.evaluate; navigate somewhere evaluable first.
+      page.go(baseURL);
       page.evaluate("window.open('about:blank')");
       assert.strictEqual(popups.length, 1);
       assert.ok(popups[0], 'Should receive a PageSync');

--- a/tests/js/sync/sync-test-server.js
+++ b/tests/js/sync/sync-test-server.js
@@ -179,12 +179,25 @@ const server = http.createServer((req, res) => {
     });
     return;
   }
-  if (req.url === '/download-file') {
+  // ?name= gives a test its own filename. Repeating one name within a browser
+  // session makes Firefox report the deduplicated name ("test(1).txt") in
+  // downloadWillBegin, so name-asserting tests must not share a filename.
+  const parsed = new URL(req.url, `http://${req.headers.host}`);
+  if (parsed.pathname === '/download-file') {
+    const name = parsed.searchParams.get('name') || 'test.txt';
     res.writeHead(200, {
       'Content-Type': 'application/octet-stream',
-      'Content-Disposition': 'attachment; filename="test.txt"',
+      'Content-Disposition': `attachment; filename="${name}"`,
     });
     res.end('download content');
+    return;
+  }
+  if (parsed.pathname === '/download' && parsed.searchParams.has('name')) {
+    const name = parsed.searchParams.get('name');
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<html><head><title>Download</title></head><body>
+  <a href="/download-file?name=${name}" id="download-link" download="${name}">Download</a>
+</body></html>`);
     return;
   }
   res.writeHead(200, { 'Content-Type': 'text/html' });

--- a/tests/py/engine/test_network_dialog.py
+++ b/tests/py/engine/test_network_dialog.py
@@ -327,13 +327,15 @@ async def test_capture_navigation(net_browser, test_server):
 @pytest.mark.capability("downloads")
 async def test_capture_download(net_browser, test_server):
     vibe = await net_browser.new_page()
-    await vibe.go(test_server + "/download")
+    # Own filename so a repeated test.txt in this session cannot come back
+    # deduplicated ("test(1).txt") on Firefox.
+    await vibe.go(test_server + "/download?name=net-captured.txt")
     link = await vibe.find("#download-link")
     async with vibe.capture.download() as info:
         await link.click()
     assert info.value is not None
-    assert info.value.url().endswith("/download-file") or "/download-file" in info.value.url()
-    assert info.value.suggested_filename() == "test.txt"
+    assert "/download-file" in info.value.url()
+    assert info.value.suggested_filename() == "net-captured.txt"
     await vibe.close()
 
 

--- a/tests/py/engine/test_sync_api.py
+++ b/tests/py/engine/test_sync_api.py
@@ -723,12 +723,14 @@ def test_capture_navigation(bro, test_server):
 @pytest.mark.capability("downloads")
 def test_capture_download(bro, test_server):
     vibe = bro.new_page()
-    vibe.go(test_server + "/download")
+    # Own filename: another test in this session downloads test.txt, and
+    # Firefox reports a repeated name deduplicated ("test(1).txt").
+    vibe.go(test_server + "/download?name=sync-captured.txt")
     with vibe.capture.download() as info:
         vibe.find("#download-link").click()
     assert info.value is not None
     assert "/download-file" in info.value["url"]
-    assert info.value["suggested_filename"] == "test.txt"
+    assert info.value["suggested_filename"] == "sync-captured.txt"
     assert info.value["path"] is not None
     vibe.close()
 

--- a/tests/py/engine/test_sync_download.py
+++ b/tests/py/engine/test_sync_download.py
@@ -20,7 +20,9 @@ def test_download_fires(sync_browser, test_server):
 def test_download_url_filename(sync_browser, test_server):
     """Download object has url and suggested_filename."""
     vibe = sync_browser.new_page()
-    vibe.go(test_server + "/download")
+    # Own filename: the session's other tests download test.txt, and Firefox
+    # reports a repeated name deduplicated ("test(1).txt").
+    vibe.go(test_server + "/download?name=named.txt")
     downloads = []
     vibe.on_download(lambda d: downloads.append(d))
     link = vibe.find("#download-link")
@@ -28,7 +30,7 @@ def test_download_url_filename(sync_browser, test_server):
     vibe.wait(1000)
     assert len(downloads) >= 1
     assert "download-file" in downloads[0].url()
-    assert downloads[0].suggested_filename() == "test.txt"
+    assert downloads[0].suggested_filename() == "named.txt"
 
 
 def test_remove_download_listeners(sync_browser, test_server):

--- a/tests/py/test_server.py
+++ b/tests/py/test_server.py
@@ -6,6 +6,7 @@ All routes match the JS sync-test-server.js so tests are equivalent.
 import json
 import threading
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from urllib.parse import parse_qs, urlparse
 
 
 HOME_HTML = """<html><head><title>Test App</title></head><body>
@@ -268,13 +269,33 @@ class VibiumTestHandler(BaseHTTPRequestHandler):
             self.wfile.write(SET_COOKIE_HTML.encode())
             return
 
+        # ?name= gives a test its own filename. Repeating one name within a
+        # browser session makes Firefox report the deduplicated name
+        # ("test(1).txt") in downloadWillBegin, so name-asserting tests must
+        # not share a filename.
         if path == "/download-file":
+            query = parse_qs(urlparse(self.path).query)
+            name = query.get("name", ["test.txt"])[0]
             self.send_response(200)
             self.send_header("Content-Type", "application/octet-stream")
-            self.send_header("Content-Disposition", 'attachment; filename="test.txt"')
+            self.send_header("Content-Disposition", f'attachment; filename="{name}"')
             self.end_headers()
             self.wfile.write(b"download content")
             return
+
+        if path == "/download":
+            query = parse_qs(urlparse(self.path).query)
+            if "name" in query:
+                name = query["name"][0]
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(
+                    f"""<html><head><title>Download</title></head><body>
+  <a href="/download-file?name={name}" id="download-link" download="{name}">Download</a>
+</body></html>""".encode()
+                )
+                return
 
         html = HTML_ROUTES.get(path, HOME_HTML)
         self.send_response(200)


### PR DESCRIPTION
Fixes VibiumDev#348.

Console and page error events, download events, popup events, and navigation capture all work on Firefox now that event subscription survives the navigationAborted rejection. This flips the four families to firefox in tests/capabilities.json, so the Node, pytest, and JUnit engine suites run them cross-engine, and updates the feature table in using-firefox.md to match.

Three sync tests encoded Chrome-only assumptions and needed adjusting, not the product:

- Firefox reports a filename that repeats within a browser session deduplicated ("test(1).txt") in downloadWillBegin, and the shared-session download tests re-download test.txt. The JS and Python test servers take ?name= on /download and /download-file so each name-asserting test downloads its own filename. One Python test only passed by running before its session's other download test; it gets its own name too.
- Firefox's initial page is a privileged parent-process context that rejects script.evaluate, so the sync popup test navigates to the test server before evaluating window.open.

Verified:

- CLI shared suite on Firefox 71/71, JS cross-engine suites 391 passing with 2 capability skips
- pytest engine suite on Firefox: 364 passed, 2 skipped, both the chrome-only pdf tests
- JUnit engine suite on Firefox: build successful, every capability-selected class runs with no skips
- Full make test green on Chrome
