### PR TITLE
Fix the docs the 26.8.21 release would have shipped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,7 @@ set-version:
 	@echo "  - packages/python/*/pyproject.toml (5 platform packages)"
 	@echo "  - packages/python/*/src/*/__init__.py (5 platform packages)"
 	@echo "  - package-lock.json (regenerated)"
+	@echo "  - README.md + docs/tutorials/getting-started-java.md (Maven coordinates)"
 
 # Show available targets
 help:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pip install vibium   # Python
 
 **Java** (Gradle):
 ```groovy
-implementation 'com.vibium:vibium:26.3.18'
+implementation 'com.vibium:vibium:26.8.21'
 ```
 
 **Java** (Maven):
@@ -97,7 +97,7 @@ implementation 'com.vibium:vibium:26.3.18'
 <dependency>
     <groupId>com.vibium</groupId>
     <artifactId>vibium</artifactId>
-    <version>26.3.18</version>
+    <version>26.8.21</version>
 </dependency>
 ```
 
@@ -108,6 +108,7 @@ This installs the Vibium binary and downloads Chrome automatically. No manual br
 **Async API:**
 ```javascript
 import { browser } from 'vibium'
+import fs from 'node:fs/promises'
 
 const bro = await browser.start()
 const vibe = await bro.page()
@@ -221,7 +222,7 @@ bro.stop();
 │  └─────┬────────┘ └──────┬─────┘  │        ┌──────────────────┐
 │        └───────▲─────────┘        │        │                  │
 │                │                  │        │                  │
-│         ┌──────▼───────┐          │  BiDi  │  Chrome Browser  │
+│         ┌──────▼───────┐          │  BiDi  │    Web Browser   │
 │         │  BiDi Proxy  │          │◄──────►│                  │
 │         └──────────────┘          │        │                  │
 └───────────────────────────────────┘        └──────────────────┘
@@ -269,7 +270,6 @@ V1 focuses on the core loop: browser control via CLI, MCP, and client libraries.
 See [ROADMAP.md](ROADMAP.md) for planned features:
 - Cortex (memory/navigation layer)
 - Retina (recording extension)
-- Video recording
 - AI-powered locators
 
 ---

--- a/docs/tutorials/getting-started-java.md
+++ b/docs/tutorials/getting-started-java.md
@@ -68,7 +68,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.vibium:vibium:26.3.18'
+    implementation 'com.vibium:vibium:26.8.21'
 }
 
 application {
@@ -96,7 +96,7 @@ Create a `pom.xml` file:
         <dependency>
             <groupId>com.vibium</groupId>
             <artifactId>vibium</artifactId>
-            <version>26.3.18</version>
+            <version>26.8.21</version>
         </dependency>
     </dependencies>
 </project>
@@ -111,7 +111,7 @@ mkdir my-first-bot
 cd my-first-bot
 
 # Download the vibium JAR and its dependency (Gson)
-curl -LO https://repo1.maven.org/maven2/com/vibium/vibium/26.3.18/vibium-26.3.18.jar
+curl -LO https://repo1.maven.org/maven2/com/vibium/vibium/26.8.21/vibium-26.8.21.jar
 curl -LO https://repo1.maven.org/maven2/com/google/code/gson/gson/2.11.0/gson-2.11.0.jar
 ```
 
@@ -189,14 +189,14 @@ mvn compile exec:java -Dexec.mainClass=Hello
 ### No build tool
 
 ```bash
-javac -cp "vibium-26.3.18.jar:gson-2.11.0.jar" Hello.java
-java -cp ".:vibium-26.3.18.jar:gson-2.11.0.jar" Hello
+javac -cp "vibium-26.8.21.jar:gson-2.11.0.jar" Hello.java
+java -cp ".:vibium-26.8.21.jar:gson-2.11.0.jar" Hello
 ```
 
 You should see:
 1. A Chrome window open
 2. example.com load
-3. The browser click "More information..."
+3. The browser click "Learn more"
 4. The browser close
 
 Check your folder - there's now a `screenshot.png` file!
@@ -287,7 +287,7 @@ If Chrome for Testing fails to auto-download (e.g. behind a corporate proxy), yo
 ### No build tool
 
 ```bash
-java -jar vibium-26.3.18.jar install
+java -jar vibium-26.8.21.jar install
 ```
 
 ### Maven
@@ -320,7 +320,7 @@ Combine with environment variables as needed:
 
 ```bash
 # Install to a custom directory
-VIBIUM_CACHE_DIR=/path/to/dir java -jar vibium-26.3.18.jar install
+VIBIUM_CACHE_DIR=/path/to/dir java -jar vibium-26.8.21.jar install
 VIBIUM_CACHE_DIR=/path/to/dir mvn compile exec:java -Dexec.mainClass=com.vibium.CLI -Dexec.args="install"
 VIBIUM_CACHE_DIR=/path/to/dir gradle vibiumInstall
 

--- a/docs/tutorials/getting-started-mcp.md
+++ b/docs/tutorials/getting-started-mcp.md
@@ -146,7 +146,7 @@ npx -y vibium install
 On macOS, if you see a Gatekeeper warning about chromedriver, run:
 
 ```bash
-xattr -cr "$(npx -y vibium which chromedriver)"
+xattr -cr "$(npx -y vibium paths | sed -n 's/^Chromedriver: //p')"
 ```
 
 ### Changes not taking effect

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -89,5 +89,30 @@ for (const relative of [
   );
 }
 
+// Java has no lockfile, so its docs pin a coordinate readers copy verbatim.
+// Prereleases are skipped: nightly Java builds publish as a `YYYY.M-SNAPSHOT`
+// snapshot, not as the npm-style version this script is handed.
+const isPrerelease = !/^\d+\.\d+\.\d+$/.test(npmVersion);
+if (!isPrerelease) {
+  for (const relative of [
+    "README.md",
+    "docs/tutorials/getting-started-java.md",
+  ]) {
+    update(relative, (source) =>
+      source
+        .replace(/(com\.vibium:vibium:)[\d.]+/g, `$1${npmVersion}`)
+        .replace(
+          /(<artifactId>vibium<\/artifactId>\s*<version>)[^<]+/g,
+          `$1${npmVersion}`,
+        )
+        .replace(/(vibium-)[\d.]+(\.jar)/g, `$1${npmVersion}$2`)
+        .replace(
+          /(maven2\/com\/vibium\/vibium\/)[\d.]+(\/)/g,
+          `$1${npmVersion}$2`,
+        ),
+    );
+  }
+}
+
 writeFileSync(resolve(root, "VERSION"), `${npmVersion}\n`);
 console.log(JSON.stringify({ npmVersion, pythonVersion, exactPythonDependencies }));

--- a/tests/cli/release-versioning.test.js
+++ b/tests/cli/release-versioning.test.js
@@ -98,4 +98,65 @@ describe('cross-ecosystem version writer', () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test('repins Java coordinates in the docs on a stable release only', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-docs-'));
+    // Only the docs matter here; the writer skips a file it is not given.
+    const docs = ['README.md', 'docs/tutorials/getting-started-java.md'];
+    const before = [
+      "implementation 'com.vibium:vibium:26.3.18'",
+      '<artifactId>my-first-bot</artifactId>',
+      '<version>1.0</version>',
+      '<artifactId>vibium</artifactId>',
+      '<version>26.3.18</version>',
+      'curl -LO https://repo1.maven.org/maven2/com/vibium/vibium/26.3.18/vibium-26.3.18.jar',
+      'curl -LO https://repo1.maven.org/maven2/com/google/code/gson/gson/2.11.0/gson-2.11.0.jar',
+      'javac -cp "vibium-26.3.18.jar:gson-2.11.0.jar" Hello.java',
+    ].join('\n');
+    const setVersion = (version, pythonVersion) => execFileSync(process.execPath, [
+      path.join(ROOT, 'scripts/set-version.mjs'), '--root', root, '--version', version,
+      ...(pythonVersion ? ['--python-version', pythonVersion] : []),
+    ]);
+    const seed = () => {
+      for (const file of [...docs, 'package.json', 'clients/javascript/package.json',
+        'packages/vibium/package.json', 'packages/linux-x64/package.json',
+        'packages/linux-arm64/package.json', 'packages/darwin-x64/package.json',
+        'packages/darwin-arm64/package.json', 'packages/win32-x64/package.json',
+        'clients/python/pyproject.toml', 'clients/python/src/vibium/__init__.py',
+        ...['darwin_arm64', 'darwin_x64', 'linux_arm64', 'linux_x64', 'win32_x64']
+          .flatMap((name) => [`packages/python/vibium_${name}/pyproject.toml`,
+            `packages/python/vibium_${name}/src/vibium_${name}/__init__.py`])]) {
+        fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+        if (docs.includes(file)) fs.writeFileSync(path.join(root, file), before);
+        else if (file.endsWith('.json')) fs.writeFileSync(path.join(root, file), '{"version": "1.2.3"}\n');
+        else if (file.endsWith('.toml')) fs.writeFileSync(path.join(root, file), 'version = "1.2.3"\n');
+        else fs.writeFileSync(path.join(root, file), '__version__ = "1.2.3"\n');
+      }
+    };
+    try {
+      seed();
+      setVersion('26.8.21');
+      for (const file of docs) {
+        const after = fs.readFileSync(path.join(root, file), 'utf8');
+        assert.match(after, /com\.vibium:vibium:26\.8\.21'/);
+        assert.match(after, /<artifactId>vibium<\/artifactId>\n<version>26\.8\.21<\/version>/);
+        assert.match(after, /vibium\/26\.8\.21\/vibium-26\.8\.21\.jar/);
+        assert.match(after, /"vibium-26\.8\.21\.jar:gson-2\.11\.0\.jar"/);
+        // The sample project's own version and Gson's are not vibium's.
+        assert.match(after, /<version>1\.0<\/version>/);
+        assert.match(after, /gson\/2\.11\.0\/gson-2\.11\.0\.jar/);
+        assert.doesNotMatch(after, /26\.3\.18/);
+      }
+
+      seed();
+      setVersion('2026.8.20-dev.20260820191542', '2026.8.20.dev20260820191542');
+      for (const file of docs) {
+        // Nightly Java builds publish as YYYY.M-SNAPSHOT, so the npm-style
+        // prerelease must not be written into a copy-paste coordinate.
+        assert.strictEqual(fs.readFileSync(path.join(root, file), 'utf8'), before);
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Found by running every getting-started tutorial end to end rather than reading them.

## Broken code and commands

- **The README's async JS sample crashed on first copy-paste** — it used `fs` without importing it (the sync sample right below does `require('fs')`). Fixed with `import fs from 'node:fs/promises'`, matching the `await` it was already using.
- **The MCP tutorial told macOS users to run `vibium which chromedriver`.** That command has never existed — no subcommand, no deleted source in history. The substitution returns empty and `xattr -cr ""` fails, in the one place a user is already stuck on a Gatekeeper warning. Now reads the path from `vibium paths`.
- **The Java tutorial pinned `26.3.18` in eight places**, two releases stale, and predicted the wrong link text on example.com (`"More information..."`; it is `"Learn more"`, which the JS and Python tutorials already had right).
- **The README Roadmap still listed video recording as planned** after it shipped, four lines below a paragraph linking to the record-video how-to. The architecture diagram said `Chrome Browser` before Firefox support landed.

## Stopping the version drift

`set-version` now repins the Java coordinates in the README and Java tutorial.

The patterns anchor on the surrounding coordinate — `com.vibium:vibium:`, the `<artifactId>vibium</artifactId>` that precedes the version, `vibium-<v>.jar`, the `maven2/com/vibium/vibium/<v>/` path segment — rather than matching a bare version. A naive `\d+\.\d+\.\d+` sweep would have clobbered the sample project's own `<version>1.0</version>` and Gson's `2.11.0`, both of which sit in the same code blocks. Verified with a round-trip: all ten pins move, those two do not.

Prereleases are skipped. Nightly Java builds publish as `YYYY.M-SNAPSHOT`, not the npm-style `2026.8.20-dev.…` this script is handed, so writing one into a copy-paste Maven coordinate would produce something that resolves to nothing. The new test covers both directions.

## Verification

The JS and Python scripts ran, the Java program compiled and ran against a freshly built jar, and the MCP server was probed over JSON-RPC. `make test` green.

Split out of #405, which should carry only the engine option rename.