### PR TITLE
Preserve Java command caller frames

### DIFF
--- a/clients/java/src/main/java/com/vibium/internal/BiDiClient.java
+++ b/clients/java/src/main/java/com/vibium/internal/BiDiClient.java
@@ -78,6 +78,7 @@ public class BiDiClient {
         if (closed) {
             throw new VibiumConnectionException("BiDi client is closed");
         }
+        StackTraceElement[] callerStack = captureCallerStack();
 
         int id = nextId.getAndIncrement();
         CompletableFuture<JsonObject> future = new CompletableFuture<>();
@@ -116,7 +117,7 @@ public class BiDiClient {
             pendingRequests.remove(id);
             Throwable cause = e.getCause();
             if (cause instanceof VibiumException) {
-                throw (VibiumException) cause;
+                throw attachCallerStack((VibiumException) cause, callerStack);
             }
             throw new VibiumException("Error executing " + method + ": " + cause.getMessage(), cause);
         } catch (InterruptedException e) {
@@ -124,6 +125,21 @@ public class BiDiClient {
             Thread.currentThread().interrupt();
             throw new VibiumException("Interrupted while waiting for response to " + method);
         }
+    }
+
+    static StackTraceElement[] captureCallerStack() {
+        StackTraceElement[] stack = new Throwable().getStackTrace();
+        int firstCaller = 0;
+        while (firstCaller < stack.length
+                && BiDiClient.class.getName().equals(stack[firstCaller].getClassName())) {
+            firstCaller++;
+        }
+        return java.util.Arrays.copyOfRange(stack, firstCaller, stack.length);
+    }
+
+    static <T extends VibiumException> T attachCallerStack(T error, StackTraceElement[] callerStack) {
+        error.setStackTrace(callerStack);
+        return error;
     }
 
     /**

--- a/clients/java/src/test/java/com/vibium/internal/BiDiClientTest.java
+++ b/clients/java/src/test/java/com/vibium/internal/BiDiClientTest.java
@@ -1,0 +1,31 @@
+package com.vibium.internal;
+
+import com.vibium.errors.ElementNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BiDiClientTest {
+
+    @Test
+    void replacesReceiverFramesWithCommandCallerFrames() {
+        ElementNotFoundException error = new ElementNotFoundException("element not found");
+
+        attachFromUserCall(error);
+
+        assertTrue(Arrays.stream(error.getStackTrace())
+            .anyMatch(frame -> frame.getMethodName().equals("replacesReceiverFramesWithCommandCallerFrames")));
+        assertFalse(Arrays.stream(error.getStackTrace())
+            .anyMatch(frame -> frame.getClassName().equals(BiDiClient.class.getName())));
+        assertEquals("element not found", error.getMessage());
+    }
+
+    private void attachFromUserCall(ElementNotFoundException error) {
+        StackTraceElement[] callerStack = BiDiClient.captureCallerStack();
+        BiDiClient.attachCallerStack(error, callerStack);
+    }
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#337.

Captures the Java caller stack when a protocol command is dispatched and attaches it to protocol-created exceptions before they return to the waiting caller.

The transport's own send frames are trimmed, so failures point at the Page or Element operation and the user's calling method instead of mapError and the BiDi receive thread. Exception types and messages are unchanged.

Tests cover retaining the user call site, removing transport frames, and preserving the original error message.

Validation: ./gradlew validateCapabilityMarkers test --tests com.vibium.internal.BiDiClientTest