### PR TITLE
Keep the sibling message field when parsing BiDi errors

### DIFF
--- a/clicker/internal/bidi/protocol.go
+++ b/clicker/internal/bidi/protocol.go
@@ -49,6 +49,11 @@ type Message struct {
 	// Event fields
 	Method string          `json:"method,omitempty"`
 	Params json.RawMessage `json:"params,omitempty"`
+
+	// ErrMessage carries the error detail. The spec sends `message` as a
+	// sibling of `error`, not nested inside it, so it must be captured on
+	// the frame or the detail is gone before anything can print it (#343).
+	ErrMessage string `json:"message,omitempty"`
 }
 
 // IsResponse returns true if the message is a response (has an ID).
@@ -75,12 +80,18 @@ func (m *Message) GetError() (*ErrorData, error) {
 	// Try to unmarshal as ErrorData object
 	var errData ErrorData
 	if err := json.Unmarshal(m.Error, &errData); err != nil {
-		// If that fails, it might be a plain string
+		// A spec-compliant endpoint sends `error` as a bare code string
+		// with the detail in the sibling `message`. Falling back to the
+		// code here is what printed it twice (#343).
 		var errStr string
 		if err := json.Unmarshal(m.Error, &errStr); err != nil {
 			return nil, err
 		}
-		return &ErrorData{Error: errStr, Message: errStr}, nil
+		detail := m.ErrMessage
+		if detail == "" {
+			detail = errStr
+		}
+		return &ErrorData{Error: errStr, Message: detail}, nil
 	}
 	return &errData, nil
 }

--- a/clicker/internal/bidi/protocol_error_test.go
+++ b/clicker/internal/bidi/protocol_error_test.go
@@ -1,0 +1,66 @@
+package bidi
+
+import "testing"
+
+// A WebDriver BiDi error response carries the error code in `error` and the
+// human-readable detail in a sibling `message` field:
+//
+//	{"type":"error","id":1,"error":"invalid argument","message":"invalid argument: ..."}
+//
+// GetError must report the detail, not a second copy of the code (#343).
+func TestGetErrorKeepsSiblingMessage(t *testing.T) {
+	raw := `{"type":"error","id":1,"error":"invalid argument",` +
+		`"message":"Invalid URL: not-a-real-url"}`
+
+	msg, err := UnmarshalMessage([]byte(raw))
+	if err != nil {
+		t.Fatalf("UnmarshalMessage: %v", err)
+	}
+	if !msg.IsError() {
+		t.Fatal("expected an error message")
+	}
+
+	errData, err := msg.GetError()
+	if err != nil {
+		t.Fatalf("GetError: %v", err)
+	}
+	if errData.Error != "invalid argument" {
+		t.Errorf("code = %q, want %q", errData.Error, "invalid argument")
+	}
+	want := "Invalid URL: not-a-real-url"
+	if errData.Message != want {
+		t.Errorf("detail = %q, want %q", errData.Message, want)
+	}
+}
+
+// The nested shape must keep working.
+func TestGetErrorNestedObjectStillParses(t *testing.T) {
+	raw := `{"type":"error","id":1,"error":{"error":"invalid argument","message":"detail here"}}`
+	msg, err := UnmarshalMessage([]byte(raw))
+	if err != nil {
+		t.Fatalf("UnmarshalMessage: %v", err)
+	}
+	errData, err := msg.GetError()
+	if err != nil {
+		t.Fatalf("GetError: %v", err)
+	}
+	if errData.Message != "detail here" {
+		t.Errorf("detail = %q, want %q", errData.Message, "detail here")
+	}
+}
+
+// A bare string error with no sibling message still reports the code rather
+// than an empty detail.
+func TestGetErrorBareStringWithoutMessage(t *testing.T) {
+	msg, err := UnmarshalMessage([]byte(`{"type":"error","id":1,"error":"unknown error"}`))
+	if err != nil {
+		t.Fatalf("UnmarshalMessage: %v", err)
+	}
+	errData, err := msg.GetError()
+	if err != nil {
+		t.Fatalf("GetError: %v", err)
+	}
+	if errData.Message != "unknown error" {
+		t.Errorf("detail = %q, want the code as fallback", errData.Message)
+	}
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#343

A BiDi error response carries the code in `error` and the human detail in a sibling `message` field. `Message` had no field for the sibling, so `encoding/json` discarded the detail while parsing the frame, and `GetError`'s string fallback then fabricated the detail by copying the code. That is why every BiDi error printed as `invalid argument - invalid argument` with the browser's explanation nowhere in the output, verbose or not.

This lands the fix the issue proposes, verified against the code before adopting: capture the sibling `message` on the frame, and in the bare-string branch use it as the detail, falling back to the code only when the endpoint sent none. The nested-object shape still parses and the formatter is untouched. Errors now read `invalid argument - Invalid URL: not-a-real-url`.

Verified:
- `go test ./internal/bidi` passes, including the issue's two regression tests plus a no-detail fallback case; the sibling-message test fails on main exactly as the issue reports
- The new frame field cannot collide: success responses and events carry no top-level `message`