### PR TITLE
Enable network events and request interception on Firefox

### DIFF
--- a/docs/how-to-guides/using-firefox.md
+++ b/docs/how-to-guides/using-firefox.md
@@ -113,7 +113,7 @@ currently requires Firefox, while PDF output may differ between engines.
 | Navigation, elements, input, pages, screenshots, storage, and trace recording | Supported | Supported and covered by the Firefox core suite |
 | Native video (`recording.start({ video: true })`) | Not implemented by Chrome yet | Firefox 154+; see [Record Video](record-video.md) |
 | Dialog callbacks and `capture.dialog()` | Supported | Not supported reliably by Vibium's native Firefox path yet |
-| Network events and request interception | Supported | Not supported reliably by Vibium's native Firefox path yet |
+| Network events and request interception | Supported | Supported and covered by the cross-engine suites |
 | PDF printing (`page.pdf`) | Supported | Output and support may differ |
 | Console and page error events (`onConsole`, `onError`) | Supported | Not delivered by Vibium's native Firefox path yet |
 | Download events (`onDownload`, `capture.download()`) | Supported | Not delivered by Vibium's native Firefox path yet |

--- a/tests/capabilities.json
+++ b/tests/capabilities.json
@@ -1,6 +1,6 @@
 {
   "core": ["chrome", "firefox"],
-  "network": ["chrome"],
+  "network": ["chrome", "firefox"],
   "dialogs": ["chrome"],
   "pdf": ["chrome"],
   "prompt-blocking": ["chrome"],


### PR DESCRIPTION
Fixes VibiumDev#324.

Routes, request and response waiting, network capture, response bodies, and setHeaders pass the cross-engine suites on Firefox now that network.beforeRequestSent and network.responseCompleted are delivered. The interception handlers (addIntercept, continueRequest, provideResponse, failRequest) were already spec-standard BiDi commands, so no product change was needed: this flips network to firefox in tests/capabilities.json and updates the feature table row in using-firefox.md.

Verified:

- Network tests pass in the CLI shared, JS, Python, and Java engine suites on Firefox 154
- Suites on the combined branch: CLI shared 71/71, JS 391 passing, pytest 364 passing, JUnit build successful
- Full make test green on Chrome
