### PR TITLE
Honor quotes in VIBIUM_CHROME_ARGS values

### DIFF
--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -284,9 +284,10 @@ func chromeArgs(headless bool) []string {
 	if headless {
 		args = append(args, "--headless=new")
 	}
-	// Append any custom flags from VIBIUM_CHROME_ARGS (space-separated) so users
-	// can pass --no-sandbox etc. in root/CI/container environments where Chrome
-	// refuses to start otherwise. Empty tokens (from extra whitespace) are skipped.
+	// Append any custom flags from VIBIUM_CHROME_ARGS (space-separated, with
+	// quoting for values that contain spaces) so users can pass --no-sandbox
+	// etc. in root/CI/container environments where Chrome refuses to start
+	// otherwise. Empty tokens (from extra whitespace) are skipped.
 	args = append(args, customChromeArgs()...)
 	return args
 }
@@ -302,10 +303,49 @@ func vmFastLaunchShim() string {
 }
 
 // customChromeArgs reads extra Chrome flags from the VIBIUM_CHROME_ARGS
-// environment variable, splitting on whitespace and dropping empty tokens.
-// Returns nil when the variable is unset or contains only whitespace.
+// environment variable. Returns nil when the variable is unset or contains
+// only whitespace.
 func customChromeArgs() []string {
-	return strings.Fields(os.Getenv("VIBIUM_CHROME_ARGS"))
+	return splitFlagString(os.Getenv("VIBIUM_CHROME_ARGS"))
+}
+
+// splitFlagString splits a space-separated flag string, honoring single and
+// double quotes so a value may contain spaces: --profile-directory="Profile 1"
+// is one token with the quotes removed. strings.Fields cut such values at the
+// space, so the quoted part reached Chrome as a separate flag (#306). An
+// unterminated quote runs to the end of the string.
+func splitFlagString(s string) []string {
+	var args []string
+	var cur strings.Builder
+	inToken := false
+	var quote byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			} else {
+				cur.WriteByte(c)
+			}
+		case c == '\'' || c == '"':
+			quote = c
+			inToken = true
+		case c == ' ' || c == '\t' || c == '\n':
+			if inToken {
+				args = append(args, cur.String())
+				cur.Reset()
+				inToken = false
+			}
+		default:
+			cur.WriteByte(c)
+			inToken = true
+		}
+	}
+	if inToken {
+		args = append(args, cur.String())
+	}
+	return args
 }
 
 // buildCapabilities returns the capabilities map for BiDi session.new.

--- a/clicker/internal/browser/sandbox_unix.go
+++ b/clicker/internal/browser/sandbox_unix.go
@@ -5,7 +5,6 @@ package browser
 import (
 	"errors"
 	"os"
-	"strings"
 )
 
 // errRootSandbox explains the one launch failure that looks like a crash but is
@@ -27,8 +26,9 @@ func checkSandboxable() error {
 	if os.Geteuid() != 0 {
 		return nil
 	}
-	// Already opted out, so root is fine.
-	for _, arg := range strings.Fields(os.Getenv("VIBIUM_CHROME_ARGS")) {
+	// Already opted out, so root is fine. Same split as customChromeArgs, so
+	// this check sees the flags Chrome will actually receive.
+	for _, arg := range customChromeArgs() {
 		if arg == "--no-sandbox" {
 			return nil
 		}

--- a/clicker/internal/browser/split_flags_test.go
+++ b/clicker/internal/browser/split_flags_test.go
@@ -1,0 +1,60 @@
+package browser
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Flag values containing spaces must survive as one token when quoted;
+// strings.Fields cut them at the space, so Chrome received the quoted tail
+// as a separate flag (#306).
+func TestSplitFlagString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   \t ", nil},
+		{"plain flags", "--no-sandbox --disable-gpu", []string{"--no-sandbox", "--disable-gpu"}},
+		{"extra whitespace skipped", "  --a   --b  ", []string{"--a", "--b"}},
+		{
+			"double-quoted value with space",
+			`--user-data-dir=/tmp/v --profile-directory="Profile 1"`,
+			[]string{"--user-data-dir=/tmp/v", "--profile-directory=Profile 1"},
+		},
+		{
+			"single-quoted value with space",
+			`--profile-directory='Profile 1'`,
+			[]string{"--profile-directory=Profile 1"},
+		},
+		{
+			"fully quoted token",
+			`"--profile-directory=Profile 1"`,
+			[]string{"--profile-directory=Profile 1"},
+		},
+		{
+			"quote character inside the other quote kind",
+			`--flag="it's here"`,
+			[]string{"--flag=it's here"},
+		},
+		{
+			"unterminated quote runs to the end",
+			`--flag="Profile 1`,
+			[]string{"--flag=Profile 1"},
+		},
+	}
+	for _, tc := range cases {
+		if got := splitFlagString(tc.in); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s: splitFlagString(%q) = %#v, want %#v", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCustomChromeArgsHonorsQuoting(t *testing.T) {
+	t.Setenv("VIBIUM_CHROME_ARGS", `--user-data-dir=/tmp/v --profile-directory="Profile 1"`)
+	want := []string{"--user-data-dir=/tmp/v", "--profile-directory=Profile 1"}
+	if got := customChromeArgs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("customChromeArgs() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#306

`strings.Fields` split `VIBIUM_CHROME_ARGS` on every space, so a flag value containing one, like `--profile-directory="Profile 1"`, reached Chrome as two flags, and quoting made it worse by leaking the quote character into the first token. There was no way to express such a value.

The variable is now split with a quote-aware tokenizer: single or double quotes group a value and are removed (quotes can wrap the whole token or just the value part), and an unterminated quote runs to the end of the string. Both call sites are switched: the launch args and the root `--no-sandbox` opt-out check in `checkSandboxable`, so the sandbox check sees the same tokens Chrome receives.

Verified:
- `go test ./internal/browser -run 'TestSplitFlagString|TestCustomChromeArgs'` passes, covering the issue's two repro shapes plus single quotes, mixed quotes, and unterminated quotes; the quoted-value cases fail on main where Fields cuts at the space
- Plain space-separated values (the documented `--no-sandbox` case) split exactly as before