### PR TITLE
Verify Firefox downloads against Mozilla's SHA256SUMS

### DIFF
--- a/clicker/internal/browser/installer.go
+++ b/clicker/internal/browser/installer.go
@@ -175,6 +175,9 @@ func findDownloadURL(downloads []Download, platform string) string {
 }
 
 // downloadAndExtract downloads a zip file and extracts it to the destination.
+// Unlike Firefox (SHA256SUMS, verified in installer_firefox.go), Chrome for
+// Testing publishes no checksums — its downloads JSON carries only platform
+// and url — so there is nothing official to verify the archive against.
 func downloadAndExtract(url, destDir string) error {
 	// Download to temp file
 	resp, err := http.Get(url)

--- a/clicker/internal/browser/installer_firefox.go
+++ b/clicker/internal/browser/installer_firefox.go
@@ -1,6 +1,8 @@
 package browser
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/vibium/clicker/internal/paths"
 )
@@ -63,14 +66,28 @@ func InstallFirefox() (string, error) {
 	downloadURL := firefoxDownloadURL(version)
 	fmt.Printf("Downloading Firefox from %s...\n", downloadURL)
 
+	pattern := "firefox-*.tar.xz"
+	if runtime.GOOS == "darwin" {
+		pattern = "firefox-*.dmg"
+	}
+	archivePath, err := downloadToTemp(downloadURL, pattern)
+	if err != nil {
+		return "", fmt.Errorf("failed to download Firefox: %w", err)
+	}
+	defer os.Remove(archivePath)
+
+	if err := verifyFirefoxArchive(archivePath, version); err != nil {
+		return "", fmt.Errorf("Firefox download failed verification: %w", err)
+	}
+
 	if err := os.MkdirAll(versionDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create version dir: %w", err)
 	}
 
 	if runtime.GOOS == "darwin" {
-		err = installFirefoxDMG(downloadURL, versionDir)
+		err = installFirefoxDMG(archivePath, versionDir)
 	} else {
-		err = installFirefoxTarXZ(downloadURL, versionDir)
+		err = installFirefoxTarXZ(archivePath, versionDir)
 	}
 	if err != nil {
 		os.RemoveAll(versionDir)
@@ -156,17 +173,100 @@ func firefoxDownloadURL(version string) string {
 }
 
 func firefoxDownloadURLFor(goos, goarch, version string) string {
-	base := "https://ftp.mozilla.org/pub/firefox/releases/" + version
+	segments := strings.Split(firefoxArchiveRelPath(goos, goarch, version), "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return "https://ftp.mozilla.org/pub/firefox/releases/" + version + "/" + strings.Join(segments, "/")
+}
+
+// firefoxArchiveRelPath returns the archive's path relative to the release
+// directory, unescaped, exactly as it appears in Mozilla's SHA256SUMS.
+func firefoxArchiveRelPath(goos, goarch, version string) string {
 	switch goos {
 	case "darwin":
-		return base + "/mac/en-US/" + url.PathEscape("Firefox "+version+".dmg")
+		return "mac/en-US/Firefox " + version + ".dmg"
 	default: // linux
 		arch := "linux-x86_64"
 		if goarch == "arm64" {
 			arch = "linux-aarch64"
 		}
-		return base + "/" + arch + "/en-US/firefox-" + version + ".tar.xz"
+		return arch + "/en-US/firefox-" + version + ".tar.xz"
 	}
+}
+
+// verifyFirefoxArchive checks the downloaded archive against Mozilla's
+// published SHA256SUMS for the release, before anything unpacks it.
+func verifyFirefoxArchive(archivePath, version string) error {
+	sums, err := fetchFirefoxChecksums(version)
+	if err != nil {
+		return fmt.Errorf("fetching SHA256SUMS: %w", err)
+	}
+	relPath := firefoxArchiveRelPath(runtime.GOOS, runtime.GOARCH, version)
+	if err := verifyArchiveAgainstSums(archivePath, sums, relPath); err != nil {
+		return err
+	}
+	fmt.Printf("Verified Firefox archive against Mozilla's SHA256SUMS.\n")
+	return nil
+}
+
+// fetchFirefoxChecksums downloads the SHA256SUMS body for a release.
+func fetchFirefoxChecksums(version string) (string, error) {
+	resp, err := http.Get("https://ftp.mozilla.org/pub/firefox/releases/" + version + "/SHA256SUMS")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// verifyArchiveAgainstSums compares the file's SHA256 with the entry for
+// relPath in a SHA256SUMS body (lines of "<hex>  <path>").
+func verifyArchiveAgainstSums(archivePath, sums, relPath string) error {
+	want := findFirefoxChecksum(sums, relPath)
+	if want == "" {
+		return fmt.Errorf("no SHA256SUMS entry for %q", relPath)
+	}
+	got, err := sha256File(archivePath)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("SHA256 mismatch for %q: got %s, want %s", relPath, got, want)
+	}
+	return nil
+}
+
+// findFirefoxChecksum returns the hash listed for relPath, or "" if absent.
+func findFirefoxChecksum(sums, relPath string) string {
+	for _, line := range strings.Split(sums, "\n") {
+		hash, path, ok := strings.Cut(line, "  ")
+		if ok && path == relPath {
+			return hash
+		}
+	}
+	return ""
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // downloadToTemp downloads a URL to a temp file and returns its path.
@@ -203,13 +303,7 @@ func downloadToTemp(downloadURL, pattern string) (string, error) {
 // installFirefoxDMG mounts the DMG and copies Firefox.app into versionDir.
 // cp -R (not Go file walking) preserves the app bundle's symlinks and
 // permissions, which code signing validation depends on.
-func installFirefoxDMG(downloadURL, versionDir string) error {
-	dmgPath, err := downloadToTemp(downloadURL, "firefox-*.dmg")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(dmgPath)
-
+func installFirefoxDMG(dmgPath, versionDir string) error {
 	mountPoint, err := os.MkdirTemp("", "firefox-dmg-")
 	if err != nil {
 		return err
@@ -229,13 +323,7 @@ func installFirefoxDMG(downloadURL, versionDir string) error {
 
 // installFirefoxTarXZ extracts the Linux tar.xz (a firefox/ directory) into
 // versionDir. The system tar handles xz; Go's stdlib does not.
-func installFirefoxTarXZ(downloadURL, versionDir string) error {
-	tarPath, err := downloadToTemp(downloadURL, "firefox-*.tar.xz")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(tarPath)
-
+func installFirefoxTarXZ(tarPath, versionDir string) error {
 	if out, err := exec.Command("tar", "-xJf", tarPath, "-C", versionDir).CombinedOutput(); err != nil {
 		return fmt.Errorf("extracting Firefox archive failed: %w: %s", err, out)
 	}

--- a/clicker/internal/browser/installer_firefox_checksum_test.go
+++ b/clicker/internal/browser/installer_firefox_checksum_test.go
@@ -1,0 +1,69 @@
+package browser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sha256("abc"), a fixed test vector.
+const abcSHA256 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+const sampleSums = "87e9fcaecaef101d7a0910ba8960d4b72b5b4ae91fd4e08069088d3c06f9a792  linux-aarch64/en-US/firefox-153.0.4.tar.xz\n" +
+	abcSHA256 + "  mac/en-US/Firefox 153.0.4.dmg\n" +
+	"da8897a6a618e73878e6022a2bece76af509c304c73ae5c53dc523d35cb7bae6  linux-x86_64/en-US/firefox-153.0.4.tar.xz\n"
+
+func writeArchive(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "archive")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The SHA256SUMS paths use unescaped spaces (mac DMG), so the lookup key must
+// be the raw relative path, not the URL form.
+func TestFirefoxArchiveRelPathMatchesSums(t *testing.T) {
+	cases := []struct {
+		goos, goarch, version, want string
+	}{
+		{"darwin", "arm64", "153.0.4", "mac/en-US/Firefox 153.0.4.dmg"},
+		{"linux", "amd64", "153.0.4", "linux-x86_64/en-US/firefox-153.0.4.tar.xz"},
+		{"linux", "arm64", "153.0.4", "linux-aarch64/en-US/firefox-153.0.4.tar.xz"},
+	}
+	for _, tc := range cases {
+		if got := firefoxArchiveRelPath(tc.goos, tc.goarch, tc.version); got != tc.want {
+			t.Errorf("firefoxArchiveRelPath(%s, %s, %s) = %q, want %q",
+				tc.goos, tc.goarch, tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestFindFirefoxChecksum(t *testing.T) {
+	if got := findFirefoxChecksum(sampleSums, "mac/en-US/Firefox 153.0.4.dmg"); got != abcSHA256 {
+		t.Errorf("findFirefoxChecksum = %q, want %q", got, abcSHA256)
+	}
+	if got := findFirefoxChecksum(sampleSums, "mac/en-US/Firefox 999.0.dmg"); got != "" {
+		t.Errorf("findFirefoxChecksum for absent path = %q, want empty", got)
+	}
+}
+
+func TestVerifyArchiveAgainstSums(t *testing.T) {
+	good := writeArchive(t, "abc")
+	if err := verifyArchiveAgainstSums(good, sampleSums, "mac/en-US/Firefox 153.0.4.dmg"); err != nil {
+		t.Errorf("matching archive rejected: %v", err)
+	}
+
+	tampered := writeArchive(t, "abc-tampered")
+	err := verifyArchiveAgainstSums(tampered, sampleSums, "mac/en-US/Firefox 153.0.4.dmg")
+	if err == nil || !strings.Contains(err.Error(), "SHA256 mismatch") {
+		t.Errorf("tampered archive: got %v, want SHA256 mismatch error", err)
+	}
+
+	err = verifyArchiveAgainstSums(good, sampleSums, "mac/en-US/Firefox 999.0.dmg")
+	if err == nil || !strings.Contains(err.Error(), "no SHA256SUMS entry") {
+		t.Errorf("absent entry: got %v, want no-entry error", err)
+	}
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#313

Both installers fetched executables over HTTPS with no integrity check. Mozilla publishes SHA256SUMS alongside every release, so the Firefox installer now downloads the archive once, verifies its SHA256 against the published entry, and only then unpacks it (and, on macOS, strips quarantine). A missing entry or a mismatch fails the install with a clear error.

The archive's relative path is built by one function shared by the download URL and the checksum lookup, because the SHA256SUMS keys use the unescaped form (the mac DMG name contains a space). The pinned URL-shape tests from #363 pass unchanged against the refactor.

Chrome for Testing publishes no checksums; its downloads JSON carries only platform and url (checked 2026-08-20). There is nothing official to verify Chrome against, so the Chrome installer is unchanged apart from a comment recording that finding.

Verified:
- New unit tests cover the rel-path/SUMS key match, checksum lookup, a good archive, a tampered archive (SHA256 mismatch error), and a missing entry
- go test ./... clean
- Real install end to end into a scratch HOME: Firefox 154.0 downloaded, verified against Mozilla's live SHA256SUMS, installed