### PR TITLE
Let Java callers set a single video dimension

### DIFF
--- a/clients/java/src/main/java/com/vibium/types/RecordingOptions.java
+++ b/clients/java/src/main/java/com/vibium/types/RecordingOptions.java
@@ -37,9 +37,32 @@ public class RecordingOptions {
      * the engine can't deliver. false: off.
      */
     public RecordingOptions video(boolean video) { this.video = video; return this; }
-    /** Video dimensions in pixels (default: viewport). Implies video on. */
+    /**
+     * Video dimensions in pixels (default: viewport). Implies video on.
+     * Pass 0 for a dimension to leave it unset, letting the engine derive it
+     * from the viewport aspect ratio, matching {@link #videoWidth(int)} and
+     * {@link #videoHeight(int)}.
+     */
     public RecordingOptions videoSize(int width, int height) {
+        this.videoWidth = width > 0 ? width : null;
+        this.videoHeight = height > 0 ? height : null;
+        return this;
+    }
+
+    /**
+     * Video width in pixels; the engine derives the height from the viewport
+     * aspect ratio. Implies video on.
+     */
+    public RecordingOptions videoWidth(int width) {
         this.videoWidth = width;
+        return this;
+    }
+
+    /**
+     * Video height in pixels; the engine derives the width from the viewport
+     * aspect ratio. Implies video on.
+     */
+    public RecordingOptions videoHeight(int height) {
         this.videoHeight = height;
         return this;
     }

--- a/clients/java/src/test/java/com/vibium/RecordingOptionsTest.java
+++ b/clients/java/src/test/java/com/vibium/RecordingOptionsTest.java
@@ -1,0 +1,51 @@
+package com.vibium;
+
+import com.vibium.types.RecordingOptions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A single video dimension must reach the wire alone so the engine derives
+ * the other from the viewport aspect ratio, as the JS and Python clients
+ * already allow (#409).
+ */
+class RecordingOptionsTest {
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> videoParams(RecordingOptions options) {
+        Object video = options.toParams().get("video");
+        assertInstanceOf(Map.class, video, "video should be a params map");
+        return (Map<String, Object>) video;
+    }
+
+    @Test
+    void videoHeightAloneOmitsWidth() {
+        Map<String, Object> video = videoParams(new RecordingOptions().videoHeight(480));
+        assertEquals(480, video.get("height"));
+        assertFalse(video.containsKey("width"), "width should stay unset");
+    }
+
+    @Test
+    void videoWidthAloneOmitsHeight() {
+        Map<String, Object> video = videoParams(new RecordingOptions().videoWidth(640));
+        assertEquals(640, video.get("width"));
+        assertFalse(video.containsKey("height"), "height should stay unset");
+    }
+
+    @Test
+    void videoSizeZeroMeansUnset() {
+        Map<String, Object> video = videoParams(new RecordingOptions().videoSize(0, 480));
+        assertEquals(480, video.get("height"));
+        assertFalse(video.containsKey("width"), "width 0 should stay unset");
+    }
+
+    @Test
+    void videoSizeBothDimensionsStillWork() {
+        Map<String, Object> video = videoParams(new RecordingOptions().videoSize(640, 480));
+        assertEquals(640, video.get("width"));
+        assertEquals(480, video.get("height"));
+    }
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#409

`RecordingOptions.videoSize(int, int)` required both dimensions, but the engine derives the missing one from the viewport aspect ratio and overrides a mismatched second dimension anyway, so Java callers were computing a number that gets discarded. JS and Python already accept one side alone.

Adds `videoWidth(int)` and `videoHeight(int)` setters and treats 0 in `videoSize` as unset. The internal fields were already separate and `toParams` already omits null dimensions, so the change is the setters plus Javadoc. The wire protocol omits unset dimensions (`recording_video.go` only sets non-zero values), so no engine change is needed.

Verified:
- `./gradlew test --tests RecordingOptionsTest` passes: single width, single height, `videoSize(0, 480)`, and the two-dimension case all serialize as expected
- The single-dimension tests fail on main, where the setters do not exist and `videoSize` always sets both fields