### PR TITLE
Make paths honor --json and --engine

### DIFF
--- a/clicker/cmd/clicker/diagnostics.go
+++ b/clicker/cmd/clicker/diagnostics.go
@@ -24,30 +24,73 @@ func newVersionCmd() *cobra.Command {
 	}
 }
 
+// pathsInfo is the --json result for the paths command. Missing binaries are
+// omitted rather than carrying a "not found" sentinel, so scripts can test
+// key presence instead of scraping the human text (#392).
+type pathsInfo struct {
+	Engine       string `json:"engine"`
+	CacheDir     string `json:"cacheDir,omitempty"`
+	Chrome       string `json:"chrome,omitempty"`
+	Chromedriver string `json:"chromedriver,omitempty"`
+	Firefox      string `json:"firefox,omitempty"`
+}
+
 func newPathsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "paths",
-		Short: "Print browser and cache paths",
+		Short: "Print browser and cache paths for the selected engine",
+		Example: `  vibium paths
+  # Cache directory: ~/Library/Caches/vibium
+  # Chrome: .../Google Chrome for Testing
+  # Chromedriver: .../chromedriver
+
+  vibium --engine firefox paths
+  # Cache directory: ~/Library/Caches/vibium
+  # Firefox: .../Firefox.app/Contents/MacOS/firefox
+
+  vibium paths --json
+  # {"ok":true,"result":{"engine":"chrome","cacheDir":"...","chrome":"...","chromedriver":"..."}}`,
 		Run: func(cmd *cobra.Command, args []string) {
-			cacheDir, err := paths.GetCacheDir()
-			if err != nil {
-				fmt.Printf("Cache directory: error: %v\n", err)
+			info := pathsInfo{Engine: engineName}
+			cacheDir, cacheErr := paths.GetCacheDir()
+			if cacheErr == nil {
+				info.CacheDir = cacheDir
+			}
+			if engineName == "firefox" {
+				if p, err := paths.GetFirefoxExecutable(); err == nil {
+					info.Firefox = p
+				}
 			} else {
-				fmt.Printf("Cache directory: %s\n", cacheDir)
+				if p, err := paths.GetChromeExecutable(); err == nil {
+					info.Chrome = p
+				}
+				if p, err := paths.GetChromedriverPath(); err == nil {
+					info.Chromedriver = p
+				}
 			}
 
-			chromePath, err := paths.GetChromeExecutable()
-			if err != nil {
-				fmt.Println("Chrome: not found")
-			} else {
-				fmt.Printf("Chrome: %s\n", chromePath)
+			if jsonOutput {
+				printJSON(jsonEnvelope{OK: true, Result: info})
+				return
 			}
 
-			chromedriverPath, err := paths.GetChromedriverPath()
-			if err != nil {
-				fmt.Println("Chromedriver: not found")
+			if cacheErr != nil {
+				fmt.Printf("Cache directory: error: %v\n", cacheErr)
 			} else {
-				fmt.Printf("Chromedriver: %s\n", chromedriverPath)
+				fmt.Printf("Cache directory: %s\n", info.CacheDir)
+			}
+			printPath := func(label, path string) {
+				if path == "" {
+					fmt.Printf("%s: not found\n", label)
+				} else {
+					fmt.Printf("%s: %s\n", label, path)
+				}
+			}
+			if engineName == "firefox" {
+				printPath("Firefox", info.Firefox)
+			} else {
+				printPath("Chrome", info.Chrome)
+				printPath("Chromedriver", info.Chromedriver)
 			}
 		},
 	}

--- a/clicker/cmd/clicker/paths_cmd_test.go
+++ b/clicker/cmd/clicker/paths_cmd_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func runPathsCmd(t *testing.T) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	newPathsCmd().Run(nil, nil)
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+func setPathsGlobals(t *testing.T, engine string, jsonMode bool) {
+	t.Helper()
+	origEngine, origJSON := engineName, jsonOutput
+	t.Cleanup(func() { engineName, jsonOutput = origEngine, origJSON })
+	engineName, jsonOutput = engine, jsonMode
+}
+
+// paths printed with fmt.Printf unconditionally and never read --json or
+// --engine (#392): scripts had to scrape the human text, and Firefox users
+// were shown Chrome paths.
+func TestPathsJSONEmitsEnvelope(t *testing.T) {
+	t.Setenv("VIBIUM_CACHE_DIR", t.TempDir())
+	setPathsGlobals(t, "chrome", true)
+
+	var env struct {
+		OK     bool `json:"ok"`
+		Result struct {
+			Engine   string `json:"engine"`
+			CacheDir string `json:"cacheDir"`
+			Firefox  string `json:"firefox"`
+		} `json:"result"`
+	}
+	out := runPathsCmd(t)
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("--json output is not JSON: %v\n%s", err, out)
+	}
+	if !env.OK || env.Result.Engine != "chrome" || env.Result.CacheDir == "" {
+		t.Fatalf("unexpected envelope: %s", out)
+	}
+	if env.Result.Firefox != "" {
+		t.Fatalf("chrome engine should not report a firefox path: %s", out)
+	}
+}
+
+func TestPathsFirefoxEngineReportsFirefox(t *testing.T) {
+	t.Setenv("VIBIUM_CACHE_DIR", t.TempDir())
+	setPathsGlobals(t, "firefox", false)
+
+	out := runPathsCmd(t)
+	if !strings.Contains(out, "Firefox:") {
+		t.Fatalf("firefox engine output should name Firefox:\n%s", out)
+	}
+	if strings.Contains(out, "Chrome:") || strings.Contains(out, "Chromedriver:") {
+		t.Fatalf("firefox engine output should not name Chrome:\n%s", out)
+	}
+}
+
+func TestPathsFirefoxJSONUsesEnginePath(t *testing.T) {
+	t.Setenv("VIBIUM_CACHE_DIR", t.TempDir())
+	t.Setenv("VIBIUM_ENGINE_PATH", "/opt/firefox/firefox")
+	setPathsGlobals(t, "firefox", true)
+
+	var env struct {
+		Result struct {
+			Firefox string `json:"firefox"`
+			Chrome  string `json:"chrome"`
+		} `json:"result"`
+	}
+	out := runPathsCmd(t)
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("--json output is not JSON: %v\n%s", err, out)
+	}
+	if env.Result.Firefox != "/opt/firefox/firefox" || env.Result.Chrome != "" {
+		t.Fatalf("unexpected result: %s", out)
+	}
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#392

`vibium paths` printed Chrome paths with `fmt.Printf` regardless of either global flag. It now reports the selected engine's binaries (`--engine firefox` shows the Firefox path, resolving `--channel` and `VIBIUM_ENGINE_PATH` the same way launch does) and `--json` emits the standard envelope the other commands use:

```
$ vibium paths --json
{"ok":true,"result":{"engine":"chrome","cacheDir":"...","chrome":"...","chromedriver":"..."}}
```

Missing binaries are omitted from the JSON rather than carrying a "not found" sentinel, so scripts can test key presence instead of scraping text. Human output is unchanged for the Chrome case.

Verified:
- `go test ./cmd/clicker -run TestPaths` passes: JSON envelope shape, Firefox engine naming Firefox and not Chrome, and `VIBIUM_ENGINE_PATH` flowing through; the first two fail on main where the flags are ignored
- Command help now carries examples for all three forms