### PR TITLE
Fix the nightly build path on fresh checkouts and Linux runners

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,8 +132,13 @@ jobs:
       # stamped @vibium/* optional dependencies do not exist on npm until
       # this same run publishes them, so an install after stamping silently
       # drops them from the lockfile and npm ci fails the sync check.
+      # The lockfile is generated on macOS, so rollup's Linux native module is
+      # missing from it and has to be added separately, locked to the rollup
+      # version the lockfile installed (same workaround as test.yml).
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci
+          npm install --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('rollup/package.json').version")
 
       - name: Apply nightly versions
         run: |

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ build-js: deps
 # Output: clicker/bin/vibium-{os}-{arch}[.exe]
 build-go-all:
 	@echo "Cross-compiling vibium for all platforms..."
+	cp skills/vibe-check/SKILL.md clicker/cmd/clicker/SKILL.md
 	cd clicker && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X main.version=$(VERSION) -X github.com/vibium/clicker/internal/api.Version=$(VERSION)" -o bin/vibium-linux-amd64 ./cmd/clicker
 	cd clicker && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X main.version=$(VERSION) -X github.com/vibium/clicker/internal/api.Version=$(VERSION)" -o bin/vibium-linux-arm64 ./cmd/clicker
 	cd clicker && CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X main.version=$(VERSION) -X github.com/vibium/clicker/internal/api.Version=$(VERSION)" -o bin/vibium-darwin-amd64 ./cmd/clicker


### PR DESCRIPTION
Part of #396.

Two build failures only the nightly could hit. First, `build-go` copies `skills/vibe-check/SKILL.md` into `clicker/cmd/clicker` for go:embed, but `build-go-all` never did. The file is gitignored, so any fresh checkout that goes straight to `make package` fails with `pattern SKILL.md: no matching files found`; dev machines and test CI always run `build-go` first, which is why this never surfaced. This also affects manual releases from a fresh clone, and on a stale clone it silently embeds an outdated SKILL.md.

Second, the nightly's install step only ran `npm ci`. The lockfile is generated on macOS, so rollup's Linux native module is missing and tsup fails with MODULE_NOT_FOUND on the runner. test.yml has carried the explicit `@rollup/rollup-linux-x64-gnu` install since the CI split; the nightly now uses the same workaround.

Verified:
- `rm clicker/cmd/clicker/SKILL.md && make build-go-all` reproduces the CI failure without the fix; all five cross-compiles pass with it.
- Fork dry run of the nightly workflow is green through the build job and 5-platform local-smoke with both fixes: https://github.com/vincebln2/vibium/actions/runs/32521937352
