### PR TITLE
Enable dialogs and prompt blocking on Firefox

### DIFF
--- a/docs/how-to-guides/using-firefox.md
+++ b/docs/how-to-guides/using-firefox.md
@@ -112,7 +112,7 @@ currently requires Firefox, while PDF output may differ between engines.
 |------------|--------|---------|
 | Navigation, elements, input, pages, screenshots, storage, and trace recording | Supported | Supported and covered by the Firefox core suite |
 | Native video (`recording.start({ video: true })`) | Not implemented by Chrome yet | Firefox 154+; see [Record Video](record-video.md) |
-| Dialog callbacks and `capture.dialog()` | Supported | Not supported reliably by Vibium's native Firefox path yet |
+| Dialog callbacks and `capture.dialog()` | Supported | Supported and covered by the cross-engine suites |
 | Network events and request interception | Supported | Not supported reliably by Vibium's native Firefox path yet |
 | PDF printing (`page.pdf`) | Supported | Output and support may differ |
 | Console and page error events (`onConsole`, `onError`) | Supported | Not delivered by Vibium's native Firefox path yet |

--- a/tests/capabilities.json
+++ b/tests/capabilities.json
@@ -1,9 +1,9 @@
 {
   "core": ["chrome", "firefox"],
   "network": ["chrome"],
-  "dialogs": ["chrome"],
+  "dialogs": ["chrome", "firefox"],
   "pdf": ["chrome"],
-  "prompt-blocking": ["chrome"],
+  "prompt-blocking": ["chrome", "firefox"],
   "audio": [],
   "console": ["chrome"],
   "downloads": ["chrome"],


### PR DESCRIPTION
Fixes VibiumDev#323.

Dialog callbacks, capture.dialog, and the fail-fast on prompt-blocked commands pass the cross-engine suites on Firefox now that userPromptOpened and userPromptClosed are delivered. The launcher already ran Firefox with unhandledPromptBehavior ignore and the dialog handlers were already spec-standard BiDi commands, so no product change was needed: this flips dialogs and prompt-blocking to firefox in tests/capabilities.json and updates the feature table row in using-firefox.md.

Verified:

- Dialog and prompt tests pass in the CLI shared, JS, Python, and Java engine suites on Firefox 154
- Suites on the combined branch: CLI shared 71/71, JS 391 passing, pytest 364 passing, JUnit build successful
- Full make test green on Chrome
