### PR TITLE
Return an empty list from findAll when nothing matches

### DIFF
--- a/clicker/internal/api/find_timeout_test.go
+++ b/clicker/internal/api/find_timeout_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// An explicit timeout of 0 must mean "check once, do not wait", not fall back
+// to the 30s default the way the old `> 0` guard made it (#411).
+func TestFindTimeout(t *testing.T) {
+	cases := []struct {
+		name   string
+		params map[string]interface{}
+		want   time.Duration
+	}{
+		{"absent uses default", map[string]interface{}{}, DefaultTimeout},
+		{"null uses default", map[string]interface{}{"timeout": nil}, DefaultTimeout},
+		{"zero means no wait", map[string]interface{}{"timeout": float64(0)}, 0},
+		{"explicit value honored", map[string]interface{}{"timeout": float64(1500)}, 1500 * time.Millisecond},
+	}
+	for _, tc := range cases {
+		if got := findTimeout(tc.params); got != tc.want {
+			t.Errorf("%s: findTimeout = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/clicker/internal/api/handlers_elements.go
+++ b/clicker/internal/api/handlers_elements.go
@@ -30,11 +30,7 @@ func (r *Router) handleVibiumFind(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 
-	timeoutMs, _ := cmd.Params["timeout"].(float64)
-	timeout := DefaultTimeout
-	if timeoutMs > 0 {
-		timeout = time.Duration(timeoutMs) * time.Millisecond
-	}
+	timeout := findTimeout(cmd.Params)
 
 	script, args := BuildFindScript(cmd.Params, false)
 
@@ -65,11 +61,7 @@ func (r *Router) handleVibiumFindAll(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 
-	timeoutMs, _ := cmd.Params["timeout"].(float64)
-	timeout := DefaultTimeout
-	if timeoutMs > 0 {
-		timeout = time.Duration(timeoutMs) * time.Millisecond
-	}
+	timeout := findTimeout(cmd.Params)
 
 	hasText, _ := cmd.Params["hasText"].(string)
 	has, _ := cmd.Params["has"].(string)
@@ -92,6 +84,16 @@ func (r *Router) handleVibiumFindAll(session *BrowserSession, cmd bidiCommand) {
 		"elements": elements,
 		"count":    len(elements),
 	})
+}
+
+// findTimeout reads the caller's find timeout. An explicit 0 means one
+// immediate check with no waiting; only an absent timeout gets the default.
+// The old `> 0` guard silently replaced a caller's 0 with 30 seconds (#411).
+func findTimeout(params map[string]interface{}) time.Duration {
+	if ms, ok := params["timeout"].(float64); ok {
+		return time.Duration(ms) * time.Millisecond
+	}
+	return DefaultTimeout
 }
 
 // BuildFindScript builds the JS function and arguments for element finding.
@@ -379,12 +381,13 @@ func (r *Router) waitForElementWithScript(session *BrowserSession, context, scri
 	return WaitForElementWithScript(NewAPISession(r, session, context), context, script, args, timeout)
 }
 
-// waitForElements polls until at least one matching element is found, then returns all.
+// waitForElements polls until at least one matching element is found, then
+// returns all. At the deadline it returns an empty slice, not an error: a
+// collection query whose answer is "none" is a valid result, and the singular
+// find is the call that treats absence as failure (#411).
 func (r *Router) waitForElements(session *BrowserSession, context, script string, args []map[string]interface{}, hasText, has string, timeout time.Duration) ([]map[string]interface{}, error) {
 	deadline := time.Now().Add(timeout)
 	interval := 100 * time.Millisecond
-
-	desc := describeSelector(args)
 
 	for {
 		params := map[string]interface{}{
@@ -416,7 +419,7 @@ func (r *Router) waitForElements(session *BrowserSession, context, script string
 		}
 
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("timeout after %s waiting for '%s': no elements found", timeout, desc)
+			return []map[string]interface{}{}, nil
 		}
 
 		time.Sleep(interval)

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -175,12 +175,19 @@ public class Page {
         return elementFromResult(result, "", 0, locatorParams(options));
     }
 
-    /** Find all matching elements by CSS selector. */
+    /**
+     * Find all matching elements by CSS selector. Waits up to the timeout
+     * for at least one match, then returns an empty list if there is none.
+     */
     public List<Element> findAll(String selector) {
         return findAll(selector, (FindOptions) null);
     }
 
-    /** Find all matching elements by CSS selector with options. */
+    /**
+     * Find all matching elements by CSS selector with options. Waits up to
+     * the timeout for at least one match, then returns an empty list if
+     * there is none. A timeout of 0 checks once without waiting.
+     */
     public List<Element> findAll(String selector, FindOptions options) {
         JsonObject params = contextParams();
         params.addProperty("selector", selector);
@@ -191,7 +198,11 @@ public class Page {
         return elementsFromResult(result, selector);
     }
 
-    /** Find all matching elements by semantic selector. */
+    /**
+     * Find all matching elements by semantic selector. Waits up to the
+     * timeout for at least one match, then returns an empty list if there
+     * is none.
+     */
     public List<Element> findAll(SelectorOptions options) {
         JsonObject params = contextParams();
         for (Map.Entry<String, Object> entry : options.toParams().entrySet()) {

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -672,7 +672,11 @@ export class Page {
     return fluent(promise);
   }
 
-  /** Find all elements matching a CSS selector or semantic options. Waits for at least one. */
+  /**
+   * Find all elements matching a CSS selector or semantic options. Waits up
+   * to the timeout for at least one match, then returns an empty array if
+   * there is none. A timeout of 0 checks once without waiting.
+   */
   async findAll(selector: string | SelectorOptions, options?: FindOptions): Promise<Element[]> {
     const params: Record<string, unknown> = {
       context: this.contextId,

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -229,7 +229,11 @@ class Page:
         near: Optional[str] = None,
         timeout: Optional[int] = None,
     ) -> List[Element]:
-        """Find all elements matching a selector or semantic options."""
+        """Find all elements matching a selector or semantic options.
+
+        Waits up to the timeout for at least one match, then returns an empty
+        list if there is none. A timeout of 0 checks once without waiting.
+        """
         params: Dict[str, Any] = {"context": self._context_id, "timeout": timeout}
         if selector is not None:
             params["selector"] = selector

--- a/tests/js/async/engine/elements.test.js
+++ b/tests/js/async/engine/elements.test.js
@@ -55,6 +55,18 @@ describe('Element Finding', () => {
     assert.ok(paragraphs.length > 0, 'Should find at least one paragraph');
   });
 
+  test('findAll returns an empty array when nothing matches (#411)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL);
+
+    // timeout 0 means a single immediate check, so "none" comes back fast
+    // instead of after the default 30s wait.
+    const start = Date.now();
+    const none = await vibe.findAll('#definitely-not-on-this-page', { timeout: 0 });
+    assert.deepStrictEqual(none, [], 'Should resolve to an empty array, not throw');
+    assert.ok(Date.now() - start < 5000, 'timeout 0 should not wait out the default');
+  });
+
   test('findAll()[0] returns first element', async () => {
     const vibe = await bro.page();
     await vibe.go(baseURL);


### PR DESCRIPTION
Fixes VibiumDev/vibium#411

Both defects live in the engine, not the Java client, so this fixes all three clients at once.

Empty was unreachable: `waitForElements` polled for at least one match and errored at the deadline, so a collection-returning API had no way to answer "none". The wait for a first match stays (that auto-wait is the feature); only the deadline outcome changes from an error to an empty list. The singular `find` still throws, since absence is a failure when exactly one element was promised.

`timeout(0)` was silently discarded: the `timeoutMs > 0` guard in both find handlers replaced an explicit 0 with the 30s default, which is why `timeout(1)` was honored but `timeout(0)` waited 30 seconds. Timeout parsing now distinguishes absent from explicit, and 0 means one immediate check. Extracted as `findTimeout` so both handlers share it.

Client docs (Java Javadoc, JS TSDoc, Python docstring) updated to state the contract.

Verified:
- `go test ./internal/api -run TestFindTimeout` passes; the zero case fails on main where the guard maps 0 to the default
- New JS engine test asserts `findAll('#nope', { timeout: 0 })` resolves to `[]` quickly; on main it throws after the full 30s wait
- No existing test asserted the old throw-on-empty behavior (checked tests/js, tests/py, engine suites)