### PR TITLE
Extend the daemon client read deadline while a browser launch runs

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -60,6 +60,18 @@ type Handlers struct {
 	// launchedChannel distinguishes separately installed Firefox channels.
 	// It is empty for Chrome and remote sessions.
 	launchedChannel string
+
+	// launchNotify, when set, is called once at the moment a tool call
+	// commits to launching or connecting a browser, so the caller can warn
+	// its client that the response will take up to the launch bounds. The
+	// daemon sets it per request under the same mutex that serializes
+	// handler calls; it must not be mutated while a call is in flight.
+	launchNotify func()
+}
+
+// SetLaunchNotify installs (or clears, with nil) the launch-start callback.
+func (h *Handlers) SetLaunchNotify(fn func()) {
+	h.launchNotify = fn
 }
 
 // NewHandlers creates a new Handlers instance.
@@ -688,6 +700,12 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 				Text: "Browser already running",
 			}},
 		}, nil
+	}
+
+	// Past the no-op checks a launch (or remote connect) really starts, and
+	// the caller may be about to wait longer than an ordinary command.
+	if h.launchNotify != nil {
+		h.launchNotify()
 	}
 
 	// Remote browser connect mode

--- a/clicker/internal/agent/launch_notify_test.go
+++ b/clicker/internal/agent/launch_notify_test.go
@@ -1,0 +1,19 @@
+package agent
+
+import "testing"
+
+// The notify callback must fire exactly once when a call commits to starting
+// a browser, before the connect/launch work. A remote URL with nothing
+// listening makes the attempt fail fast while still crossing the commit point.
+func TestLaunchNotifyFiresOnLaunchAttempt(t *testing.T) {
+	h := NewHandlers("", "", false, "ws://127.0.0.1:1/session", nil)
+	calls := 0
+	h.SetLaunchNotify(func() { calls++ })
+
+	if _, err := h.Call("browser_start", map[string]interface{}{}); err == nil {
+		t.Fatal("expected the remote connect to fail")
+	}
+	if calls != 1 {
+		t.Fatalf("launchNotify fired %d times, want 1", calls)
+	}
+}

--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -24,6 +24,17 @@ import (
 // launch ~16s) so a wedged chromedriver can't hang it indefinitely.
 const sessionCreateTimeout = 30 * time.Second
 
+// chromedriverReadyTimeout bounds the wait for chromedriver's /status endpoint
+// after spawning it.
+const chromedriverReadyTimeout = 10 * time.Second
+
+// LaunchBudget is the wall clock a launch may legitimately spend inside its
+// own bounds: chromedriverReadyTimeout, then session creation capped at
+// sessionCreateTimeout on either route, plus slack for process spawn and the
+// WebSocket handshake. Deadlines that wait on a launch (the daemon client's
+// read deadline) derive from this instead of guessing (#407).
+const LaunchBudget = chromedriverReadyTimeout + sessionCreateTimeout + 5*time.Second
+
 // prefixWriter wraps an io.Writer and prepends a prefix to each line.
 type prefixWriter struct {
 	w      io.Writer
@@ -171,7 +182,7 @@ func Launch(opts LaunchOptions) (*LaunchResult, error) {
 
 	// Wait for chromedriver to be ready
 	baseURL := fmt.Sprintf("http://localhost:%d", port)
-	if err := waitForChromedriver(baseURL, 10*time.Second); err != nil {
+	if err := waitForChromedriver(baseURL, chromedriverReadyTimeout); err != nil {
 		cmd.Process.Kill()
 		return nil, fmt.Errorf("chromedriver failed to start: %w", err)
 	}

--- a/clicker/internal/daemon/client.go
+++ b/clicker/internal/daemon/client.go
@@ -8,12 +8,21 @@ import (
 	"time"
 
 	"github.com/vibium/clicker/internal/agent"
+	"github.com/vibium/clicker/internal/browser"
 	"github.com/vibium/clicker/internal/paths"
 )
 
-const (
+// Vars, not consts, so tests can shrink them to hermetic sizes.
+var (
 	dialTimeout = 2 * time.Second
 	readTimeout = 60 * time.Second
+
+	// launchGrace is added to the read deadline once when the daemon reports
+	// a browser launch in progress. Derived from the launch path's own bounds
+	// so the client outlasts a legitimately slow launch without hiding a
+	// wedged daemon: no launch notification means the plain readTimeout
+	// still applies (#407).
+	launchGrace = browser.LaunchBudget
 )
 
 // ToolError is an error the daemon itself reported. It means the daemon was
@@ -140,12 +149,38 @@ func sendRequest(method string, params json.RawMessage) (*agent.Response, error)
 	// bufio.Reader grows as needed; bufio.Scanner failed with "token too long"
 	// on any response over its fixed buffer — a long page's text, a large
 	// storage state (#209).
-	line, err := bufio.NewReader(conn).ReadBytes('\n')
-	if err != nil && len(line) == 0 {
-		if err != io.EOF {
-			return nil, fmt.Errorf("read response: %w", err)
+	reader := bufio.NewReader(conn)
+	var line []byte
+	extended := false
+	for {
+		line, err = reader.ReadBytes('\n')
+		if err != nil && len(line) == 0 {
+			if err != io.EOF {
+				return nil, fmt.Errorf("read response: %w", err)
+			}
+			return nil, fmt.Errorf("daemon closed connection without response")
 		}
-		return nil, fmt.Errorf("daemon closed connection without response")
+		if err != nil {
+			break // partial final line; let the response parse report it
+		}
+
+		// The daemon may send notifications (no id) ahead of the response.
+		// A launch notification means the daemon committed to a browser
+		// launch, so the response can legitimately take the launch bounds
+		// plus a normal command on top; extend the deadline once from here.
+		// Unknown notifications are skipped without extending.
+		var msg struct {
+			Method string          `json:"method"`
+			ID     json.RawMessage `json:"id"`
+		}
+		if json.Unmarshal(line, &msg) == nil && msg.Method != "" && len(msg.ID) == 0 {
+			if msg.Method == launchingBrowserMethod && !extended {
+				extended = true
+				conn.SetReadDeadline(time.Now().Add(launchGrace + readTimeout))
+			}
+			continue
+		}
+		break
 	}
 
 	var resp agent.Response

--- a/clicker/internal/daemon/client_test.go
+++ b/clicker/internal/daemon/client_test.go
@@ -1,0 +1,160 @@
+package daemon
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vibium/clicker/internal/paths"
+)
+
+// fakeDaemon listens on the session socket and serves one connection with the
+// given script. Returns after the connection is handled.
+func fakeDaemon(t *testing.T, serve func(conn net.Conn)) {
+	t.Helper()
+
+	socketPath, err := paths.GetSocketPath()
+	if err != nil {
+		t.Fatalf("get socket path: %v", err)
+	}
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		serve(conn)
+	}()
+}
+
+// shrinkTimeouts makes the package deadlines hermetic-test sized and restores
+// them afterwards.
+func shrinkTimeouts(t *testing.T, read, grace time.Duration) {
+	t.Helper()
+	origRead, origGrace := readTimeout, launchGrace
+	readTimeout, launchGrace = read, grace
+	t.Cleanup(func() { readTimeout, launchGrace = origRead, origGrace })
+}
+
+func setupSocketDir(t *testing.T) {
+	t.Helper()
+	// Keep the socket path short: sun_path caps around 104 bytes on macOS.
+	dir := t.TempDir()
+	t.Setenv("VIBIUM_CACHE_DIR", dir)
+	t.Setenv("VIBIUM_SESSION", "")
+	if len(filepath.Join(dir, "vibium.sock")) > 100 {
+		t.Skip("temp dir too long for a unix socket path")
+	}
+}
+
+const okResponse = `{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}`
+
+func readRequest(t *testing.T, conn net.Conn) {
+	t.Helper()
+	if _, err := bufio.NewReader(conn).ReadBytes('\n'); err != nil {
+		t.Errorf("read request: %v", err)
+	}
+}
+
+// A response that arrives after readTimeout but within the extended deadline
+// succeeds when the daemon announced a launch first. On a client without the
+// notification protocol this fails twice over: the notification line is
+// mistaken for the response, and the deadline is never extended.
+func TestLaunchNotificationExtendsReadDeadline(t *testing.T) {
+	setupSocketDir(t)
+	shrinkTimeouts(t, 200*time.Millisecond, 2*time.Second)
+
+	fakeDaemon(t, func(conn net.Conn) {
+		readRequest(t, conn)
+		fmt.Fprintf(conn, "{\"jsonrpc\":\"2.0\",\"method\":%q}\n", launchingBrowserMethod)
+		time.Sleep(400 * time.Millisecond) // past readTimeout, inside the grace
+		fmt.Fprintln(conn, okResponse)
+	})
+
+	result, err := Call("browser_title", nil)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if len(result.Content) != 1 || result.Content[0].Text != "ok" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+// Without a launch notification the plain deadline still applies, so a daemon
+// that goes silent is reported at readTimeout, not readTimeout+grace.
+func TestNoNotificationKeepsPlainDeadline(t *testing.T) {
+	setupSocketDir(t)
+	shrinkTimeouts(t, 200*time.Millisecond, 10*time.Second)
+
+	done := make(chan struct{})
+	fakeDaemon(t, func(conn net.Conn) {
+		readRequest(t, conn)
+		<-done // never respond
+	})
+	defer close(done)
+
+	start := time.Now()
+	_, err := Call("browser_title", nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if elapsed >= 2*time.Second {
+		t.Fatalf("timed out after %v; the deadline was extended without a notification", elapsed)
+	}
+}
+
+// A silent daemon that did announce a launch is still bounded: the extension
+// is the launch grace, not forever.
+func TestExtendedDeadlineStillBounds(t *testing.T) {
+	setupSocketDir(t)
+	shrinkTimeouts(t, 100*time.Millisecond, 300*time.Millisecond)
+
+	done := make(chan struct{})
+	fakeDaemon(t, func(conn net.Conn) {
+		readRequest(t, conn)
+		fmt.Fprintf(conn, "{\"jsonrpc\":\"2.0\",\"method\":%q}\n", launchingBrowserMethod)
+		<-done // never respond
+	})
+	defer close(done)
+
+	start := time.Now()
+	_, err := Call("browser_title", nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if elapsed >= 3*time.Second {
+		t.Fatalf("timed out after %v; extension should be bounded by the grace", elapsed)
+	}
+}
+
+// Unknown notifications are skipped without extending the deadline, so a
+// future daemon cannot silently disable the wedge bound on old clients.
+func TestUnknownNotificationSkippedWithoutExtension(t *testing.T) {
+	setupSocketDir(t)
+	shrinkTimeouts(t, 300*time.Millisecond, 10*time.Second)
+
+	fakeDaemon(t, func(conn net.Conn) {
+		readRequest(t, conn)
+		fmt.Fprintln(conn, `{"jsonrpc":"2.0","method":"daemon/somethingElse"}`)
+		fmt.Fprintln(conn, okResponse)
+	})
+
+	result, err := Call("browser_title", nil)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if len(result.Content) != 1 || result.Content[0].Text != "ok" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}

--- a/clicker/internal/daemon/router.go
+++ b/clicker/internal/daemon/router.go
@@ -23,8 +23,15 @@ type StatusResult struct {
 	Session   string `json:"session"`
 }
 
+// launchingBrowserMethod is the notification the daemon writes before a tool
+// call launches a browser, so the client can extend its read deadline to
+// cover the launch bounds instead of timing out mid-launch (#407). Sent as a
+// JSON-RPC notification (no id) ahead of the response on the same connection.
+const launchingBrowserMethod = "daemon/launchingBrowser"
+
 // handleConnection processes a single client connection.
-// Each connection sends one JSON-RPC request and receives one response.
+// Each connection sends one JSON-RPC request and receives one response,
+// optionally preceded by notifications.
 func (d *Daemon) handleConnection(conn net.Conn) {
 	defer conn.Close()
 
@@ -40,7 +47,14 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		return
 	}
 
-	response := d.handleRequest(line)
+	// The handler runs synchronously in this goroutine, so the notification
+	// write cannot interleave with the response write below.
+	notifyLaunch := func() {
+		conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		fmt.Fprintf(conn, "{\"jsonrpc\":\"2.0\",\"method\":%q}\n", launchingBrowserMethod)
+	}
+
+	response := d.handleRequest(line, notifyLaunch)
 	if response == nil {
 		return
 	}
@@ -55,8 +69,9 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 	fmt.Fprintf(conn, "%s\n", data)
 }
 
-// handleRequest parses and routes a JSON-RPC request.
-func (d *Daemon) handleRequest(data []byte) *agent.Response {
+// handleRequest parses and routes a JSON-RPC request. notifyLaunch is invoked
+// if handling the request starts a browser launch.
+func (d *Daemon) handleRequest(data []byte, notifyLaunch func()) *agent.Response {
 	var req agent.Request
 	if err := json.Unmarshal(data, &req); err != nil {
 		return &agent.Response{
@@ -81,7 +96,7 @@ func (d *Daemon) handleRequest(data []byte) *agent.Response {
 		}
 	}
 
-	result, mcpErr := d.route(req)
+	result, mcpErr := d.route(req, notifyLaunch)
 
 	if req.ID == nil {
 		return nil
@@ -103,7 +118,7 @@ func (d *Daemon) handleRequest(data []byte) *agent.Response {
 }
 
 // route dispatches requests to the appropriate handler.
-func (d *Daemon) route(req agent.Request) (interface{}, *agent.Error) {
+func (d *Daemon) route(req agent.Request, notifyLaunch func()) (interface{}, *agent.Error) {
 	log.Debug("daemon request", "method", req.Method, "id", req.ID)
 
 	switch req.Method {
@@ -113,7 +128,7 @@ func (d *Daemon) route(req agent.Request) (interface{}, *agent.Error) {
 		go d.Shutdown() // Shutdown asynchronously so we can send response
 		return map[string]string{"status": "shutting down"}, nil
 	case "tools/call":
-		return d.handleToolsCall(req.Params)
+		return d.handleToolsCall(req.Params, notifyLaunch)
 	case "tools/list":
 		return agent.ToolsListResult{
 			Tools: agent.GetToolSchemas(),
@@ -158,7 +173,7 @@ func (d *Daemon) handleInitialize() (interface{}, *agent.Error) {
 }
 
 // handleToolsCall executes a tool and returns the result.
-func (d *Daemon) handleToolsCall(params json.RawMessage) (interface{}, *agent.Error) {
+func (d *Daemon) handleToolsCall(params json.RawMessage, notifyLaunch func()) (interface{}, *agent.Error) {
 	var p agent.ToolsCallParams
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, &agent.Error{
@@ -168,9 +183,13 @@ func (d *Daemon) handleToolsCall(params json.RawMessage) (interface{}, *agent.Er
 		}
 	}
 
-	// Serialize handler access — handlers are not thread-safe
+	// Serialize handler access — handlers are not thread-safe. The launch
+	// callback targets this request's connection, so it is installed and
+	// cleared under the same lock.
 	d.mu.Lock()
+	d.handlers.SetLaunchNotify(notifyLaunch)
 	result, err := d.handlers.Call(p.Name, p.Arguments)
+	d.handlers.SetLaunchNotify(nil)
 	d.mu.Unlock()
 
 	if err != nil {


### PR DESCRIPTION
Fixes VibiumDev/vibium#407

A tool call that has to launch a browser spends the launcher's own bounds (10s chromedriver wait plus 30s session create) before the command itself starts. The daemon client's flat 60s read deadline expires mid-launch under suite load, which is how the dead-browser recovery test failed about 1 in 4 full-suite runs.

The daemon now writes a `daemon/launchingBrowser` notification on the connection when a call commits to launching, and the client extends its read deadline once from that marker by `browser.LaunchBudget`, a constant derived from the launcher's bounds. No notification means the plain 60s applies unchanged, so a wedged daemon is still reported as fast as before. This is the same shape as the pipe install marker from #390: the server announces slow but bounded work, the client extends once from the marker.

Version skew: an older client reading a newer daemon's notification would take it for the response of a launch-triggering call. Both ends ship in one binary, so this only affects mixed installs sharing a socket, the same class of tradeoff #390 accepted.

Verified:
- `go test ./internal/daemon ./internal/agent` passes; the four new client tests cover extend-on-marker, plain deadline without a marker, bounded extension for a silent daemon that did announce, and unknown notifications being skipped without extending
- The marker tests exercise new symbols so they do not compile on main; on main's client the notification line is misparsed as the response, which is the failure the first test locks out
- `tests/cli/dead-browser.test.js` unchanged and covered by fork CI's full suite