### PR TITLE
Capability tooling cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ packages/python/*/src/*/bin/vibium.exe
 **/NOTICE
 !/LICENSE
 !/NOTICE
+
+# Per-process capability counts collected during a test run
+tests/.capability-summary/

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,11 @@ CLI_ENGINE_TESTS := $(wildcard tests/cli/engine/*.test.js)
 JS_ASYNC_ENGINE_TESTS := $(wildcard tests/js/async/engine/*.test.js)
 JS_SYNC_ENGINE_TESTS := $(wildcard tests/js/sync/engine/*.test.js)
 
+# node --test prints the capability summary once per test process (one per
+# file). Each Node target collects per-process counts in its own file here and
+# prints a single roll-up afterwards.
+CAP_SUMMARY_DIR := $(CURDIR)/tests/.capability-summary
+
 # Default target
 all: build
 
@@ -309,7 +314,12 @@ test-cli-shared: build-go
 	@echo "--- CLI Shared Tests ($(ENGINE)) ---"
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 	@VIBIUM_ENGINE=$(ENGINE) $(CURDIR)/clicker/bin/vibium$(EXE) daemon start --headless
-	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 $(CLI_ENGINE_TESTS)
+	@mkdir -p $(CAP_SUMMARY_DIR) && rm -f $(CAP_SUMMARY_DIR)/cli-$(ENGINE).ndjson
+	VIBIUM_ENGINE=$(ENGINE) VIBIUM_CAPABILITY_SUMMARY_FILE=$(CAP_SUMMARY_DIR)/cli-$(ENGINE).ndjson \
+		$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 $(CLI_ENGINE_TESTS); \
+	EXIT=$$?; \
+	node scripts/report-capability-summary.mjs $(CAP_SUMMARY_DIR)/cli-$(ENGINE).ndjson; \
+	exit $$EXIT
 	@$(CURDIR)/clicker/bin/vibium$(EXE) daemon stop 2>/dev/null || true
 
 # Broad Firefox core coverage through the CLI, kept separate from the focused
@@ -337,17 +347,27 @@ JS_PARALLEL ?= $(DEFAULT_PARALLEL)
 
 test-js-async: build-go
 	@echo "--- JS Async Tests (parallel x$(JS_PARALLEL)) ---"
-	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
+	@mkdir -p $(CAP_SUMMARY_DIR) && rm -f $(CAP_SUMMARY_DIR)/js-async-$(ENGINE).ndjson
+	VIBIUM_ENGINE=$(ENGINE) VIBIUM_CAPABILITY_SUMMARY_FILE=$(CAP_SUMMARY_DIR)/js-async-$(ENGINE).ndjson \
+		$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
 		$(JS_ASYNC_ENGINE_TESTS) \
 		tests/js/async/chrome-video.test.js \
 		tests/js/async/browser-installer.test.js \
-		tests/js/async/event-setup-ordering.test.js
+		tests/js/async/event-setup-ordering.test.js; \
+	EXIT=$$?; \
+	node scripts/report-capability-summary.mjs $(CAP_SUMMARY_DIR)/js-async-$(ENGINE).ndjson; \
+	exit $$EXIT
 
 test-js-sync: build-go
 	@echo "--- JS Sync Tests (parallel x$(JS_PARALLEL)) ---"
-	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
+	@mkdir -p $(CAP_SUMMARY_DIR) && rm -f $(CAP_SUMMARY_DIR)/js-sync-$(ENGINE).ndjson
+	VIBIUM_ENGINE=$(ENGINE) VIBIUM_CAPABILITY_SUMMARY_FILE=$(CAP_SUMMARY_DIR)/js-sync-$(ENGINE).ndjson \
+		$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
 		$(JS_SYNC_ENGINE_TESTS) \
-		tests/js/sync/event-setup-ordering-sync.test.js
+		tests/js/sync/event-setup-ordering-sync.test.js; \
+	EXIT=$$?; \
+	node scripts/report-capability-summary.mjs $(CAP_SUMMARY_DIR)/js-sync-$(ENGINE).ndjson; \
+	exit $$EXIT
 
 test-js-process: build-go
 	@echo "--- JS Process Tests (sequential) ---"
@@ -360,8 +380,13 @@ test-js: test-js-async test-js-sync test-js-process
 
 test-js-engine: build-go
 	@echo "--- JS Cross-Engine Tests ($(ENGINE), parallel x$(JS_PARALLEL)) ---"
-	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
-		$(JS_ASYNC_ENGINE_TESTS) $(JS_SYNC_ENGINE_TESTS)
+	@mkdir -p $(CAP_SUMMARY_DIR) && rm -f $(CAP_SUMMARY_DIR)/js-engine-$(ENGINE).ndjson
+	VIBIUM_ENGINE=$(ENGINE) VIBIUM_CAPABILITY_SUMMARY_FILE=$(CAP_SUMMARY_DIR)/js-engine-$(ENGINE).ndjson \
+		$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=$(JS_PARALLEL) \
+		$(JS_ASYNC_ENGINE_TESTS) $(JS_SYNC_ENGINE_TESTS); \
+	EXIT=$$?; \
+	node scripts/report-capability-summary.mjs $(CAP_SUMMARY_DIR)/js-engine-$(ENGINE).ndjson; \
+	exit $$EXIT
 
 # Run MCP server tests (sequential - browser sessions)
 test-mcp: build-go
@@ -460,12 +485,20 @@ test-capability-audit: build-js python-venv
 	@echo "--- Browser-free Chrome Capability Audit ---"
 	node scripts/audit-node-capability-imports.mjs
 	node scripts/test-node-capability-fixture.mjs
+	@mkdir -p $(CAP_SUMMARY_DIR) && rm -f $(CAP_SUMMARY_DIR)/audit.ndjson
 	VIBIUM_ENGINE=chrome VIBIUM_CAPABILITY_AUDIT=1 VIBIUM_CAPABILITY_COLLECT_ONLY=1 \
+		VIBIUM_CAPABILITY_SUMMARY_FILE=$(CAP_SUMMARY_DIR)/audit.ndjson \
 		node --test --test-reporter=dot --test-concurrency=1 $(CLI_ENGINE_TESTS) \
-		$(JS_ASYNC_ENGINE_TESTS) $(JS_SYNC_ENGINE_TESTS)
+		$(JS_ASYNC_ENGINE_TESTS) $(JS_SYNC_ENGINE_TESTS); \
+	EXIT=$$?; \
+	node scripts/report-capability-summary.mjs $(CAP_SUMMARY_DIR)/audit.ndjson; \
+	exit $$EXIT
 	@cd clients/python && . $(VENV_ACTIVATE) && \
 		VIBIUM_ENGINE=chrome python -m pytest ../../tests/py/engine/ --collect-only -q --capability-audit
+	@cd clients/python && . $(VENV_ACTIVATE) && \
+		VIBIUM_ENGINE=chrome python ../../scripts/test_pytest_capability_fixture.py
 	cd clients/java && VIBIUM_ENGINE=chrome VIBIUM_CAPABILITY_AUDIT=1 ./gradlew validateCapabilityMarkers compileTestJava
+	./scripts/test-java-capability-fixture.sh
 
 # Package Java JAR with native binaries
 package-java: build-go-all

--- a/clients/java/build.gradle.kts
+++ b/clients/java/build.gradle.kts
@@ -49,8 +49,13 @@ tasks.test {
 // declarations cannot turn into a new filename allowlist. Validate the source
 // before JUnit launches a browser; method-level markers add requirements to the
 // mandatory class-level baseline.
+// -PcapabilityMarkerRoot points the validator at a synthetic tree so the
+// fixture runner can assert it still rejects bad markers.
+val capabilityMarkerRoot =
+    (findProperty("capabilityMarkerRoot") as String?) ?: "src/test/java/com/vibium/engine"
+
 val validateCapabilityMarkers by tasks.registering {
-    inputs.dir("src/test/java/com/vibium/engine")
+    inputs.dir(capabilityMarkerRoot)
     inputs.file("../../tests/capabilities.json")
     doLast {
         val manifestText = file("../../tests/capabilities.json").readText()
@@ -67,7 +72,7 @@ val validateCapabilityMarkers by tasks.registering {
             "@RequiresCapability\\([^)]*\\)\\s*(?:@[\\w.]+(?:\\([^)]*\\))?\\s*)*" +
             "(?:\\b(?:public|final|abstract)\\b\\s+)*class\\s"
         )
-        fileTree("src/test/java/com/vibium/engine") {
+        fileTree(capabilityMarkerRoot) {
             include("**/*Test.java")
         }.forEach { file ->
             val source = file.readText()

--- a/scripts/report-capability-summary.mjs
+++ b/scripts/report-capability-summary.mjs
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: report-capability-summary.mjs <ndjson-file>');
+  process.exit(1);
+}
+
+let text;
+try {
+  text = fs.readFileSync(file, 'utf8');
+} catch {
+  // No adapter-using test file ran, so there is nothing to report.
+  process.exit(0);
+}
+
+const totals = { collected: 0, selected: 0, skipped: 0 };
+const capabilities = new Map();
+const engines = new Set();
+for (const line of text.split('\n')) {
+  if (!line.trim()) continue;
+  const entry = JSON.parse(line);
+  engines.add(entry.engine);
+  totals.collected += entry.collected;
+  totals.selected += entry.selected;
+  totals.skipped += entry.skipped;
+  for (const [name, count] of Object.entries(entry.capabilities)) {
+    capabilities.set(name, (capabilities.get(name) || 0) + count);
+  }
+}
+
+console.log(
+  `capabilities: engine=${[...engines].join(',')} collected=${totals.collected} ` +
+  `selected=${totals.selected} skipped=${totals.skipped}`
+);
+for (const [name, count] of [...capabilities].sort()) {
+  console.log(`capabilities: skip:${name}=${count}`);
+}
+fs.rmSync(file, { force: true });

--- a/scripts/test-java-capability-fixture.sh
+++ b/scripts/test-java-capability-fixture.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Assert the Java capability marker validator rejects the synthetic fixtures.
+set -eu
+cd "$(dirname "$0")/../clients/java"
+
+expect_failure() {
+    fixture=$1
+    pattern=$2
+    if output=$(./gradlew -q validateCapabilityMarkers \
+        -PcapabilityMarkerRoot="../../tests/capability-fixtures/java/$fixture" 2>&1); then
+        echo "validateCapabilityMarkers accepted $fixture:" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+    case $output in
+        *"$pattern"*) ;;
+        *)
+            echo "unexpected failure output for $fixture:" >&2
+            echo "$output" >&2
+            exit 1
+            ;;
+    esac
+}
+
+expect_failure missing-class-marker "missing class-level @RequiresCapability"
+expect_failure unknown-capability "unknown capability nonexistent"
+echo "Java capability validator fixtures ok"

--- a/scripts/test_pytest_capability_fixture.py
+++ b/scripts/test_pytest_capability_fixture.py
@@ -1,0 +1,27 @@
+"""Assert the pytest capability adapter's selection and skip counts."""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+env = dict(os.environ, VIBIUM_ENGINE="chrome")
+
+result = subprocess.run(
+    [
+        sys.executable, "-m", "pytest",
+        str(root / "tests" / "capability-fixtures" / "py"),
+        "--collect-only", "-q", "--capability-audit",
+    ],
+    capture_output=True,
+    text=True,
+    env=env,
+    cwd=root,
+)
+output = result.stdout + result.stderr
+assert result.returncode == 0, output
+assert re.search(r"engine=chrome collected=3 selected=1 skipped=2", output), output
+assert re.search(r"skip:audio=2", output), output
+print("pytest capability fixture counts ok")

--- a/tests/capability-fixtures/java/missing-class-marker/MethodMarkerOnlyTest.java
+++ b/tests/capability-fixtures/java/missing-class-marker/MethodMarkerOnlyTest.java
@@ -1,0 +1,11 @@
+package com.vibium.engine;
+
+import org.junit.jupiter.api.Test;
+
+// Regex fixture only, never compiled: a method-level marker without the
+// class-level baseline must be rejected.
+class MethodMarkerOnlyTest {
+    @RequiresCapability("core")
+    @Test
+    void marked() {}
+}

--- a/tests/capability-fixtures/java/unknown-capability/UnknownCapabilityTest.java
+++ b/tests/capability-fixtures/java/unknown-capability/UnknownCapabilityTest.java
@@ -1,0 +1,11 @@
+package com.vibium.engine;
+
+import org.junit.jupiter.api.Test;
+
+// Regex fixture only, never compiled: a capability missing from the manifest
+// must be rejected.
+@RequiresCapability("nonexistent")
+class UnknownCapabilityTest {
+    @Test
+    void marked() {}
+}

--- a/tests/capability-fixtures/py/conftest.py
+++ b/tests/capability-fixtures/py/conftest.py
@@ -1,0 +1,8 @@
+"""Load the capability adapter for the synthetic fixture suite."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "py"))
+
+from capability_adapter import *  # noqa: E402,F401,F403

--- a/tests/capability-fixtures/py/test_capability_fixture.py
+++ b/tests/capability-fixtures/py/test_capability_fixture.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.mark.capability("core")
+def test_selected_core():
+    pass
+
+
+@pytest.mark.capability("audio")
+def test_no_engine_capability():
+    pass
+
+
+@pytest.mark.capability("core", "audio")
+def test_and_requirements():
+    pass

--- a/tests/helpers/capabilities.js
+++ b/tests/helpers/capabilities.js
@@ -14,6 +14,11 @@ if (!['chrome', 'firefox'].includes(engine)) {
 
 const collectOnly = process.env.VIBIUM_CAPABILITY_COLLECT_ONLY === '1';
 const audit = process.env.VIBIUM_CAPABILITY_AUDIT === '1';
+// node --test runs each file in its own process, so printing here means one
+// summary per file. When a summary file is set, each process appends its
+// counts there and scripts/report-capability-summary.mjs prints one roll-up
+// for the whole run.
+const summaryFile = process.env.VIBIUM_CAPABILITY_SUMMARY_FILE;
 const counts = { collected: 0, selected: 0, skipped: 0, capabilities: new Map() };
 let summaryInstalled = false;
 let summaryPrinted = false;
@@ -37,6 +42,19 @@ function installSummary() {
   const printSummary = () => {
     if (summaryPrinted) return;
     summaryPrinted = true;
+    if (summaryFile) {
+      fs.appendFileSync(
+        summaryFile,
+        JSON.stringify({
+          engine,
+          collected: counts.collected,
+          selected: counts.selected,
+          skipped: counts.skipped,
+          capabilities: Object.fromEntries(counts.capabilities),
+        }) + '\n'
+      );
+      return;
+    }
     console.log(
       `capabilities: engine=${engine} collected=${counts.collected} ` +
       `selected=${counts.selected} skipped=${counts.skipped}`

--- a/tests/py/capability_adapter.py
+++ b/tests/py/capability_adapter.py
@@ -1,0 +1,127 @@
+"""Capability selection for pytest.
+
+Lives outside conftest.py so the synthetic fixture suite in
+tests/capability-fixtures/py can load the same hooks through its own conftest.
+"""
+
+import json
+import os
+from collections import Counter
+from pathlib import Path
+import pytest
+
+
+_CAPABILITIES_FILE = Path(__file__).parents[1] / "capabilities.json"
+_CROSS_ENGINE_ROOT = Path(__file__).parent / "engine"
+
+
+def _engine():
+    engine = os.environ.get("VIBIUM_ENGINE") or "chrome"
+    if engine not in {"chrome", "firefox"}:
+        raise pytest.UsageError(f"unknown VIBIUM_ENGINE: {engine}")
+    return engine
+
+
+def _manifest():
+    data = json.loads(_CAPABILITIES_FILE.read_text())
+    if not isinstance(data, dict):
+        raise pytest.UsageError("tests/capabilities.json must be an object")
+    return data
+
+
+def _requirements(item):
+    requirements = []
+    for marker in item.iter_markers("capability"):
+        for name in marker.args:
+            if not isinstance(name, str):
+                raise pytest.UsageError(f"{item.nodeid}: capability names must be strings")
+            if name not in requirements:
+                requirements.append(name)
+    return requirements
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "capability(*names): browser capabilities required by a test "
+        "(requirements use AND semantics)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    manifest = _manifest()
+    engine = _engine()
+    counts = Counter(collected=len(items))
+
+    for item in items:
+        requirements = _requirements(item)
+        in_root = item.path.is_relative_to(_CROSS_ENGINE_ROOT)
+        if in_root and not requirements:
+            raise pytest.UsageError(f"{item.nodeid}: unmarked test in Python cross-engine root")
+
+        if requirements:
+            counts["marked"] += 1
+
+        unknown = [name for name in requirements if name not in manifest]
+        if unknown:
+            raise pytest.UsageError(f"{item.nodeid}: unknown capabilities: {', '.join(unknown)}")
+
+        missing = [name for name in requirements if engine not in manifest[name]]
+        if missing:
+            counts["skipped"] += 1
+            for name in missing:
+                counts[f"skip:{name}"] += 1
+            reason = f"{engine} lacks capabilities: {', '.join(missing)}"
+            item.add_marker(pytest.mark.skip(reason=reason))
+        else:
+            counts["selected"] += 1
+
+        # The manifest must not list an engine for a capability unless chrome
+        # is also listed; empty entries are fine. Add an exemption mechanism
+        # before introducing one.
+        if config.getoption("capability_audit") and engine == "chrome":
+            invalid = [name for name in missing if manifest[name]]
+            if invalid:
+                raise pytest.UsageError(
+                    f"{item.nodeid}: Chrome audit rejected skips for: {', '.join(invalid)}"
+                )
+
+    config._vibium_capability_counts = counts
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--capability-audit",
+        action="store_true",
+        help="fail if Chrome skips a capability supported by any engine",
+    )
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    counts = getattr(config, "_vibium_capability_counts", Counter())
+    # Suites without capability markers (unit tests, browser-mode tests) have
+    # nothing to report; printing there is noise.
+    if not counts["marked"] and not config.getoption("capability_audit"):
+        return
+    terminalreporter.write_sep(
+        "-",
+        "capabilities: "
+        f"engine={_engine()} collected={counts['collected']} "
+        f"selected={counts['selected']} skipped={counts['skipped']}",
+    )
+    for key in sorted(k for k in counts if k.startswith("skip:")):
+        terminalreporter.write_line(f"capabilities: {key}={counts[key]}")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Send one deterministic collection summary back from xdist workers."""
+    if hasattr(session.config, "workeroutput"):
+        counts = getattr(session.config, "_vibium_capability_counts", Counter())
+        session.config.workeroutput["vibium_capability_counts"] = dict(counts)
+
+
+def pytest_testnodedown(node, error):
+    """All xdist workers collect the same items; retain (do not sum) one copy."""
+    raw = node.workeroutput.get("vibium_capability_counts")
+    if raw is not None and not hasattr(node.config, "_vibium_capability_counts"):
+        node.config._vibium_capability_counts = Counter(raw)

--- a/tests/py/conftest.py
+++ b/tests/py/conftest.py
@@ -1,115 +1,13 @@
 """Shared fixtures and capability selection for the Python test suite."""
 
-import asyncio
-import json
-import os
-from collections import Counter
-from pathlib import Path
 import pytest
 import pytest_asyncio
 
 from test_server import start_test_server
 
-
-_CAPABILITIES_FILE = Path(__file__).parents[1] / "capabilities.json"
-_CROSS_ENGINE_ROOT = Path(__file__).parent / "engine"
-
-
-def _engine():
-    engine = os.environ.get("VIBIUM_ENGINE") or "chrome"
-    if engine not in {"chrome", "firefox"}:
-        raise pytest.UsageError(f"unknown VIBIUM_ENGINE: {engine}")
-    return engine
-
-
-def _manifest():
-    data = json.loads(_CAPABILITIES_FILE.read_text())
-    if not isinstance(data, dict):
-        raise pytest.UsageError("tests/capabilities.json must be an object")
-    return data
-
-
-def _requirements(item):
-    requirements = []
-    for marker in item.iter_markers("capability"):
-        for name in marker.args:
-            if not isinstance(name, str):
-                raise pytest.UsageError(f"{item.nodeid}: capability names must be strings")
-            if name not in requirements:
-                requirements.append(name)
-    return requirements
-
-
-def pytest_collection_modifyitems(config, items):
-    manifest = _manifest()
-    engine = _engine()
-    counts = Counter(collected=len(items))
-
-    for item in items:
-        requirements = _requirements(item)
-        in_root = item.path.is_relative_to(_CROSS_ENGINE_ROOT)
-        if in_root and not requirements:
-            raise pytest.UsageError(f"{item.nodeid}: unmarked test in Python cross-engine root")
-
-        unknown = [name for name in requirements if name not in manifest]
-        if unknown:
-            raise pytest.UsageError(f"{item.nodeid}: unknown capabilities: {', '.join(unknown)}")
-
-        missing = [name for name in requirements if engine not in manifest[name]]
-        if missing:
-            counts["skipped"] += 1
-            for name in missing:
-                counts[f"skip:{name}"] += 1
-            reason = f"{engine} lacks capabilities: {', '.join(missing)}"
-            item.add_marker(pytest.mark.skip(reason=reason))
-        else:
-            counts["selected"] += 1
-
-        # The manifest must not list an engine for a capability unless chrome
-        # is also listed; empty entries are fine. Add an exemption mechanism
-        # before introducing one.
-        if config.getoption("capability_audit") and engine == "chrome":
-            invalid = [name for name in missing if manifest[name]]
-            if invalid:
-                raise pytest.UsageError(
-                    f"{item.nodeid}: Chrome audit rejected skips for: {', '.join(invalid)}"
-                )
-
-    config._vibium_capability_counts = counts
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--capability-audit",
-        action="store_true",
-        help="fail if Chrome skips a capability supported by any engine",
-    )
-
-
-def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    counts = getattr(config, "_vibium_capability_counts", Counter())
-    terminalreporter.write_sep(
-        "-",
-        "capabilities: "
-        f"engine={_engine()} collected={counts['collected']} "
-        f"selected={counts['selected']} skipped={counts['skipped']}",
-    )
-    for key in sorted(k for k in counts if k.startswith("skip:")):
-        terminalreporter.write_line(f"capabilities: {key}={counts[key]}")
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """Send one deterministic collection summary back from xdist workers."""
-    if hasattr(session.config, "workeroutput"):
-        counts = getattr(session.config, "_vibium_capability_counts", Counter())
-        session.config.workeroutput["vibium_capability_counts"] = dict(counts)
-
-
-def pytest_testnodedown(node, error):
-    """All xdist workers collect the same items; retain (do not sum) one copy."""
-    raw = node.workeroutput.get("vibium_capability_counts")
-    if raw is not None and not hasattr(node.config, "_vibium_capability_counts"):
-        node.config._vibium_capability_counts = Counter(raw)
+# Hooks are discovered by name in the conftest namespace, so the star import
+# registers the whole capability adapter.
+from capability_adapter import *  # noqa: F401,F403
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes VibiumDev/vibium#350

## What changed

**Node summary rolls up to one line per run.** node --test runs each file in its own process, so the adapter printed one summary per file (about 20 lines in the audit). With VIBIUM_CAPABILITY_SUMMARY_FILE set, each process appends its counts to an ndjson file and scripts/report-capability-summary.mjs prints a single total afterwards. Wired into test-cli-shared, test-js-async, test-js-sync, test-js-engine, and the audit target; exit codes propagate.

**pytest summary prints only when capability selection was in play.** Suites without capability markers (test_browser_modes.py and friends) no longer emit it; passing --capability-audit still forces it. The hooks moved from conftest.py to capability_adapter.py unchanged (star-imported back) so a fixture suite outside tests/py can load them.

**Regression fixtures for the two validators that had none.** A pytest fixture suite asserts selection and skip counts (mirroring the Node one), and two synthetic Java trees assert validateCapabilityMarkers still rejects a missing class-level marker and an unknown capability. The Java marker root is overridable via -PcapabilityMarkerRoot for the fixture runs. Both are wired into make test-capability-audit.

The Java engine-test package mismatch from the issue is already fixed on main; every file declares com.vibium.engine.

Verified:
- make test-capability-audit green end to end, now printing one Node summary line (collected=464) instead of one per file
- Both Java fixture trees rejected with the expected messages; the real tree still validates
- pytest fixture counts assert engine=chrome collected=3 selected=1 skipped=2, skip:audio=2
- Summary guard checked both ways: unmarked suite prints nothing, engine suite output unchanged
- test-cli-shared 71/71 green with the new recipe chaining (daemon cleanup still runs after)