### PR TITLE
Retry script evals whose realm a navigation destroyed

### DIFF
--- a/clicker/internal/api/eval_navigation_retry_test.go
+++ b/clicker/internal/api/eval_navigation_retry_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// scriptedSession replays a fixed sequence of responses; the last entry
+// repeats if called again.
+type scriptedSession struct {
+	steps []struct {
+		resp json.RawMessage
+		err  error
+	}
+	calls int
+	nav   *NavigationTracker
+}
+
+func (f *scriptedSession) step(resp string, err error) {
+	var raw json.RawMessage
+	if resp != "" {
+		raw = json.RawMessage(resp)
+	}
+	f.steps = append(f.steps, struct {
+		resp json.RawMessage
+		err  error
+	}{raw, err})
+}
+
+func (f *scriptedSession) SendBidiCommand(method string, params map[string]interface{}) (json.RawMessage, error) {
+	i := f.calls
+	if i >= len(f.steps) {
+		i = len(f.steps) - 1
+	}
+	f.calls++
+	return f.steps[i].resp, f.steps[i].err
+}
+
+func (f *scriptedSession) SendBidiCommandWithTimeout(method string, params map[string]interface{}, timeout time.Duration) (json.RawMessage, error) {
+	return f.SendBidiCommand(method, params)
+}
+
+func (f *scriptedSession) GetContextID() (string, error)  { return "ctx", nil }
+func (f *scriptedSession) SetLastElementBox(box *BoxInfo) {}
+func (f *scriptedSession) NavTracker() *NavigationTracker { return f.nav }
+
+const evalOK = `{"result":{"type":"success","result":{"type":"string","value":"ok"},"realm":"r1"}}`
+
+// A navigation destroys the realm under an in-flight eval; the browsing
+// context survives, so the eval must retry against the new document instead
+// of surfacing the one-per-navigation error (#335).
+func TestEvalRetriesWhenNavigationDestroysRealm(t *testing.T) {
+	f := &scriptedSession{}
+	// Proxy-shaped error envelope, as chromedriver reports the torn realm.
+	f.step(`{"type":"error","error":"unknown error","message":"unknown error: Execution context was destroyed"}`, nil)
+	f.step(evalOK, nil)
+
+	out, err := EvalSimpleScript(f, "ctx", "() => 'x'")
+	if err != nil {
+		t.Fatalf("EvalSimpleScript: %v", err)
+	}
+	if out != "ok" || f.calls != 2 {
+		t.Fatalf("out=%q calls=%d, want ok after one retry", out, f.calls)
+	}
+}
+
+// The MCP path reports the same condition as a Go error from the client.
+func TestEvalRetriesOnClientSideDestroyedError(t *testing.T) {
+	f := &scriptedSession{}
+	f.step("", errors.New("BiDi error: unknown error - Execution context was destroyed"))
+	f.step(evalOK, nil)
+
+	out, err := EvalSimpleScript(f, "ctx", "() => 'x'")
+	if err != nil || out != "ok" {
+		t.Fatalf("out=%q err=%v, want retry to succeed", out, err)
+	}
+}
+
+// Firefox aborts the in-flight query instead of naming the realm.
+func TestEvalRetriesOnFirefoxAbort(t *testing.T) {
+	f := &scriptedSession{}
+	f.step("", errors.New("BiDi error: unknown error - Actor 'MessageHandlerFrame' destroyed before query 'EvaluateExpression' could be resolved"))
+	f.step(evalOK, nil)
+
+	if out, err := EvalSimpleScript(f, "ctx", "() => 'x'"); err != nil || out != "ok" {
+		t.Fatalf("out=%q err=%v, want retry to succeed", out, err)
+	}
+}
+
+// Errors with no navigation in the picture must surface immediately: a script
+// exception is the caller's bug, not a race.
+func TestEvalDoesNotRetryUnrelatedErrors(t *testing.T) {
+	f := &scriptedSession{}
+	f.step(`{"result":{"type":"exception","exceptionDetails":{"text":"boom","lineNumber":1}}}`, nil)
+	f.step(evalOK, nil)
+
+	_, err := EvalSimpleScript(f, "ctx", "() => { throw new Error('boom') }")
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err=%v, want the exception surfaced", err)
+	}
+	if f.calls != 1 {
+		t.Fatalf("calls=%d, an unrelated error must not retry", f.calls)
+	}
+}
+
+// A realm that never comes back stops at the budget instead of retrying
+// forever.
+func TestEvalRetryIsBounded(t *testing.T) {
+	f := &scriptedSession{}
+	f.step(`{"type":"error","error":"unknown error","message":"unknown error: Execution context was destroyed"}`, nil)
+
+	start := time.Now()
+	_, err := EvalSimpleScript(f, "ctx", "() => 'x'")
+	elapsed := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "context was destroyed") {
+		t.Fatalf("err=%v, want the persistent error surfaced", err)
+	}
+	if elapsed > evalNavigationRetryBudget+time.Second {
+		t.Fatalf("retried for %v, want the budget respected", elapsed)
+	}
+}

--- a/clicker/internal/api/helpers.go
+++ b/clicker/internal/api/helpers.go
@@ -301,8 +301,36 @@ func (r *Router) resolveElement(session *BrowserSession, context string, ep Elem
 // Exported standalone functions — usable from both proxy and MCP handlers.
 // ---------------------------------------------------------------------------
 
+// evalNavigationRetryBudget bounds how long EvalSimpleScript keeps retrying
+// an eval whose realm a navigation tore down. The gap between the old realm
+// dying and the new document's realm existing is milliseconds; the budget
+// only has to outlast a slow document swap, not a page load.
+const evalNavigationRetryBudget = 2 * time.Second
+
+// realmDestroyedByNavigation reports whether a script command failed because
+// a navigation replaced the document under it. Chrome reports the torn-down
+// realm as "Execution context was destroyed"; Firefox aborts the in-flight
+// query ("destroyed before query") or reports the context discarded.
+func realmDestroyedByNavigation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "context was destroyed") ||
+		strings.Contains(msg, "destroyed before query") ||
+		strings.Contains(msg, "browsing context discarded")
+}
+
 // EvalSimpleScript runs a no-argument script.callFunction via the Session and
 // returns the string result.
+//
+// A navigation destroys the document's realm the instant it commits, so a
+// command landing in that window fails — exactly one failure per navigation
+// under a tight poll (#335). The browsing context survives the navigation,
+// so the eval is retried against the document that replaces it, bounded by
+// evalNavigationRetryBudget. The capture path handles the same race with
+// captureWithNavigationRetry; script commands do get an answer (an error),
+// so retrying on that answer is enough here.
 func EvalSimpleScript(s Session, context, fn string) (string, error) {
 	params := map[string]interface{}{
 		"functionDeclaration": fn,
@@ -311,13 +339,34 @@ func EvalSimpleScript(s Session, context, fn string) (string, error) {
 		"awaitPromise":        false,
 		"resultOwnership":     "root",
 	}
-
-	resp, err := s.SendBidiCommand("script.callFunction", params)
-	if err != nil {
-		return "", err
+	send := func() (string, error) {
+		resp, err := s.SendBidiCommand("script.callFunction", params)
+		if err != nil {
+			return "", err
+		}
+		return parseScriptResult(resp)
 	}
 
-	return parseScriptResult(resp)
+	out, err := send()
+	deadline := time.Now().Add(evalNavigationRetryBudget)
+	for err != nil && time.Now().Before(deadline) {
+		nav := s.NavTracker()
+		navigating := nav != nil && nav.IsNavigating(context)
+		if !navigating && !realmDestroyedByNavigation(err) {
+			break
+		}
+		// The event naming the navigation can trail the failed command by
+		// ~10ms (#291), so the tracker may not know about it yet: settle
+		// when it does, pause briefly when only the error message says a
+		// navigation happened.
+		if navigating {
+			nav.WaitForSettled(context, time.Until(deadline))
+		} else {
+			time.Sleep(25 * time.Millisecond)
+		}
+		out, err = send()
+	}
+	return out, err
 }
 
 // QueryViewport asks the page for its viewport size. ok is false when the


### PR DESCRIPTION
Fixes VibiumDev/vibium#335

A navigation destroys the document's realm the instant it commits. A script-backed command landing in that window failed with exactly one failure per navigation, which is the issue's measured shape (10 navigations, 13,724 polls, 10 failures). The exposure is every caller of `EvalSimpleScript`: `page.url`, `title`, `content`, frames, viewport, and the `waitForLoad` readyState probe, which is the reported checkout-button case. The capture path already handles this race with `captureWithNavigationRetry` (#289/#291); the script path had no equivalent.

The browsing context survives the navigation, only the realm dies, so `EvalSimpleScript` now retries against the document that replaces it, bounded by a 2s budget (the realm gap is milliseconds; the budget only outlasts a slow document swap). The retry fires when the navigation tracker reports the context navigating, or when the error names the torn realm, because #291 measured the navigation event trailing the failed command by ~10ms, so the tracker alone has a blind spot. Recognized shapes: Chrome's "Execution context was destroyed", Firefox's "destroyed before query" and "browsing context discarded". Both server modes are covered since proxy envelope errors and MCP client errors funnel through the same return. Unrelated errors, including script exceptions, surface immediately without a retry.

The element find loops already tolerate this race by polling, which is why `findAll` never showed it.

Verified:
- `go test ./internal/api -run TestEval` passes: retry on the chromedriver envelope shape, on the MCP client error shape, on the Firefox abort shape, no retry for script exceptions, and the budget bound; the retry tests fail on main where the first error surfaces directly
- Full `./internal/api` suite passes