### PR TITLE
Add one-shot capture APIs to Java

### DIFF
--- a/clients/java/src/main/java/com/vibium/Capture.java
+++ b/clients/java/src/main/java/com/vibium/Capture.java
@@ -1,0 +1,206 @@
+package com.vibium;
+
+import com.vibium.errors.VibiumException;
+import com.vibium.errors.VibiumTimeoutException;
+import com.vibium.types.WaitOptions;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+/**
+ * One-shot event capture helpers. Each method registers its listener before
+ * starting the action, then removes that listener on every exit path.
+ */
+public final class Capture {
+
+    private static final long DEFAULT_TIMEOUT_MS = 10_000;
+    private static final ExecutorService ACTIONS = Executors.newCachedThreadPool(r -> {
+        Thread thread = new Thread(r, "vibium-capture-action");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private final Page page;
+
+    Capture(Page page) {
+        this.page = page;
+    }
+
+    public Request request(String pattern, Runnable action) {
+        return request(pattern, action, null);
+    }
+
+    public Request request(String pattern, Runnable action, WaitOptions options) {
+        return await(
+            handler -> page.addRequestListener(handler),
+            handler -> page.removeRequestListener(handler),
+            request -> Page.matchPattern(pattern, request.url()),
+            action,
+            options,
+            "request matching '" + pattern + "'");
+    }
+
+    public Response response(String pattern, Runnable action) {
+        return response(pattern, action, null);
+    }
+
+    public Response response(String pattern, Runnable action, WaitOptions options) {
+        return await(
+            handler -> page.addResponseListener(handler),
+            handler -> page.removeResponseListener(handler),
+            response -> Page.matchPattern(pattern, response.url()),
+            action,
+            options,
+            "response matching '" + pattern + "'");
+    }
+
+    public String navigation(Runnable action) {
+        return navigation(action, null);
+    }
+
+    public String navigation(Runnable action, WaitOptions options) {
+        return await(
+            handler -> page.addNavigationListener(handler),
+            handler -> page.removeNavigationListener(handler),
+            value -> true,
+            action,
+            options,
+            "navigation");
+    }
+
+    public Download download(Runnable action) {
+        return download(action, null);
+    }
+
+    public Download download(Runnable action, WaitOptions options) {
+        return await(
+            handler -> page.addDownloadListener(handler),
+            handler -> page.removeDownloadListener(handler),
+            value -> true,
+            action,
+            options,
+            "download");
+    }
+
+    public Dialog dialog(Runnable action) {
+        return dialog(action, null);
+    }
+
+    public Dialog dialog(Runnable action, WaitOptions options) {
+        return await(
+            handler -> page.addDialogListener(handler),
+            handler -> page.removeDialogListener(handler),
+            value -> true,
+            action,
+            options,
+            "dialog");
+    }
+
+    public Object event(String name, Runnable action) {
+        return event(name, action, null);
+    }
+
+    public Object event(String name, Runnable action, WaitOptions options) {
+        switch (name) {
+            case "request":
+                return awaitAny(page::addRequestListener, page::removeRequestListener,
+                    action, options, name);
+            case "response":
+                return awaitAny(page::addResponseListener, page::removeResponseListener,
+                    action, options, name);
+            case "navigation":
+                return awaitAny(page::addNavigationListener, page::removeNavigationListener,
+                    action, options, name);
+            case "download":
+                return awaitAny(page::addDownloadListener, page::removeDownloadListener,
+                    action, options, name);
+            case "dialog":
+                return awaitAny(page::addDialogListener, page::removeDialogListener,
+                    action, options, name);
+            case "console":
+                return awaitAny(page::addConsoleListener, page::removeConsoleListener,
+                    action, options, name);
+            case "error":
+                return awaitAny(page::addErrorListener, page::removeErrorListener,
+                    action, options, name);
+            default:
+                throw new IllegalArgumentException("Unknown event name: '" + name + "'");
+        }
+    }
+
+    private <T> T awaitAny(Consumer<Consumer<T>> register,
+                           Consumer<Consumer<T>> unregister,
+                           Runnable action, WaitOptions options, String name) {
+        return await(register, unregister, value -> true, action, options,
+            "event '" + name + "'");
+    }
+
+    private <T> T await(Consumer<Consumer<T>> register,
+                        Consumer<Consumer<T>> unregister,
+                        java.util.function.Predicate<T> matches,
+                        Runnable action, WaitOptions options, String description) {
+        if (action == null) {
+            throw new IllegalArgumentException("capture action must not be null");
+        }
+
+        CompletableFuture<T> captured = new CompletableFuture<>();
+        Consumer<T> handler = value -> {
+            if (matches.test(value)) {
+                captured.complete(value);
+            }
+        };
+
+        register.accept(handler);
+        CompletableFuture<Void> actionFuture;
+        try {
+            actionFuture = CompletableFuture.runAsync(action, ACTIONS);
+        } catch (RuntimeException error) {
+            unregister.accept(handler);
+            throw error;
+        }
+
+        // A normal action completion does not end capture: the event can arrive
+        // after the action returns. A failure before the event does end it.
+        actionFuture.whenComplete((ignored, error) -> {
+            if (error != null) captured.completeExceptionally(unwrap(error));
+        });
+
+        try {
+            return captured.get(timeout(options), TimeUnit.MILLISECONDS);
+        } catch (TimeoutException error) {
+            actionFuture.cancel(true);
+            throw new VibiumTimeoutException("Timeout waiting for " + description);
+        } catch (ExecutionException error) {
+            Throwable cause = unwrap(error.getCause());
+            if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+            throw new VibiumException("Capture action failed: " + cause.getMessage(), cause);
+        } catch (InterruptedException error) {
+            actionFuture.cancel(true);
+            Thread.currentThread().interrupt();
+            throw new VibiumException("Interrupted while waiting for " + description, error);
+        } finally {
+            unregister.accept(handler);
+        }
+    }
+
+    private static long timeout(WaitOptions options) {
+        return options != null && options.timeout() != null
+            ? options.timeout()
+            : DEFAULT_TIMEOUT_MS;
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        Throwable current = error;
+        while ((current instanceof java.util.concurrent.CompletionException
+                || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/clients/java/src/main/java/com/vibium/Capture.java
+++ b/clients/java/src/main/java/com/vibium/Capture.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /**
@@ -149,8 +150,9 @@ public final class Capture {
         }
 
         CompletableFuture<T> captured = new CompletableFuture<>();
+        AtomicBoolean actionStarted = new AtomicBoolean();
         Consumer<T> handler = value -> {
-            if (matches.test(value)) {
+            if (actionStarted.get() && matches.test(value)) {
                 captured.complete(value);
             }
         };
@@ -158,7 +160,10 @@ public final class Capture {
         register.accept(handler);
         CompletableFuture<Void> actionFuture;
         try {
-            actionFuture = CompletableFuture.runAsync(action, ACTIONS);
+            actionFuture = CompletableFuture.runAsync(() -> {
+                actionStarted.set(true);
+                action.run();
+            }, ACTIONS);
         } catch (RuntimeException error) {
             unregister.accept(handler);
             throw error;

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -28,6 +28,7 @@ public class Page {
     private final Mouse mouse;
     private final Touch touch;
     private final Clock clock;
+    private final Capture capture;
 
     // Event listeners
     private final CopyOnWriteArrayList<Consumer<Request>> requestListeners = new CopyOnWriteArrayList<>();
@@ -37,6 +38,7 @@ public class Page {
     private final CopyOnWriteArrayList<Consumer<String>> errorListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<Download>> downloadListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<WebSocketInfo>> webSocketListeners = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<Consumer<String>> navigationListeners = new CopyOnWriteArrayList<>();
 
     // Buffered events
     private final List<ConsoleMessage> bufferedConsole = Collections.synchronizedList(new ArrayList<>());
@@ -59,6 +61,7 @@ public class Page {
         this.mouse = new Mouse(client, contextId);
         this.touch = new Touch(client, contextId);
         this.clock = new Clock(client, contextId);
+        this.capture = new Capture(this);
 
         // Register event handler
         this.eventHandler = this::handleEvent;
@@ -81,6 +84,9 @@ public class Page {
 
     /** Get the Clock for this page. */
     public Clock clock() { return clock; }
+
+    /** Get the one-shot event capture helpers for this page. */
+    public Capture capture() { return capture; }
 
     /** Get the parent BrowserContext. */
     public BrowserContext context() { return browserContext; }
@@ -601,6 +607,7 @@ public class Page {
             errorListeners.clear();
             downloadListeners.clear();
             webSocketListeners.clear();
+            navigationListeners.clear();
             return;
         }
         switch (event) {
@@ -611,6 +618,7 @@ public class Page {
             case "error": errorListeners.clear(); break;
             case "download": downloadListeners.clear(); break;
             case "websocket": webSocketListeners.clear(); break;
+            case "navigation": navigationListeners.clear(); break;
         }
     }
 
@@ -747,6 +755,11 @@ public class Page {
             case "browsingContext.downloadEnd":
                 handleDownloadCompleted(params);
                 break;
+            case "browsingContext.load":
+            case "browsingContext.fragmentNavigated":
+            case "browsingContext.historyUpdated":
+                handleNavigationEvent(params);
+                break;
             case "vibium:network.intercepted":
                 handleRouteEvent(params);
                 break;
@@ -818,6 +831,29 @@ public class Page {
             download.complete(status, path);
         }
     }
+
+    private void handleNavigationEvent(JsonObject params) {
+        String url = params.has("url") ? params.get("url").getAsString() : "";
+        if (url.isEmpty()) return;
+        for (Consumer<String> listener : navigationListeners) {
+            try { listener.accept(url); } catch (Exception ignored) {}
+        }
+    }
+
+    void addRequestListener(Consumer<Request> listener) { requestListeners.add(listener); }
+    void removeRequestListener(Consumer<Request> listener) { requestListeners.remove(listener); }
+    void addResponseListener(Consumer<Response> listener) { responseListeners.add(listener); }
+    void removeResponseListener(Consumer<Response> listener) { responseListeners.remove(listener); }
+    void addNavigationListener(Consumer<String> listener) { navigationListeners.add(listener); }
+    void removeNavigationListener(Consumer<String> listener) { navigationListeners.remove(listener); }
+    void addDownloadListener(Consumer<Download> listener) { downloadListeners.add(listener); }
+    void removeDownloadListener(Consumer<Download> listener) { downloadListeners.remove(listener); }
+    void addDialogListener(Consumer<Dialog> listener) { dialogListeners.add(listener); }
+    void removeDialogListener(Consumer<Dialog> listener) { dialogListeners.remove(listener); }
+    void addConsoleListener(Consumer<ConsoleMessage> listener) { consoleListeners.add(listener); }
+    void removeConsoleListener(Consumer<ConsoleMessage> listener) { consoleListeners.remove(listener); }
+    void addErrorListener(Consumer<String> listener) { errorListeners.add(listener); }
+    void removeErrorListener(Consumer<String> listener) { errorListeners.remove(listener); }
 
     private void handleRouteEvent(JsonObject params) {
         if (routes.isEmpty()) return;

--- a/clients/java/src/test/java/com/vibium/engine/CaptureTest.java
+++ b/clients/java/src/test/java/com/vibium/engine/CaptureTest.java
@@ -1,0 +1,124 @@
+package com.vibium.engine;
+
+import com.vibium.Browser;
+import com.vibium.ConsoleMessage;
+import com.vibium.Dialog;
+import com.vibium.Download;
+import com.vibium.Page;
+import com.vibium.Request;
+import com.vibium.Response;
+import com.vibium.Vibium;
+import com.vibium.errors.VibiumTimeoutException;
+import com.vibium.types.StartOptions;
+import com.vibium.types.WaitOptions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** One-shot capture parity with the JavaScript and Python clients. */
+@RequiresCapability("core")
+class CaptureTest {
+
+    static Browser browser;
+    static TestServer server;
+    Page page;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        server = new TestServer();
+        server.start();
+        browser = Vibium.start(new StartOptions().headless(true));
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (browser != null) browser.stop();
+        if (server != null) server.stop();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        page = browser.page();
+        page.go(server.baseUrl() + "/fetch");
+    }
+
+    @Test
+    @RequiresCapability("network")
+    void capturesRequestAndResponse() {
+        Request request = page.capture().request("**/api/data",
+            () -> page.evaluate("doFetch()"));
+        assertTrue(request.url().endsWith("/api/data"));
+
+        Response response = page.capture().response("**/api/data",
+            () -> page.evaluate("doFetch()"));
+        assertEquals(200, response.status());
+    }
+
+    @Test
+    @RequiresCapability("navigation-capture")
+    void capturesNavigation() {
+        String url = page.capture().navigation(
+            () -> page.go(server.baseUrl() + "/subpage"));
+        assertTrue(url.endsWith("/subpage"));
+    }
+
+    @Test
+    @RequiresCapability("downloads")
+    void capturesDownload() {
+        page.go(server.baseUrl() + "/download");
+        Download download = page.capture().download(
+            () -> page.find("#download-link").click());
+        assertEquals("test.txt", download.suggestedFilename());
+    }
+
+    @Test
+    @RequiresCapability("dialogs")
+    void dialogCaptureDoesNotDeadlockWhenActionBlocks() {
+        Dialog dialog = page.capture().dialog(
+            () -> page.evaluate("alert('captured')"),
+            new WaitOptions().timeout(5000));
+
+        assertEquals("captured", dialog.message());
+        dialog.accept();
+        assertEquals("Fetch", page.title());
+    }
+
+    @Test
+    @RequiresCapability("console")
+    void capturesNamedEvent() {
+        Object event = page.capture().event("console",
+            () -> page.evaluate("console.log('captured console')"));
+        ConsoleMessage message = assertInstanceOf(ConsoleMessage.class, event);
+        assertTrue(message.text().contains("captured console"));
+    }
+
+    @Test
+    void propagatesActionFailureAndCleansListener() {
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+            () -> page.capture().navigation(() -> {
+                throw new IllegalStateException("action failed");
+            }));
+        assertEquals("action failed", error.getMessage());
+
+        String url = page.capture().navigation(
+            () -> page.go(server.baseUrl() + "/subpage"));
+        assertTrue(url.endsWith("/subpage"));
+    }
+
+    @Test
+    void timeoutCleansListener() {
+        assertThrows(VibiumTimeoutException.class,
+            () -> page.capture().navigation(
+                () -> {}, new WaitOptions().timeout(50)));
+
+        String url = page.capture().navigation(
+            () -> page.go(server.baseUrl() + "/subpage"));
+        assertTrue(url.endsWith("/subpage"));
+    }
+}

--- a/clients/java/src/test/java/com/vibium/engine/CaptureTest.java
+++ b/clients/java/src/test/java/com/vibium/engine/CaptureTest.java
@@ -114,11 +114,12 @@ class CaptureTest {
     @Test
     void timeoutCleansListener() {
         assertThrows(VibiumTimeoutException.class,
-            () -> page.capture().navigation(
+            () -> page.capture().event("console",
                 () -> {}, new WaitOptions().timeout(50)));
 
-        String url = page.capture().navigation(
-            () -> page.go(server.baseUrl() + "/subpage"));
-        assertTrue(url.endsWith("/subpage"));
+        ConsoleMessage message = assertInstanceOf(ConsoleMessage.class,
+            page.capture().event("console",
+                () -> page.evaluate("console.log('after timeout')")));
+        assertTrue(message.text().contains("after timeout"));
     }
 }


### PR DESCRIPTION
Fixes VibiumDev#367.

Java exposed persistent event listeners but none of the one-shot capture surface available in JavaScript and Python. Callers had to build their own listener, ordering, timeout, and cleanup around every action.

## What changed

- Added page.capture() with typed request, response, navigation, download, dialog, and generic event capture methods
- Every method installs its listener before starting the action and removes exactly that listener on success, timeout, interruption, or action failure
- Capture actions run on a daemon executor. The event can return while an action is blocked by a native dialog, so Java does not inherit the capture.dialog deadlock tracked in VibiumDev#146
- Added Java navigation event delivery for load, fragment, and history updates

Verified:

- Focused CaptureTest: 7/7 green on Chrome
- Tests cover all capture families, the blocking alert reproduction, generic console capture, action failure, timeout, and reuse after cleanup
- validateCapabilityMarkers and compileTestJava green
- Fork CI covers the complete Chrome and Firefox suites