### PR TITLE
Suppress Node test hooks when capability requirements are missing

### DIFF
--- a/scripts/test-node-capability-fixture.mjs
+++ b/scripts/test-node-capability-fixture.mjs
@@ -1,21 +1,42 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 
-const result = spawnSync(
-  process.execPath,
-  ['--test', '--test-reporter=spec', 'tests/capability-fixtures/node.test.js'],
-  {
-    cwd: process.cwd(),
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      VIBIUM_ENGINE: 'chrome',
-      VIBIUM_CAPABILITY_AUDIT: '1',
-      VIBIUM_CAPABILITY_COLLECT_ONLY: '1',
-    },
-  }
-);
-assert.equal(result.status, 0, result.stderr || result.stdout);
-assert.match(result.stdout, /engine=chrome collected=3 selected=1 skipped=2/);
-assert.match(result.stdout, /skip:audio=2/);
+function run(file, env = {}) {
+  const result = spawnSync(
+    process.execPath,
+    ['--test', '--test-reporter=spec', file],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        VIBIUM_ENGINE: 'chrome',
+        VIBIUM_CAPABILITY_AUDIT: '1',
+        ...env,
+      },
+    }
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout;
+}
+
+const counts = run('tests/capability-fixtures/node.test.js', {
+  VIBIUM_CAPABILITY_COLLECT_ONLY: '1',
+});
+assert.match(counts, /engine=chrome collected=3 selected=1 skipped=2/);
+assert.match(counts, /skip:audio=2/);
 console.log('Node capability fixture counts ok');
+
+// These two run without collect-only: hook suppression only matters when the
+// hooks would otherwise execute.
+const suiteSkip = run('tests/capability-fixtures/node-skipped-suite.test.js');
+assert.match(suiteSkip, /engine=chrome collected=2 selected=0 skipped=2/);
+assert.match(suiteSkip, /skip:audio=2/);
+assert.doesNotMatch(suiteSkip, /-RAN/);
+
+const describeSkip = run('tests/capability-fixtures/node-skipped-describe.test.js');
+assert.match(describeSkip, /SUITE-BEFORE-RAN/);
+assert.doesNotMatch(describeSkip, /AUDIO-BEFORE-RAN/);
+assert.match(describeSkip, /engine=chrome collected=2 selected=1 skipped=1/);
+assert.match(describeSkip, /skip:audio=1/);
+console.log('Node capability fixture hook suppression ok');

--- a/tests/capability-fixtures/node-skipped-describe.test.js
+++ b/tests/capability-fixtures/node-skipped-describe.test.js
@@ -1,0 +1,11 @@
+const { suite } = require('../helpers/capabilities');
+const { test, describe, before } = suite('core');
+
+before(() => console.log('SUITE-BEFORE-RAN'));
+
+test('selected test', () => {});
+
+describe.requires('audio')('audio group', () => {
+  before(() => console.log('AUDIO-BEFORE-RAN'));
+  test('audio test', () => {});
+});

--- a/tests/capability-fixtures/node-skipped-suite.test.js
+++ b/tests/capability-fixtures/node-skipped-suite.test.js
@@ -1,0 +1,13 @@
+const { suite } = require('../helpers/capabilities');
+const { test, describe, before, after, beforeEach } = suite('audio');
+
+before(() => console.log('SUITE-BEFORE-RAN'));
+beforeEach(() => console.log('SUITE-BEFOREEACH-RAN'));
+after(() => console.log('SUITE-AFTER-RAN'));
+
+test('skipped test', () => console.log('TEST-BODY-RAN'));
+
+describe('nested group', () => {
+  before(() => console.log('NESTED-BEFORE-RAN'));
+  test('nested skipped test', () => {});
+});

--- a/tests/helpers/capabilities.js
+++ b/tests/helpers/capabilities.js
@@ -80,6 +80,12 @@ function suite(...baseRequirements) {
   validate(baseRequirements);
   installSummary();
   let inherited = [...baseRequirements];
+  // node:test runs before/after hooks even when every test in scope is
+  // skipped, so hooks registered under missing requirements must become
+  // no-ops. Skipping the describe itself would not work: node never invokes
+  // a skipped describe's callback, so its tests would vanish from the
+  // summary counts instead of being reported as skipped.
+  let suppressHooks = missingCapabilities(baseRequirements).length > 0;
 
   function wrapTest(extraRequirements = []) {
     return (...args) => {
@@ -115,7 +121,9 @@ function suite(...baseRequirements) {
       const mergedCallbackIndex = callbackIndex + (values.length - args.length);
       values[mergedCallbackIndex] = (...callbackArgs) => {
         const previous = inherited;
+        const previousSuppress = suppressHooks;
         inherited = [...new Set([...inherited, ...extraRequirements])];
+        suppressHooks = suppressHooks || missingCapabilities(inherited).length > 0;
         try {
           const result = callback(...callbackArgs);
           if (result && typeof result.then === 'function') {
@@ -126,6 +134,7 @@ function suite(...baseRequirements) {
           return result;
         } finally {
           inherited = previous;
+          suppressHooks = previousSuppress;
         }
       };
       return nodeTest.describe(...values);
@@ -137,14 +146,19 @@ function suite(...baseRequirements) {
   test.requires = (...names) => wrapTest(names);
   describe.requires = (...names) => wrapDescribe(names);
 
-  const noopHook = collectOnly ? () => {} : null;
+  // Suppression is decided at registration time; describe callbacks are
+  // synchronous (enforced above), so the flag is accurate for nested hooks.
+  const wrapHook = (register) => (...args) => {
+    if (collectOnly || suppressHooks) return;
+    return register(...args);
+  };
   return {
     test,
     describe,
-    before: noopHook || nodeTest.before,
-    after: noopHook || nodeTest.after,
-    beforeEach: noopHook || nodeTest.beforeEach,
-    afterEach: noopHook || nodeTest.afterEach,
+    before: wrapHook(nodeTest.before),
+    after: wrapHook(nodeTest.after),
+    beforeEach: wrapHook(nodeTest.beforeEach),
+    afterEach: wrapHook(nodeTest.afterEach),
   };
 }
 


### PR DESCRIPTION
Fixes VibiumDev/vibium#349

node:test runs before/after hooks even when every test in scope is skipped, so a file whose suite-level requirements are missing on the current engine still launched browsers and HTTP servers from its hooks. The same applies to hooks inside a describe whose merged requirements are missing.

The suite adapter now registers no-op hooks when the suite-level requirements are missing, and tracks the same suppression through nested describes. The issue suggested passing skip on the describe instead, but node never invokes a skipped describe's callback, so its tests would vanish from the summary counts instead of being reported as skipped. Individual test skips and the summary stay exactly as before.

Two synthetic fixture files cover both scenarios (suite-level and describe-level missing requirements) since no real file is fully skipped on either engine after the capability parity work.

Verified:
- New fixture assertions fail on main (SUITE-BEFORE-RAN prints there, hooks ran for a fully skipped suite) and pass on the branch
- make test-capability-audit green (import audit, fixture counts, chrome collect-only across all engine files)
- Real-world sanity: console-error.test.js on Firefox runs 17/17 with hooks intact