### PR TITLE
Bound the stdin drain in the Python client's command path

### DIFF
--- a/clients/python/src/vibium/client.py
+++ b/clients/python/src/vibium/client.py
@@ -172,7 +172,16 @@ class BiDiClient:
         try:
             line = json.dumps(command) + "\n"
             self._stdin.write(line.encode())  # type: ignore[union-attr]
-            await self._stdin.drain()  # type: ignore[union-attr]
+            # drain() carries no deadline of its own. If the vibium process
+            # stops reading stdin, it blocks before the response timer below
+            # ever starts, turning a wedged pipe into a hang that outlives
+            # every client timeout (#397).
+            try:
+                await asyncio.wait_for(self._stdin.drain(), timeout=timeout)  # type: ignore[union-attr]
+            except asyncio.TimeoutError:
+                raise errors.TimeoutError(
+                    f"Command '{method}' was not accepted by the vibium process after {timeout}s"
+                )
             try:
                 response = await asyncio.wait_for(future, timeout=timeout)
             except asyncio.TimeoutError:

--- a/tests/py/test_send_deadlines.py
+++ b/tests/py/test_send_deadlines.py
@@ -1,0 +1,67 @@
+"""BiDiClient deadline tests (#397).
+
+CI hangs outlived every client timeout: captures cap at 10s, download
+completion at 300s, commands at 60s, yet suites sat for 8+ minutes until
+the 600s watchdog killed them. The one await in the command path with no
+deadline was stdin drain(): when the vibium process stops reading its
+pipe, _send blocked before the response timer ever started, and the
+setup gate in send() inherited the hang. These tests pin _send to a
+deadline using in-process fakes; no browser, no binary.
+"""
+
+import asyncio
+
+import pytest
+
+from vibium import errors
+from vibium.client import BiDiClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class _WedgedStdin:
+    """A pipe whose buffer never drains, like a binary that stopped reading."""
+
+    def write(self, data: bytes) -> None:
+        pass
+
+    async def drain(self) -> None:
+        await asyncio.Event().wait()
+
+
+class _SilentStdout:
+    """A pipe that never produces a line."""
+
+    async def readline(self) -> bytes:
+        await asyncio.Event().wait()
+        return b""
+
+
+class _FakePipes:
+    def __init__(self):
+        self.stdin = _WedgedStdin()
+        self.stdout = _SilentStdout()
+
+
+class _FakeProcess:
+    def __init__(self):
+        self._process = _FakePipes()
+
+
+async def test_send_fails_fast_when_stdin_never_drains():
+    client = BiDiClient(_FakeProcess())
+    # The outer wait_for is the test's own tripwire: without the drain
+    # deadline the send hangs and this raises asyncio.TimeoutError, which
+    # is not the vibium TimeoutError the assertion demands.
+    with pytest.raises(errors.TimeoutError, match="not accepted"):
+        await asyncio.wait_for(client._send("session.status", timeout=0.2), timeout=5)
+
+
+async def test_setup_gate_cannot_outlive_its_setups():
+    client = BiDiClient(_FakeProcess())
+    # A registration wedged on the same dead pipe must not park every
+    # later command forever: the setup fails at its own deadline, the
+    # gate opens, and the command reports its own drain timeout.
+    client.send_setup("script.addPreloadScript", timeout=0.2)
+    with pytest.raises(errors.TimeoutError, match="not accepted"):
+        await asyncio.wait_for(client.send("browsingContext.navigate", timeout=0.2), timeout=5)


### PR DESCRIPTION
Part of #397. Fixes mechanism 2 (hangs that outlive every timeout), with one correction to the issue's analysis: the suspect there was the missing timeout on the `_pending_setups` gate, but the gate turns out to be transitively bounded, since every setup task runs through `_send`, whose response wait has a deadline. The genuinely unbounded await was the stdin `drain()` that runs before the response timer starts. When the vibium process stops reading its pipe, every command and every setup registration blocked there forever, which matches the CI process tables: healthy idle browser, client waiting on nothing, no timeout ever firing.

The drain now shares the command's timeout and raises a TimeoutError naming the command that could not be written, so the next wedged-pipe incident fails in seconds with a pointer instead of eating a 10 minute watchdog kill. The setup gate needs no change once drain is bounded, and the new test pins that.

Verified:
- New hermetic tests (tests/py/test_send_deadlines.py, in-process fakes, no browser) fail on main by hanging into their own 5s tripwires and pass with the fix in under a second.
- test_event_setup_ordering.py and test_sync_event_setup_ordering.py, which exercise the same send/setup path, pass unchanged.
