### PR TITLE
Extract the Java binary to a per-version directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ scripts/package-lock.json
 clients/java/build/
 clients/java/.gradle/
 clients/java/src/main/resources/natives/
+clients/java/src/main/resources/vibium-version.txt
 vibium-bundle.zip
 
 # Python

--- a/clients/java/build.gradle.kts
+++ b/clients/java/build.gradle.kts
@@ -113,14 +113,26 @@ tasks.register<Copy>("copyNativeBinaries") {
     into("src/main/resources/natives")
 }
 
+// BinaryResolver keys its extraction cache on this resource; without it every
+// jar extracts to vibium-unknown and the first install pins its binary (#330).
+val writeVersionResource by tasks.registering {
+    val versionFile = file("src/main/resources/vibium-version.txt")
+    inputs.property("version", vibiumVersion)
+    outputs.file(versionFile)
+    doLast {
+        versionFile.parentFile.mkdirs()
+        versionFile.writeText(vibiumVersion + "\n")
+    }
+}
+
 // Don't fail build if native binaries aren't present (dev mode)
 tasks.named("processResources") {
-    dependsOn(tasks.named("copyNativeBinaries"))
+    dependsOn(tasks.named("copyNativeBinaries"), writeVersionResource)
 }
 
 // sourcesJar also reads src/main/resources, so it needs the same dependency
 tasks.named("sourcesJar") {
-    dependsOn(tasks.named("copyNativeBinaries"))
+    dependsOn(tasks.named("copyNativeBinaries"), writeVersionResource)
 }
 
 // Copy runtime dependencies for JShell / standalone use

--- a/clients/java/src/test/java/com/vibium/BinaryVersionResourceTest.java
+++ b/clients/java/src/test/java/com/vibium/BinaryVersionResourceTest.java
@@ -1,0 +1,30 @@
+package com.vibium;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * BinaryResolver keys its extraction cache on the vibium-version.txt resource.
+ * Without it every jar extracts to vibium-unknown, and the first jar to run on
+ * a machine pins its binary for every later version (#330).
+ */
+class BinaryVersionResourceTest {
+
+    @Test
+    void versionResourceMatchesRepoVersion() throws Exception {
+        try (InputStream is = getClass().getClassLoader()
+                .getResourceAsStream("vibium-version.txt")) {
+            assertNotNull(is,
+                "vibium-version.txt must be on the classpath so extraction dirs are versioned");
+            String resource = new String(is.readAllBytes()).trim();
+            String repo = new String(Files.readAllBytes(Paths.get("../../VERSION"))).trim();
+            assertEquals(repo, resource);
+        }
+    }
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#330

BinaryResolver names its extraction directory from the vibium-version.txt classpath resource, but nothing in the build ever generated that resource. Every published jar resolved the version to "unknown", extracted its binary to the shared vibium-unknown directory, and skipped the copy when a file was already there. The first vibium jar to run on a machine pinned its binary for every later version.

The build now writes vibium-version.txt from the root VERSION file, wired into processResources next to the existing native-binary copy. Extraction lands in a per-version directory, so a version bump extracts its own binary.

No BinaryResolver changes: the extraction concurrency issue stays tracked in #329.

Verified:
- New BinaryVersionResourceTest asserts the resource is on the classpath and matches VERSION. Fails on main (resource is absent), passes with this change.
- `gradlew jar` output now contains vibium-version.txt with content 26.5.31, so extraction uses vibium-26.5.31 instead of vibium-unknown.
- Full make test green on this tree.
