### PR TITLE
Name the repo for gh release commands in checkout-less jobs 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -270,6 +270,10 @@ jobs:
       - name: Create or update draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          # No checkout in this job: gh release resolves the repo from the
+          # git remote unless GH_REPO names it (gh api calls are unaffected,
+          # they use explicit repos/... paths).
+          GH_REPO: ${{ github.repository }}
         run: |
           tag='${{ needs.select.outputs.tag }}'
           # A draft's tag does not exist until publish, so drafts are not
@@ -514,6 +518,9 @@ jobs:
       - name: Finalize the audit manifest in the draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          # Same reason as draft-release: no checkout, so gh release needs
+          # the repo named explicitly.
+          GH_REPO: ${{ github.repository }}
         run: |
           metadata_url='https://central.sonatype.com/repository/maven-snapshots/com/vibium/vibium/${{ needs.select.outputs.maven_version }}/maven-metadata.xml'
           for delay in 5 10 20 40 80; do
@@ -536,6 +543,7 @@ jobs:
       - name: Publish GitHub prerelease
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh release edit '${{ needs.select.outputs.tag }}' --draft=false --prerelease
 
   # Depends only on select so pruning keeps running while publishing is red;


### PR DESCRIPTION
Part of #396.

The first real (publishing) nightly run failed in draft-release with "fatal: not a git repository" at `gh release upload`. That job never checks out the repo, and gh release commands resolve their target repo from the git remote; the gh api calls above survive because they name the repo in their URL paths. The same latent bug sat in both promote steps (manifest upload and the draft-to-prerelease flip), which would have failed identically hours later.

All three gh release invocations now set GH_REPO. Dry runs skip these jobs entirely, which is why four green dry runs never saw this; it could only surface on a real run.

Verified:
- Real (dry_run=false) dispatch on the fork, where publishing cannot succeed (OIDC matches no trusted publisher), executed draft-release for real: draft created and all assets uploaded, where main's run 32526921315 failed at the same step: https://github.com/vincebln2/vibium/actions/runs/32527554512
