### PR TITLE
Install npm dependencies before stamping nightly versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,14 +128,19 @@ jobs:
           distribution: temurin
           cache: gradle
 
+      # Install from the committed lockfile BEFORE stamping versions: the
+      # stamped @vibium/* optional dependencies do not exist on npm until
+      # this same run publishes them, so an install after stamping silently
+      # drops them from the lockfile and npm ci fails the sync check.
+      - name: Install dependencies
+        run: npm ci
+
       - name: Apply nightly versions
         run: |
           node scripts/set-version.mjs \
             --version '${{ needs.select.outputs.npm_version }}' \
             --python-version '${{ needs.select.outputs.python_version }}' \
             --python-exact
-          npm install --package-lock-only --ignore-scripts
-          npm ci
 
       - name: Build distributions
         run: |


### PR DESCRIPTION
Fixes #394 

The first two nightly runs failed in the build job at "Apply nightly versions" (scheduled: https://github.com/VibiumDev/vibium/actions/runs/32469897088, manual: https://github.com/VibiumDev/vibium/actions/runs/32422003532).

The step stamped the nightly version into every package.json, then regenerated the lockfile before `npm ci`. The stamped `@vibium/*` platform versions do not exist on npm until the same run publishes them, so `npm install --package-lock-only` silently dropped their lockfile entries and `npm ci` failed the sync check with `Missing: @vibium/<platform>@ from lock file`.

The fix installs from the committed, in-sync lockfile before stamping and stops regenerating the lockfile. The stamped package.json files are only read by `npm pack`, which does not use the lockfile, and `make package` only installs when node_modules is missing.

Verified:
- Old order reproduces the CI failure locally: stamp, `npm install --package-lock-only --ignore-scripts`, `npm ci` fails with the same EUSAGE error and the lockfile loses all five `@vibium/*` entries.
- New order passes: `npm ci` succeeds, stamping leaves package-lock.json untouched, and `npm pack ./packages/vibium --dry-run` produces `vibium-2026.8.21-dev.1.tgz`.
