### PR TITLE
Accept --version and -V in the Python CLI

### DIFF
--- a/clients/python/src/vibium/cli.py
+++ b/clients/python/src/vibium/cli.py
@@ -20,7 +20,7 @@ def main():
 
     if command == "install":
         install_browser()
-    elif command == "version":
+    elif command in ("version", "--version", "-V"):
         from . import __version__
         print(f"vibium {__version__}")
     else:


### PR DESCRIPTION
Part of #396.

After `pip install vibium`, `vibium --version` failed with an unknown-command error: the Python CLI only understood the bare `version` subcommand, while the Go binary and the npm shim both accept the flag form users try first. Caught by the nightly local-smoke job on all five platforms.

Verified:
- `vibium --version`, `-V`, and `version` all print the version; unknown commands still exit 1 with usage.
- Nightly dry run local-smoke, which runs `vibium --version` from the pip install, is green on all five platforms with this fix: https://github.com/vincebln2/vibium/actions/runs/32521937352
