### PR TITLE
Forward vibium stderr into the CI job log

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,15 @@ on:
 permissions:
   contents: read
 
+# Forward the vibium binary's stderr through the JS and Python clients into
+# the job log. Without it the clients drain stderr into a small in-memory
+# tail that only surfaces on a client-raised error, so a hung test killed by
+# the watchdog shows nothing: the #397 incident on run 32789877533 left the
+# router's slow-delivery diagnostics (#403) unreadable. Costs a few
+# connection lines per healthy test.
+env:
+  VIBIUM_STDERR: 1
+
 jobs:
   chrome:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Related: VibiumDev/vibium#397, VibiumDev/vibium#403

Main's run 32789877533 (after the #421 merge) failed on the known #397 flake: the sync download tutorial hung until the 600s watchdog. It was the first incident since the router's slow-delivery logging (#403) merged, and it surfaced a visibility gap instead of diagnostics: both the JS and Python clients drain the binary's stderr into a small in-memory tail (8KiB in Python) that is only printed when the client itself raises an error. A watchdog-killed hang never raises one, so whatever the router logged was unreadable.

Both clients already forward stderr live when `VIBIUM_STDERR` is set (`clients/python/src/vibium/binary.py`, `clients/javascript/src/clicker/process.ts`); nothing in CI set it. This sets it workflow-wide in test.yml so the next incident carries the router's stall lines, at the cost of a few connection lines per healthy test.

Verified:
- Grepped run 32789877533's full log: no `[router]` lines anywhere in the hang window, and `VIBIUM_STDERR` appears nowhere in workflows, Makefile, or tests, confirming the gap is structural rather than this incident lacking stalls
- Workflow-only change; no product code touched