### PR TITLE
Ship the GitHub prerelease nightly without registry publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -299,7 +299,12 @@ jobs:
             release/bin/* release/java/* release/npm/* release/python/* \
             release/manifest.json release/SHA256SUMS --clobber
 
+  # The three registry jobs (and public-smoke behind them) stay parked until
+  # the trusted publishers and signing secrets exist (#396): set the
+  # NIGHTLY_PUBLISH_REGISTRIES repository variable to 'true' to enable them.
+  # The GitHub prerelease in promote ships either way.
   publish-npm:
+    if: vars.NIGHTLY_PUBLISH_REGISTRIES == 'true'
     needs: [select, local-smoke, draft-release]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -326,6 +331,7 @@ jobs:
           done
 
   publish-pypi-platforms:
+    if: vars.NIGHTLY_PUBLISH_REGISTRIES == 'true'
     needs: [select, local-smoke, draft-release]
     strategy:
       fail-fast: false
@@ -376,6 +382,7 @@ jobs:
           verbose: true
 
   publish-maven:
+    if: vars.NIGHTLY_PUBLISH_REGISTRIES == 'true'
     needs: [select, local-smoke, draft-release]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -480,8 +487,16 @@ jobs:
             stable-venv/bin/python -c "import vibium; assert 'dev' not in vibium.__version__"
           fi
 
+  # Publishes the GitHub prerelease once the bundle has passed local-smoke.
+  # With registries enabled, public-smoke must also pass first; with them
+  # parked (skipped), the release ships on the strength of local-smoke alone.
   promote:
-    needs: [select, public-smoke]
+    needs: [select, local-smoke, draft-release, public-smoke]
+    if: >-
+      !cancelled() &&
+      needs.local-smoke.result == 'success' &&
+      needs.draft-release.result == 'success' &&
+      (needs.public-smoke.result == 'success' || needs.public-smoke.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: nightly
@@ -502,6 +517,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - name: Check dist-tag token expiry
+        if: vars.NIGHTLY_PUBLISH_REGISTRIES == 'true'
         env:
           EXPIRES_AT: ${{ vars.NPM_DIST_TAG_TOKEN_EXPIRES_AT }}
         run: |
@@ -515,7 +531,10 @@ jobs:
           if [ $((expires - now)) -lt $((30 * 24 * 60 * 60)) ]; then
             echo '::warning::NPM_DIST_TAG_TOKEN expires within 30 days; rotate it and update NPM_DIST_TAG_TOKEN_EXPIRES_AT.'
           fi
+      # The manifest's final Maven coordinate only exists after publish-maven,
+      # so with registries parked the release keeps the as-built manifest.
       - name: Finalize the audit manifest in the draft release
+        if: vars.NIGHTLY_PUBLISH_REGISTRIES == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           # Same reason as draft-release: no checkout, so gh release needs
@@ -531,6 +550,7 @@ jobs:
           node scripts/finalize-nightly-manifest.mjs release "$resolved"
           gh release upload '${{ needs.select.outputs.tag }}' release/manifest.json --clobber
       - name: Promote verified npm versions
+        if: vars.NIGHTLY_PUBLISH_REGISTRIES == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_DIST_TAG_TOKEN }}
         run: |


### PR DESCRIPTION
Part of #396.

Registry publishing needs configuration that does not exist yet: npm and PyPI trusted publishers on twelve packages, Maven signing secrets, and the dist-tag token. The GitHub prerelease needs none of that, and its bundle is already built, inspected, and install-tested on five platforms every run. The first real run proved the split: everything through draft-release green, all three registries failing on missing config.

This makes the GitHub prerelease the shipping path and parks the registries until they are configured:

- The three registry publish jobs (and public-smoke behind them) sit behind a NIGHTLY_PUBLISH_REGISTRIES repository variable and skip cleanly until it is 'true'. Enabling them later needs no workflow change, just the variable plus the registry configuration tracked in #396.
- promote no longer waits on the registries: it publishes the prerelease once local-smoke and draft-release pass, and additionally requires public-smoke whenever the registries are enabled. Its registry-only steps (dist-tag expiry check and promotion, Maven manifest finalization) are gated the same way.
- notify counts only failures, so a night with skipped registry jobs resolves the failure issue rather than filing one.

What ships per night: five standalone binaries, six npm tarballs, six wheels, three jars, manifest.json, and SHA256SUMS, as a prerelease tagged nightly-<version>-<sha>.

Verified:
- Real (dry_run=false) dispatch on the fork ran the full pipeline end to end: registry jobs and public-smoke skipped, promote published the prerelease with all 22 assets, notify green: https://github.com/vincebln2/vibium/actions/runs/32530702853 (validation release deleted after inspection)
- An earlier attempt from a stale base also confirmed the failure side of the gate: with draft-release red, promote refuses to publish.
