### PR TITLE
Add flat waitFor names to the JS and Python page wait methods

### DIFF
--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -596,13 +596,31 @@ export class Page {
     event(name: string, fn?: () => Promise<void>, options?: { timeout?: number }): Promise<unknown>;
   };
 
-  /** Wait until a condition is met. Callable with a function, or use .url() / .loaded() sub-methods. */
+  /**
+   * Wait until a condition is met. Callable with a function, or use .url() / .loaded() sub-methods.
+   * @deprecated Use waitForFunction(), waitForURL(), or waitForLoad().
+   */
   readonly waitUntil: ((fn: string, options?: { timeout?: number }) => Promise<unknown>) & {
-    /** Wait until the page URL matches a pattern. */
+    /** @deprecated Use waitForURL(). */
     url(pattern: string, options?: { timeout?: number }): Promise<void>;
-    /** Wait until the page reaches a load state. */
+    /** @deprecated Use waitForLoad(). */
     loaded(state?: string, options?: { timeout?: number }): Promise<void>;
   };
+
+  /** Wait until a function returns a truthy value. */
+  async waitForFunction(fn: string, options?: { timeout?: number }): Promise<unknown> {
+    return this._waitForFunction(fn, options);
+  }
+
+  /** Wait until the page URL matches a pattern. */
+  async waitForURL(pattern: string, options?: { timeout?: number }): Promise<void> {
+    await this._waitForURL(pattern, options);
+  }
+
+  /** Wait until the page reaches a load state. */
+  async waitForLoad(state?: string, options?: { timeout?: number }): Promise<void> {
+    await this._waitForLoad(state, options);
+  }
 
   /** Wait for a fixed amount of time (milliseconds). Discouraged but useful for debugging. */
   async wait(ms: number): Promise<void> {

--- a/clients/javascript/src/sync/page.ts
+++ b/clients/javascript/src/sync/page.ts
@@ -254,11 +254,32 @@ export class PageSync {
     };
   }
 
-  /** Wait until a condition is met. Callable with a function, or use .url() / .loaded() sub-methods. */
+  /**
+   * Wait until a condition is met. Callable with a function, or use .url() / .loaded() sub-methods.
+   * @deprecated Use waitForFunction(), waitForURL(), or waitForLoad().
+   */
   readonly waitUntil: ((fn: string, options?: { timeout?: number }) => unknown) & {
+    /** @deprecated Use waitForURL(). */
     url(pattern: string, options?: { timeout?: number }): void;
+    /** @deprecated Use waitForLoad(). */
     loaded(state?: string, options?: { timeout?: number }): void;
   };
+
+  /** Wait until a function returns a truthy value. */
+  waitForFunction(fn: string, options?: { timeout?: number }): unknown {
+    const result = this._bridge.call<{ value: unknown }>('page.waitForFunction', [this._pageId, fn, options]);
+    return result.value;
+  }
+
+  /** Wait until the page URL matches a pattern. */
+  waitForURL(pattern: string, options?: { timeout?: number }): void {
+    this._bridge.call('page.waitForURL', [this._pageId, pattern, options]);
+  }
+
+  /** Wait until the page reaches a load state. */
+  waitForLoad(state?: string, options?: { timeout?: number }): void {
+    this._bridge.call('page.waitForLoad', [this._pageId, state, options]);
+  }
 
   wait(ms: number): void {
     this._bridge.call('page.wait', [this._pageId, ms]);

--- a/clients/javascript/src/sync/worker.ts
+++ b/clients/javascript/src/sync/worker.ts
@@ -399,19 +399,19 @@ const handlers: Record<string, Handler> = {
 
   'page.waitForURL': async (args) => {
     const [pageId, pattern, options] = args as [number, string, { timeout?: number } | undefined];
-    await getPage(pageId).waitUntil.url(pattern, options);
+    await getPage(pageId).waitForURL(pattern, options);
     return { success: true };
   },
 
   'page.waitForLoad': async (args) => {
     const [pageId, state, options] = args as [number, string | undefined, { timeout?: number } | undefined];
-    await getPage(pageId).waitUntil.loaded(state, options);
+    await getPage(pageId).waitForLoad(state, options);
     return { success: true };
   },
 
   'page.waitForFunction': async (args) => {
     const [pageId, fn, options] = args as [number, string, { timeout?: number } | undefined];
-    const value = await getPage(pageId).waitUntil(fn, options);
+    const value = await getPage(pageId).waitForFunction(fn, options);
     return { value };
   },
 

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -7,6 +7,7 @@ import base64
 import fnmatch
 import logging
 import re
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 from .. import errors
@@ -259,8 +260,25 @@ class Page:
 
     @property
     def wait_until(self) -> _WaitUntilNamespace:
-        """Wait until a condition is met. Callable or use .url() / .loaded() sub-methods."""
+        """Deprecated alias — use wait_for_function / wait_for_url / wait_for_load."""
+        warnings.warn(
+            "wait_until is deprecated; use wait_for_function, wait_for_url, or wait_for_load",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return _WaitUntilNamespace(self)
+
+    async def wait_for_function(self, fn: str, timeout: Optional[int] = None) -> Any:
+        """Wait until a function returns a truthy value."""
+        return await self._wait_for_function(fn, timeout)
+
+    async def wait_for_url(self, pattern: str, timeout: Optional[int] = None) -> None:
+        """Wait until the page URL matches a pattern."""
+        await self._wait_for_url(pattern, timeout)
+
+    async def wait_for_load(self, state: Optional[str] = None, timeout: Optional[int] = None) -> None:
+        """Wait until the page reaches a load state."""
+        await self._wait_for_load(state, timeout)
 
     async def wait(self, ms: int) -> None:
         """Wait for a fixed amount of time (milliseconds)."""

--- a/clients/python/src/vibium/sync_api/page.py
+++ b/clients/python/src/vibium/sync_api/page.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 from .._types import A11yNode
@@ -187,8 +188,25 @@ class Page:
 
     @property
     def wait_until(self) -> _SyncWaitUntilNamespace:
-        """Wait until a condition is met. Callable or use .url() / .loaded() sub-methods."""
+        """Deprecated alias — use wait_for_function / wait_for_url / wait_for_load."""
+        warnings.warn(
+            "wait_until is deprecated; use wait_for_function, wait_for_url, or wait_for_load",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return _SyncWaitUntilNamespace(self)
+
+    def wait_for_function(self, fn: str, timeout: Optional[int] = None) -> Any:
+        """Wait until a function returns a truthy value."""
+        return self._loop.run(self._async._wait_for_function(fn, timeout))
+
+    def wait_for_url(self, pattern: str, timeout: Optional[int] = None) -> None:
+        """Wait until the page URL matches a pattern."""
+        self._loop.run(self._async._wait_for_url(pattern, timeout))
+
+    def wait_for_load(self, state: Optional[str] = None, timeout: Optional[int] = None) -> None:
+        """Wait until the page reaches a load state."""
+        self._loop.run(self._async._wait_for_load(state, timeout))
 
     def wait(self, ms: int) -> None:
         self._loop.run(self._async.wait(ms))

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -42,7 +42,7 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 23 | Add a style tag | `vibium:page.addStyle` | ⬜ | ⬜ | `page.addStyle(src)` | `page.add_style(src)` | `page.addStyle(src)` |
 | 24 | Expose a function to the page | `vibium:page.expose` | — | — | `page.expose(name, fn)` | `page.expose(name, fn)` | `page.expose(name, fn)` |
 | 25 | Wait for a duration | `vibium:page.wait` | `vibium sleep <ms>` | `browser_sleep` | `page.wait(ms)` | `page.wait(ms)` | `page.sleep(ms)` |
-| 26 | Wait for a selector | `vibium:page.waitFor` | `vibium wait <sel>` | `browser_wait` | `page.waitFor(sel, opts?)` | `page.wait_for(sel, **opts)` | `page.waitFor(sel, options?)` |
+| 26 | Wait for a selector | `vibium:page.waitFor` | `vibium wait <sel>` | `browser_wait` | — | — | `page.waitFor(sel, options?)` |
 | 27 | Wait for JS function to return truthy | `vibium:page.waitForFunction` | `vibium wait fn <expr>` | `browser_wait_for_fn` | `page.waitForFunction(fn, opts?)` | `page.wait_for_function(fn, **opts)` | `page.waitForFunction(fn, options?)` |
 | 28 | Wait for URL to match | `vibium:page.waitForURL` | `vibium wait url <pat>` | `browser_wait_for_url` | `page.waitForURL(url, opts?)` | `page.wait_for_url(url, **opts)` | `page.waitForURL(url, options?)` |
 | 29 | Wait for page load | `vibium:page.waitForLoad` | `vibium wait load` | `browser_wait_for_load` | `page.waitForLoad(opts?)` | `page.wait_for_load(**opts)` | `page.waitForLoad(options?)` |
@@ -209,7 +209,7 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 |---|---|---|---|---|---|---|---|
 | 139 | Save a download to path | `vibium:download.saveAs` | ⬜ | ⬜ | `download.saveAs(path)` | `download.save_as(path)` | `download.saveAs(path)` |
 | 140 | Get download URL | *from event data* | — | — | `download.url()` | `download.url()` | `download.url()` |
-| 141 | Get download filename | *from event data* | — | — | `download.filename()` | `download.filename()` | `download.suggestedFilename()` |
+| 141 | Get download filename | *from event data* | — | — | `download.suggestedFilename()` | `download.suggested_filename()` | `download.suggestedFilename()` |
 | 142 | Get download path | *from event data* | — | — | `download.path()` | `download.path()` | `download.path()` |
 
 ## Request

--- a/tests/js/async/engine/download-file.test.js
+++ b/tests/js/async/engine/download-file.test.js
@@ -160,7 +160,7 @@ describe('Element: el.setFiles', () => {
       await vibe.find('#file-input').setFiles([testFile]);
       // setFiles may resolve before the change-event handler runs in Chrome
       // and updates #file-name. Poll the DOM instead of sleeping.
-      await vibe.waitUntil(
+      await vibe.waitForFunction(
         `() => document.getElementById('file-name').textContent === 'upload-test.txt'`,
         { timeout: 5000 },
       );

--- a/tests/js/async/engine/input-eval.test.js
+++ b/tests/js/async/engine/input-eval.test.js
@@ -322,7 +322,7 @@ describe('Input & Eval Checkpoint', () => {
     // Submit the form
     const btn = await vibe.find('button[type="submit"]');
     await btn.click();
-    await vibe.waitUntil.url('**/secure');
+    await vibe.waitForURL('**/secure');
 
     const url = await vibe.url();
     assert.ok(url.includes('/secure'), `Should be on /secure, got: ${url}`);

--- a/tests/js/async/engine/interaction.test.js
+++ b/tests/js/async/engine/interaction.test.js
@@ -38,7 +38,7 @@ describe('Interaction: Checkpoint', () => {
     const loginBtn = await vibe.find('button[type="submit"]');
     await loginBtn.click();
 
-    await vibe.waitUntil.url('**/secure');
+    await vibe.waitForURL('**/secure');
     const url = await vibe.url();
     assert.ok(url.includes('/secure'), `Should be on /secure page, got: ${url}`);
   });
@@ -94,7 +94,7 @@ describe('Interaction: Click variants', () => {
     const link = await vibe.find('a[href="/login"]');
     await link.click();
 
-    await vibe.waitUntil.url('**/login');
+    await vibe.waitForURL('**/login');
     const url = await vibe.url();
     assert.ok(url.includes('/login'), `Should navigate to /login, got: ${url}`);
   });
@@ -170,7 +170,7 @@ describe('Interaction: Input methods', () => {
     // Press Enter to submit instead of clicking
     await password.press('Enter');
 
-    await vibe.waitUntil.url('**/secure');
+    await vibe.waitForURL('**/secure');
     const url = await vibe.url();
     assert.ok(url.includes('/secure'), `Enter should submit form, got: ${url}`);
   });

--- a/tests/js/async/engine/navigation.test.js
+++ b/tests/js/async/engine/navigation.test.js
@@ -1,7 +1,7 @@
 /**
  * JS Library Tests: Navigation
  * Tests page.go(), back(), forward(), reload(), url(), title(), content(),
- * waitUntil.url(), waitUntil.loaded()
+ * waitForURL(), waitForLoad()
  */
 
 const { test, describe, before, after } = require("../../../helpers/capabilities").suite("core");
@@ -77,34 +77,41 @@ describe('JS Navigation', () => {
     assert.ok(content.includes('Welcome to the-internet'), 'Should contain page content');
   });
 
-  test('page.waitUntil.url() waits for matching URL', async () => {
+  test('page.waitForURL() waits for matching URL', async () => {
     const vibe = await bro.page();
     await vibe.go(baseURL + '/login');
 
-    // URL should already match — waitUntil.url should return immediately
-    await vibe.waitUntil.url('/login', { timeout: 5000 });
+    // URL should already match — waitForURL should return immediately
+    await vibe.waitForURL('/login', { timeout: 5000 });
 
     const url = await vibe.url();
     assert.ok(url.includes('/login'), 'Should have matched login URL');
   });
 
-  test('page.waitUntil.loaded() waits for load state', async () => {
+  test('page.waitForLoad() waits for load state', async () => {
     const vibe = await bro.page();
     await vibe.go(baseURL + '/');
-    await vibe.waitUntil.loaded('complete', { timeout: 10000 });
+    await vibe.waitForLoad('complete', { timeout: 10000 });
     // If we get here, it passed
     assert.ok(true);
   });
 
-  test('page.waitUntil.url() times out on mismatch', async () => {
+  test('page.waitForURL() times out on mismatch', async () => {
     const vibe = await bro.page();
     await vibe.go(baseURL + '/');
 
     await assert.rejects(
-      () => vibe.waitUntil.url('**/nonexistent-page-xyz', { timeout: 1000 }),
+      () => vibe.waitForURL('**/nonexistent-page-xyz', { timeout: 1000 }),
       /timeout/i,
       'Should timeout when URL does not match'
     );
+  });
+
+  test('waitUntil.url() and .loaded() still work as deprecated aliases (#304)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL + '/login');
+    await vibe.waitUntil.url('/login', { timeout: 5000 });
+    await vibe.waitUntil.loaded('complete', { timeout: 10000 });
   });
 
   test('a non-timeout error is not mislabeled as a timeout (#64)', async () => {

--- a/tests/js/async/engine/state.test.js
+++ b/tests/js/async/engine/state.test.js
@@ -1,8 +1,8 @@
 /**
  * JS Library Tests: Element State + Waiting
  * Tests el.text, innerText, html, value, attr, bounds, isVisible, isHidden,
- * isEnabled, isChecked, isEditable, eval, screenshot, waitUntil.
- * Also tests page.wait, page.waitUntil.
+ * isEnabled, isChecked, isEditable, eval, screenshot, waitForFunction.
+ * Also tests page.wait, page.waitForFunction.
  */
 
 const { test, describe, before, after } = require("../../../helpers/capabilities").suite("core");
@@ -207,12 +207,20 @@ describe('Page Waiting', () => {
     assert.ok(elapsed >= 150, `Should wait at least 150ms, waited ${elapsed}ms`);
   });
 
-  test('waitUntil(fn) resolves when function returns truthy', async () => {
+  test('waitForFunction(fn) resolves when function returns truthy', async () => {
+    const vibe = await bro.page();
+    await vibe.go(`${baseURL}/example`);
+
+    const result = await vibe.waitForFunction('() => document.querySelector("h1") !== null');
+    assert.ok(result, 'waitForFunction should return truthy value');
+  });
+
+  test('waitUntil(fn) still works as a deprecated alias (#304)', async () => {
     const vibe = await bro.page();
     await vibe.go(`${baseURL}/example`);
 
     const result = await vibe.waitUntil('() => document.querySelector("h1") !== null');
-    assert.ok(result, 'waitUntil should return truthy value');
+    assert.ok(result, 'waitUntil alias should return truthy value');
   });
 
   test('waitUntil(bare expression) resolves, not just functions (#123)', async () => {
@@ -220,8 +228,8 @@ describe('Page Waiting', () => {
     await vibe.go('data:text/html,<h1>hi</h1>');
 
     // A bare boolean expression (no "() =>") previously always timed out.
-    const result = await vibe.waitUntil(`document.readyState === 'complete'`, { timeout: 3000 });
-    assert.ok(result, 'bare-expression waitUntil should resolve');
+    const result = await vibe.waitForFunction(`document.readyState === 'complete'`, { timeout: 3000 });
+    assert.ok(result, 'bare-expression waitForFunction should resolve');
   });
 });
 

--- a/tests/js/sync/engine/sync-api.test.js
+++ b/tests/js/sync/engine/sync-api.test.js
@@ -84,6 +84,24 @@ describe('Sync API: Navigation', () => {
     assert.ok(url.includes('127.0.0.1'), 'Should contain host');
   });
 
+  test('waitForURL / waitForLoad / waitForFunction resolve (#304)', () => {
+    const vibe = bro.page();
+    vibe.go(baseURL);
+    vibe.waitForURL('**/', { timeout: 5000 });
+    vibe.waitForLoad('complete', { timeout: 10000 });
+    const value = vibe.waitForFunction(`document.readyState === 'complete'`, { timeout: 5000 });
+    assert.ok(value, 'waitForFunction should return truthy value');
+  });
+
+  test('waitUntil still works as a deprecated alias (#304)', () => {
+    const vibe = bro.page();
+    vibe.go(baseURL);
+    vibe.waitUntil.url('**/', { timeout: 5000 });
+    vibe.waitUntil.loaded('complete', { timeout: 10000 });
+    const value = vibe.waitUntil(`document.readyState === 'complete'`, { timeout: 5000 });
+    assert.ok(value, 'waitUntil alias should return truthy value');
+  });
+
   test('title() returns page title', () => {
     const vibe = bro.page();
     vibe.go(baseURL);

--- a/tests/py/engine/test_async_api.py
+++ b/tests/py/engine/test_async_api.py
@@ -45,7 +45,7 @@ async def test_element_click(async_page, test_server):
     await async_page.go(test_server)
     link = await async_page.find('a[href="/subpage"]')
     await link.click()
-    await async_page.wait_until.url("**/subpage")
+    await async_page.wait_for_url("**/subpage")
     title = await async_page.title()
     assert title == "Subpage"
 

--- a/tests/py/engine/test_interaction.py
+++ b/tests/py/engine/test_interaction.py
@@ -9,7 +9,7 @@ async def test_click_navigates(async_page, test_server):
     await async_page.go(test_server)
     link = await async_page.find('a[href="/subpage"]')
     await link.click()
-    await async_page.wait_until.url("**/subpage")
+    await async_page.wait_for_url("**/subpage")
     assert await async_page.title() == "Subpage"
 
 

--- a/tests/py/engine/test_navigation.py
+++ b/tests/py/engine/test_navigation.py
@@ -44,21 +44,28 @@ async def test_content(async_page, test_server):
     assert "Welcome to test-app" in html
 
 
-async def test_wait_until_url(async_page, test_server):
+async def test_wait_for_url(async_page, test_server):
     await async_page.go(test_server)
     link = await async_page.find('a[href="/subpage"]')
     await link.click()
-    await async_page.wait_until.url("**/subpage")
+    await async_page.wait_for_url("**/subpage")
     assert "/subpage" in await async_page.url()
 
 
-async def test_wait_until_loaded(async_page, test_server):
+async def test_wait_for_load(async_page, test_server):
     await async_page.go(test_server)
-    await async_page.wait_until.loaded()
+    await async_page.wait_for_load()
     assert await async_page.title() == "Test App"
 
 
-async def test_wait_until_url_timeout(async_page, test_server):
+async def test_wait_for_url_timeout(async_page, test_server):
     await async_page.go(test_server)
     with pytest.raises(Exception):
-        await async_page.wait_until.url("**/never-going-here", timeout=1000)
+        await async_page.wait_for_url("**/never-going-here", timeout=1000)
+
+
+async def test_wait_until_deprecated_alias(async_page, test_server):
+    await async_page.go(test_server)
+    with pytest.warns(DeprecationWarning):
+        await async_page.wait_until.loaded()
+    assert await async_page.title() == "Test App"

--- a/tests/py/engine/test_state.py
+++ b/tests/py/engine/test_state.py
@@ -154,10 +154,10 @@ async def test_wait_ms(async_page, test_server):
     await async_page.wait(100)  # should not throw
 
 
-async def test_wait_until_function(async_page, test_server):
+async def test_wait_for_function(async_page, test_server):
     await async_page.go(test_server)
     await async_page.evaluate("setTimeout(() => { window.__ready = true }, 200)")
-    result = await async_page.wait_until("() => window.__ready", timeout=5000)
+    result = await async_page.wait_for_function("() => window.__ready", timeout=5000)
     assert result is True
 
 

--- a/tests/py/engine/test_sync_api.py
+++ b/tests/py/engine/test_sync_api.py
@@ -195,8 +195,17 @@ def test_click_navigates(bro, test_server):
     vibe.go(test_server)
     link = vibe.find('a[href="/subpage"]')
     link.click()
-    vibe.wait_until.url("**/subpage")
+    vibe.wait_for_url("**/subpage")
     assert vibe.title() == "Subpage"
+
+
+def test_wait_for_names_and_deprecated_alias(bro, test_server):
+    vibe = bro.page()
+    vibe.go(test_server)
+    vibe.wait_for_load()
+    assert vibe.wait_for_function("() => document.readyState === 'complete'", timeout=5000)
+    with pytest.warns(DeprecationWarning):
+        vibe.wait_until.loaded()
 
 
 def test_fill_and_value(bro, test_server):

--- a/tests/py/test_errors.py
+++ b/tests/py/test_errors.py
@@ -138,6 +138,6 @@ async def test_timeout_error_is_catchable_as_builtin(async_page, test_server):
     import vibium
 
     await async_page.go(test_server)
-    # Use wait_until with an expression that never becomes truthy to get a pure timeout
+    # Use wait_for_function with an expression that never becomes truthy to get a pure timeout
     with pytest.raises(builtins.TimeoutError):
-        await async_page.wait_until("() => false", timeout=500)
+        await async_page.wait_for_function("() => false", timeout=500)


### PR DESCRIPTION
Fixes VibiumDev/vibium#304

The JS and Python clients exposed waits through a waitUntil namespace while every other surface, including the wire protocol, uses flat waitFor names. The namespace shape did not port to Java, collides with Playwright's waitUntil option value, and is inconsistent with itself (callable and object on one identifier).

JS async and sync pages get waitForFunction/waitForURL/waitForLoad; Python async and sync pages get wait_for_function/wait_for_url/wait_for_load. waitUntil and wait_until stay as deprecated aliases for at least one release: JSDoc @deprecated in TypeScript, DeprecationWarning on the Python property. Tests migrate to the new names with one alias test kept per surface.

Also fixes two api.md rows that were wrong regardless: row 26 claimed page.waitFor(sel) exists in JS and Python (neither exposes it, find() auto-waits; the Java column stays, Page.waitFor is real there), and row 141 documented download.filename() which never existed in either client; both ship suggestedFilename/suggested_filename.

Verified:
- New methods absent on main, present on the branch, checked on all four surfaces (Page/PageSync prototypes, Python async/sync hasattr)
- Touched JS async engine files 78/78 green on Chrome (state, navigation, download-file, input-eval, interaction)
- sync-api.test.js 72/72 green including the new flat-name and alias tests
- Touched Python files 139/139 green (navigation, state, interaction, async_api, sync_api, errors)

Note for local runs: input-eval's hover test failed on this VM on unmodified main too; Chrome's compositor was producing zero rAF frames (wedged VM GPU, VIBIUM_CHROME_ARGS=--disable-gpu works around it). Not related to this diff.