### PR TITLE
Extract the jar binary atomically

### DIFF
--- a/clients/java/src/main/java/com/vibium/internal/BinaryResolver.java
+++ b/clients/java/src/main/java/com/vibium/internal/BinaryResolver.java
@@ -73,28 +73,63 @@ public final class BinaryResolver {
             return null;
         }
 
-        try {
+        try (InputStream in = stream) {
             // Read version for cache directory
             String version = readVersion();
             Path extractDir = Paths.get(System.getProperty("java.io.tmpdir"), "vibium-" + version);
             Files.createDirectories(extractDir);
 
             Path target = extractDir.resolve(PlatformDetector.executableName());
-
-            // Only extract if not already present
-            if (!Files.exists(target)) {
-                Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING);
-                // Set executable permission on Unix
-                if (!System.getProperty("os.name", "").toLowerCase().contains("windows")) {
-                    target.toFile().setExecutable(true);
-                }
-            }
-            stream.close();
-            return target.toAbsolutePath().toString();
+            Path extracted = extractTo(in, extractDir, target, isWindows());
+            return extracted.toAbsolutePath().toString();
         } catch (IOException e) {
-            try { stream.close(); } catch (IOException ignored) {}
             return null;
         }
+    }
+
+    /**
+     * Extracts the binary so the target path only ever names a complete,
+     * executable file: the bytes go to a private temp file, the executable
+     * bit is set there, and an atomic rename publishes it. The old code
+     * guarded on Files.exists(target), which is true from the first byte of
+     * another JVM's in-progress copy, so parallel JVMs on a cold cache were
+     * handed a half-written, not-yet-executable binary (#329).
+     *
+     * Visible for testing.
+     */
+    static Path extractTo(InputStream in, Path extractDir, Path target, boolean windows) throws IOException {
+        if (isUsable(target, windows)) {
+            return target;
+        }
+
+        Path tmp = Files.createTempFile(extractDir, ".extract-", ".tmp");
+        try {
+            Files.copy(in, tmp, StandardCopyOption.REPLACE_EXISTING);
+            if (!windows) {
+                tmp.toFile().setExecutable(true);
+            }
+            // On POSIX the rename atomically replaces a stale or concurrent
+            // target. On Windows it can fail if another JVM's binary is in
+            // place or running; theirs is complete, so use it.
+            Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException moveFailed) {
+            Files.deleteIfExists(tmp);
+            if (isUsable(target, windows)) {
+                return target;
+            }
+            throw moveFailed;
+        }
+        return target;
+    }
+
+    // A completed extraction is executable; existence alone can be a
+    // half-written file from a concurrent or crashed extraction.
+    private static boolean isUsable(Path target, boolean windows) {
+        return Files.exists(target) && (windows || Files.isExecutable(target));
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase().contains("windows");
     }
 
     private static String readVersion() {

--- a/clients/java/src/test/java/com/vibium/internal/BinaryResolverTest.java
+++ b/clients/java/src/test/java/com/vibium/internal/BinaryResolverTest.java
@@ -1,0 +1,75 @@
+package com.vibium.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * extractTo must never publish a path to a half-written or non-executable
+ * binary: bytes land in a temp file, the executable bit is set there, and an
+ * atomic rename publishes the finished file (#329).
+ */
+class BinaryResolverTest {
+
+    private static final boolean WINDOWS =
+        System.getProperty("os.name", "").toLowerCase().contains("windows");
+
+    private static ByteArrayInputStream bytes(String s) {
+        return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void freshExtractionIsCompleteAndExecutable(@TempDir Path dir) throws IOException {
+        Path target = dir.resolve("vibium");
+        Path result = BinaryResolver.extractTo(bytes("binary-bytes"), dir, target, WINDOWS);
+
+        assertEquals(target, result);
+        assertEquals("binary-bytes", Files.readString(target));
+        if (!WINDOWS) {
+            assertTrue(Files.isExecutable(target), "published binary must be executable");
+        }
+    }
+
+    @Test
+    void staleNonExecutablePartialIsReplaced(@TempDir Path dir) throws IOException {
+        Path target = dir.resolve("vibium");
+        Files.writeString(target, "half-writ");
+        if (!WINDOWS) {
+            assertFalse(Files.isExecutable(target), "precondition: stale file is not executable");
+        }
+
+        BinaryResolver.extractTo(bytes("binary-bytes"), dir, target, false);
+
+        assertEquals("binary-bytes", Files.readString(target));
+        assertTrue(Files.isExecutable(target), "stale partial must be replaced with a complete binary");
+    }
+
+    @Test
+    void existingExecutableIsReusedWithoutRewriting(@TempDir Path dir) throws IOException {
+        Path target = dir.resolve("vibium");
+        Files.writeString(target, "already-there");
+        assertTrue(target.toFile().setExecutable(true));
+
+        BinaryResolver.extractTo(bytes("newer-bytes"), dir, target, WINDOWS);
+
+        assertEquals("already-there", Files.readString(target), "a usable binary is kept as is");
+    }
+
+    @Test
+    void noTempFilesLeftBehind(@TempDir Path dir) throws IOException {
+        Path target = dir.resolve("vibium");
+        BinaryResolver.extractTo(bytes("binary-bytes"), dir, target, WINDOWS);
+
+        try (DirectoryStream<Path> entries = Files.newDirectoryStream(dir, ".extract-*")) {
+            assertFalse(entries.iterator().hasNext(), "temp files must not accumulate");
+        }
+    }
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#329

`extractFromJar` guarded the copy with `Files.exists(target)`, which is true from the first byte of another JVM's in-progress copy, and set the executable bit only after the copy finished. With several JVMs starting against a cold cache (Surefire `forkCount=4` in the report), the losers were handed a half-written, not-yet-executable path and their exec failed.

The extraction core is now `extractTo`: bytes go to a private temp file in the same directory, the executable bit is set on the temp file, and `ATOMIC_MOVE` publishes it, so the target path only ever names a complete executable. On POSIX the rename atomically replaces a stale or concurrent target; on Windows a failed move falls back to the other JVM's completed binary. The reuse check requires executability rather than existence, so a stale partial from a crashed extraction is replaced instead of returned.

Verified:
- `./gradlew test --tests com.vibium.internal.BinaryResolverTest` passes: fresh extraction complete and executable, stale non-executable partial replaced, usable binary reused without rewriting, no temp files left behind
- The stale-partial case is the single-process shape of the reported race; on main the exists-guard returns the partial untouched