### PR TITLE
Generate the mcp help tool list from the schema registry

### DIFF
--- a/clicker/cmd/clicker/mcp_cmd.go
+++ b/clicker/cmd/clicker/mcp_cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -11,6 +12,19 @@ import (
 	"github.com/vibium/clicker/internal/paths"
 	"github.com/vibium/clicker/internal/process"
 )
+
+// mcpToolList renders the served tools for --help from the same registry the
+// tools/list request reads, so the help cannot drift from the server again: a
+// hand-written copy here had frozen at 22 of 85 tools (#393).
+func mcpToolList() string {
+	tools := agent.GetToolSchemas()
+	var b strings.Builder
+	fmt.Fprintf(&b, "The server provides %d browser automation tools:\n", len(tools))
+	for _, t := range tools {
+		fmt.Fprintf(&b, "  - %s: %s\n", t.Name, t.Description)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
 
 func newMCPCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -21,29 +35,7 @@ func newMCPCmd() *cobra.Command {
 This runs a JSON-RPC 2.0 server over stdin/stdout, designed for integration
 with LLM agents like Claude Code.
 
-The server provides browser automation tools:
-  - browser_start: Start a browser session
-  - browser_navigate: Go to a URL
-  - browser_click: Click an element
-  - browser_type: Type into an element
-  - browser_screenshot: Capture the page
-  - browser_find: Find element info
-  - browser_evaluate: Execute JavaScript
-  - browser_stop: Stop the browser
-  - browser_get_text: Get page/element text
-  - browser_get_url: Get current URL
-  - browser_get_title: Get page title
-  - browser_get_html: Get page/element HTML
-  - browser_find_all: Find all matching elements
-  - browser_wait: Wait for element state
-  - browser_hover: Hover over an element
-  - browser_select: Select a dropdown option
-  - browser_scroll: Scroll the page
-  - browser_keys: Press keys
-  - browser_new_page: Open a new page
-  - browser_list_pages: List open pages
-  - browser_switch_page: Switch pages
-  - browser_close_page: Close a page`,
+` + mcpToolList(),
 		Example: `  # Run directly (for testing)
   vibium mcp
 

--- a/clicker/cmd/clicker/mcp_cmd_test.go
+++ b/clicker/cmd/clicker/mcp_cmd_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vibium/clicker/internal/agent"
+)
+
+// The help must name every tool the server serves. The old hand-written list
+// froze at 22 of 85 tools (#393); generating it from the registry keeps the
+// two in lockstep, and this locks that in.
+func TestMCPHelpListsEveryServedTool(t *testing.T) {
+	long := newMCPCmd().Long
+	for _, tool := range agent.GetToolSchemas() {
+		if !strings.Contains(long, "- "+tool.Name+":") {
+			t.Errorf("mcp --help is missing tool %q", tool.Name)
+		}
+	}
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#393

The hand-written tool list in `vibium mcp --help` froze at 22 tools while the server grew to 85. The help is now generated from `agent.GetToolSchemas()`, the same registry `tools/list` serves, with the count stated in the header, so it cannot drift again.

Sample output:

```
The server provides 85 browser automation tools:
  - browser_start: Start a browser session
  - browser_navigate: Navigate to a URL in the browser
  ...
```

Verified:
- New test asserts the help names every tool in the registry; on main it fails for all 63 missing tools
- `vibium mcp --help` renders all 85 entries with their registry descriptions