### PR TITLE
Add Java WebSocket monitoring

### DIFF
--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -37,6 +37,9 @@ public class Page {
     private final CopyOnWriteArrayList<Consumer<String>> errorListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<Download>> downloadListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<WebSocketInfo>> webSocketListeners = new CopyOnWriteArrayList<>();
+    private final Map<Integer, WebSocketInfo> webSockets = new java.util.concurrent.ConcurrentHashMap<>();
+    private final Object webSocketSetupLock = new Object();
+    private volatile boolean webSocketMonitorInstalled = false;
 
     // Buffered events
     private final List<ConsoleMessage> bufferedConsole = Collections.synchronizedList(new ArrayList<>());
@@ -492,6 +495,7 @@ public class Page {
         JsonObject params = new JsonObject();
         params.addProperty("context", contextId);
         client.send("browsingContext.close", params);
+        webSockets.clear();
         client.offEvent(eventHandler);
     }
 
@@ -579,6 +583,20 @@ public class Page {
     /** Listen for WebSocket connections. */
     public void onWebSocket(Consumer<WebSocketInfo> callback) {
         webSocketListeners.add(callback);
+        if (webSocketMonitorInstalled) return;
+
+        synchronized (webSocketSetupLock) {
+            if (webSocketMonitorInstalled) return;
+            try {
+                // Synchronous by design: the monitor is installed before the
+                // caller can issue the command that opens the socket (#351).
+                client.send("vibium:page.onWebSocket", contextParams());
+                webSocketMonitorInstalled = true;
+            } catch (RuntimeException error) {
+                webSocketListeners.remove(callback);
+                throw error;
+            }
+        }
     }
 
     /** Get buffered console messages. */
@@ -747,6 +765,15 @@ public class Page {
             case "browsingContext.downloadEnd":
                 handleDownloadCompleted(params);
                 break;
+            case "vibium:ws.created":
+                handleWebSocketCreated(params);
+                break;
+            case "vibium:ws.message":
+                handleWebSocketMessage(params);
+                break;
+            case "vibium:ws.closed":
+                handleWebSocketClosed(params);
+                break;
             case "vibium:network.intercepted":
                 handleRouteEvent(params);
                 break;
@@ -817,6 +844,34 @@ public class Page {
             String path = params.has("filepath") ? params.get("filepath").getAsString() : null;
             download.complete(status, path);
         }
+    }
+
+    private void handleWebSocketCreated(JsonObject params) {
+        if (!params.has("id")) return;
+        int id = params.get("id").getAsInt();
+        WebSocketInfo info = new WebSocketInfo(params);
+        webSockets.put(id, info);
+        for (Consumer<WebSocketInfo> listener : webSocketListeners) {
+            try { listener.accept(info); } catch (Exception ignored) {}
+        }
+    }
+
+    private void handleWebSocketMessage(JsonObject params) {
+        if (!params.has("id")) return;
+        WebSocketInfo info = webSockets.get(params.get("id").getAsInt());
+        if (info == null) return;
+        String data = params.has("data") ? params.get("data").getAsString() : "";
+        String direction = params.has("direction") ? params.get("direction").getAsString() : "";
+        info.emitMessage(data, direction);
+    }
+
+    private void handleWebSocketClosed(JsonObject params) {
+        if (!params.has("id")) return;
+        WebSocketInfo info = webSockets.remove(params.get("id").getAsInt());
+        if (info == null) return;
+        Integer code = params.has("code") ? params.get("code").getAsInt() : null;
+        String reason = params.has("reason") ? params.get("reason").getAsString() : null;
+        info.emitClose(code, reason);
     }
 
     private void handleRouteEvent(JsonObject params) {

--- a/clients/java/src/test/java/com/vibium/engine/WebSocketTest.java
+++ b/clients/java/src/test/java/com/vibium/engine/WebSocketTest.java
@@ -1,0 +1,123 @@
+package com.vibium.engine;
+
+import com.vibium.Browser;
+import com.vibium.Page;
+import com.vibium.Vibium;
+import com.vibium.WebSocketInfo;
+import com.vibium.types.StartOptions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@RequiresCapability("core")
+class WebSocketTest {
+
+    static Browser browser;
+    static TestServer http;
+    static WebSocketTestServer sockets;
+    Page page;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        http = new TestServer();
+        http.start();
+        sockets = new WebSocketTestServer();
+        browser = Vibium.start(new StartOptions().headless(true));
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (browser != null) browser.stop();
+        if (sockets != null) sockets.close();
+        if (http != null) http.stop();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        page = browser.newPage();
+        page.go(http.baseUrl());
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (page != null) page.close();
+    }
+
+    @Test
+    void setupCompletesBeforeImmediateSocketAndDispatchesLifecycle() throws Exception {
+        CountDownLatch created = new CountDownLatch(1);
+        CountDownLatch sent = new CountDownLatch(1);
+        CountDownLatch received = new CountDownLatch(1);
+        CountDownLatch closed = new CountDownLatch(1);
+        AtomicReference<WebSocketInfo> info = new AtomicReference<>();
+        List<String> messages = new CopyOnWriteArrayList<>();
+
+        page.onWebSocket(ws -> {
+            info.set(ws);
+            ws.onMessage((data, direction) -> {
+                messages.add(direction + ":" + data);
+                if ("sent".equals(direction)) sent.countDown();
+                if ("received".equals(direction)) received.countDown();
+            });
+            ws.onClose((code, reason) -> closed.countDown());
+            created.countDown();
+        });
+
+        page.evaluate("(() => { const socket = new WebSocket('" + sockets.url()
+            + "'); socket.onopen = () => socket.send('echo-me');"
+            + " socket.onmessage = () => socket.close(1000, 'done'); return true; })()");
+
+        assertTrue(created.await(5, TimeUnit.SECONDS));
+        assertEquals(sockets.url(), info.get().url());
+        assertTrue(sent.await(5, TimeUnit.SECONDS));
+        assertTrue(received.await(5, TimeUnit.SECONDS));
+        assertTrue(closed.await(5, TimeUnit.SECONDS));
+        assertTrue(info.get().isClosed());
+        assertTrue(messages.contains("sent:echo-me"));
+        assertTrue(messages.contains("received:echo-me"));
+    }
+
+    @Test
+    void monitoringPersistsAcrossNavigation() throws Exception {
+        CountDownLatch created = new CountDownLatch(2);
+        page.onWebSocket(ws -> created.countDown());
+
+        page.evaluate("(() => { new WebSocket('" + sockets.url() + "'); return true; })()");
+        page.go(http.baseUrl() + "/subpage");
+        page.evaluate("(() => { new WebSocket('" + sockets.url() + "'); return true; })()");
+
+        assertTrue(created.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void removeAllListenersStopsDelivery() throws Exception {
+        AtomicInteger delivered = new AtomicInteger();
+        CountDownLatch first = new CountDownLatch(1);
+        page.onWebSocket(ws -> {
+            delivered.incrementAndGet();
+            first.countDown();
+        });
+
+        page.evaluate("(() => { new WebSocket('" + sockets.url() + "'); return true; })()");
+        assertTrue(first.await(5, TimeUnit.SECONDS));
+        page.removeAllListeners("websocket");
+
+        int connections = sockets.connectionCount();
+        page.evaluate("(() => { new WebSocket('" + sockets.url() + "'); return true; })()");
+        assertTrue(sockets.awaitConnections(connections + 1, 5, TimeUnit.SECONDS));
+        page.evaluate("1");
+        assertEquals(1, delivered.get());
+    }
+}

--- a/clients/java/src/test/java/com/vibium/engine/WebSocketTestServer.java
+++ b/clients/java/src/test/java/com/vibium/engine/WebSocketTestServer.java
@@ -1,0 +1,190 @@
+package com.vibium.engine;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Minimal local RFC 6455 echo server for the Java client tests. */
+final class WebSocketTestServer implements AutoCloseable {
+
+    private static final String MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+    private final ServerSocket server;
+    private final ExecutorService workers = Executors.newCachedThreadPool(r -> {
+        Thread thread = new Thread(r, "vibium-test-websocket");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final AtomicInteger connections = new AtomicInteger();
+    private volatile CountDownLatch connectionChanged = new CountDownLatch(1);
+    private volatile boolean closed;
+
+    WebSocketTestServer() throws IOException {
+        server = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        workers.submit(this::acceptLoop);
+    }
+
+    String url() {
+        return "ws://127.0.0.1:" + server.getLocalPort();
+    }
+
+    int connectionCount() {
+        return connections.get();
+    }
+
+    boolean awaitConnections(int count, long timeout, TimeUnit unit) throws InterruptedException {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+        while (connections.get() < count) {
+            long remaining = deadline - System.nanoTime();
+            if (remaining <= 0 || !connectionChanged.await(remaining, TimeUnit.NANOSECONDS)) {
+                return connections.get() >= count;
+            }
+        }
+        return true;
+    }
+
+    private void acceptLoop() {
+        while (!closed) {
+            try {
+                Socket socket = server.accept();
+                connections.incrementAndGet();
+                CountDownLatch changed = connectionChanged;
+                connectionChanged = new CountDownLatch(1);
+                changed.countDown();
+                workers.submit(() -> handle(socket));
+            } catch (IOException error) {
+                if (!closed) throw new RuntimeException(error);
+            }
+        }
+    }
+
+    private void handle(Socket socket) {
+        try (Socket ignored = socket;
+             BufferedInputStream input = new BufferedInputStream(socket.getInputStream());
+             BufferedOutputStream output = new BufferedOutputStream(socket.getOutputStream())) {
+            String headers = readHeaders(input);
+            String key = null;
+            for (String line : headers.split("\\r\\n")) {
+                if (line.toLowerCase(Locale.ROOT).startsWith("sec-websocket-key:")) {
+                    key = line.substring(line.indexOf(':') + 1).trim();
+                }
+            }
+            if (key == null) return;
+
+            String accept = Base64.getEncoder().encodeToString(
+                MessageDigest.getInstance("SHA-1")
+                    .digest((key + MAGIC).getBytes(StandardCharsets.US_ASCII)));
+            output.write(("HTTP/1.1 101 Switching Protocols\r\n"
+                + "Upgrade: websocket\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Sec-WebSocket-Accept: " + accept + "\r\n\r\n")
+                .getBytes(StandardCharsets.US_ASCII));
+            output.flush();
+
+            while (!socket.isClosed()) {
+                Frame frame = readFrame(input);
+                if (frame == null) return;
+                if (frame.opcode == 1) {
+                    writeFrame(output, 1, frame.payload);
+                } else if (frame.opcode == 8) {
+                    writeFrame(output, 8, frame.payload);
+                    return;
+                } else if (frame.opcode == 9) {
+                    writeFrame(output, 10, frame.payload);
+                }
+            }
+        } catch (Exception ignored) {
+            // A browser closing a test page can drop the socket mid-frame.
+        }
+    }
+
+    private static String readHeaders(BufferedInputStream input) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        int state = 0;
+        while (bytes.size() < 16 * 1024) {
+            int value = input.read();
+            if (value < 0) break;
+            bytes.write(value);
+            state = value == "\r\n\r\n".charAt(state) ? state + 1 : (value == '\r' ? 1 : 0);
+            if (state == 4) break;
+        }
+        return bytes.toString(StandardCharsets.US_ASCII);
+    }
+
+    private static Frame readFrame(BufferedInputStream input) throws IOException {
+        int first = input.read();
+        int second = input.read();
+        if (first < 0 || second < 0) return null;
+
+        long length = second & 0x7f;
+        if (length == 126) {
+            length = (readRequired(input) << 8) | readRequired(input);
+        } else if (length == 127) {
+            length = 0;
+            for (int i = 0; i < 8; i++) length = (length << 8) | readRequired(input);
+        }
+        if (length > 1024 * 1024) throw new IOException("test WebSocket frame too large");
+
+        byte[] mask = null;
+        if ((second & 0x80) != 0) {
+            mask = input.readNBytes(4);
+            if (mask.length != 4) throw new IOException("truncated WebSocket mask");
+        }
+        byte[] payload = input.readNBytes((int) length);
+        if (payload.length != length) throw new IOException("truncated WebSocket payload");
+        if (mask != null) {
+            for (int i = 0; i < payload.length; i++) payload[i] ^= mask[i % 4];
+        }
+        return new Frame(first & 0x0f, payload);
+    }
+
+    private static int readRequired(BufferedInputStream input) throws IOException {
+        int value = input.read();
+        if (value < 0) throw new IOException("truncated WebSocket frame");
+        return value;
+    }
+
+    private static void writeFrame(BufferedOutputStream output, int opcode, byte[] payload)
+            throws IOException {
+        output.write(0x80 | opcode);
+        if (payload.length < 126) {
+            output.write(payload.length);
+        } else {
+            output.write(126);
+            output.write((payload.length >>> 8) & 0xff);
+            output.write(payload.length & 0xff);
+        }
+        output.write(payload);
+        output.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        server.close();
+        workers.shutdownNow();
+    }
+
+    private static final class Frame {
+        final int opcode;
+        final byte[] payload;
+
+        Frame(int opcode, byte[] payload) {
+            this.opcode = opcode;
+            this.payload = payload;
+        }
+    }
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#368.

Adds Java WebSocket lifecycle monitoring with the same created, message, and close events as the JavaScript and Python clients.

The setup call completes synchronously before onWebSocket returns, so a socket opened immediately afterward cannot race monitor installation as described in #351. Monitoring persists across navigation, and removeAllListeners("websocket") stops callback delivery.

Tests cover immediate socket creation, sent and received messages, close metadata, navigation persistence, and listener cleanup.

Validation: ./gradlew validateCapabilityMarkers compileTestJava