### PR TITLE
Honor -h and --help on commands that disable flag parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ test-go:
 # Process tests run separately with --test-concurrency=1 to avoid interference
 test-cli: build-go
 	@echo "--- CLI Tests (no daemon) ---"
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/is-installed.test.js tests/cli/packaging.test.js tests/cli/release-versioning.test.js tests/cli/wrapper.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/help-flags.test.js tests/cli/is-installed.test.js tests/cli/packaging.test.js tests/cli/release-versioning.test.js tests/cli/wrapper.test.js
 	@"$(MAKE)" test-cli-shared ENGINE=$(ENGINE)
 	@echo "--- CLI Process Tests (sequential) ---"
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js tests/cli/dead-browser.test.js

--- a/clicker/cmd/clicker/helpers.go
+++ b/clicker/cmd/clicker/helpers.go
@@ -82,8 +82,8 @@ func parseFlagsAllowNegative(cmd *cobra.Command, raw []string) ([]string, error)
 	}
 
 	// DisableFlagParsing also disables cobra's help interception, so -h and
-	// --help land in the flag set unhandled — the command would then run for
-	// real, destructively for fill (#422, #423). Honor the flag here.
+	// --help land in the flag set unhandled and the command runs for real,
+	// destructively for fill (#422, #423). Honor the flag here.
 	if help, _ := flags.GetBool("help"); help {
 		cmd.Help()
 		os.Exit(0)

--- a/clicker/cmd/clicker/helpers.go
+++ b/clicker/cmd/clicker/helpers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -79,5 +80,14 @@ func parseFlagsAllowNegative(cmd *cobra.Command, raw []string) ([]string, error)
 	if err := flags.Parse(flagTokens); err != nil {
 		return nil, err
 	}
+
+	// DisableFlagParsing also disables cobra's help interception, so -h and
+	// --help land in the flag set unhandled — the command would then run for
+	// real, destructively for fill (#422, #423). Honor the flag here.
+	if help, _ := flags.GetBool("help"); help {
+		cmd.Help()
+		os.Exit(0)
+	}
+
 	return positionals, nil
 }

--- a/tests/cli/help-flags.test.js
+++ b/tests/cli/help-flags.test.js
@@ -1,0 +1,88 @@
+/**
+ * CLI Tests: -h/--help on commands that disable cobra flag parsing
+ *
+ * fill, type, geolocation, and sleep set DisableFlagParsing to support
+ * negative-number positionals, which also bypasses cobra's built-in help
+ * interception. Regression tests for #422 (bare --help returned an arity
+ * error) and #423 (--help alongside positionals executed the command).
+ *
+ * All cases must short-circuit before any daemon call, so no browser or
+ * daemon is needed.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { VIBIUM } = require('../helpers');
+
+function run(args) {
+  const result = spawnSync(VIBIUM, args, {
+    encoding: 'utf-8',
+    timeout: 30000,
+    env: { ...process.env, VIBIUM_SESSION: `help-flags-test-${process.pid}` },
+  });
+  assert.strictEqual(result.error, undefined, `spawn failed: ${result.error}`);
+  return result;
+}
+
+const COMMANDS = {
+  fill: { short: 'Clear an input field', executed: /Filled/ },
+  type: { short: 'Type text into an element', executed: /Typed/ },
+  geolocation: { short: 'Override the browser geolocation', executed: /Geolocation set/ },
+  sleep: { short: 'Pause execution', executed: /Slept/ },
+};
+
+function assertHelp(result, cmd, invocation) {
+  const { short, executed } = COMMANDS[cmd];
+  assert.strictEqual(result.status, 0, `${invocation}: expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+  assert.match(result.stdout, /Usage:/, `${invocation}: help text should include usage`);
+  assert.ok(result.stdout.includes(short), `${invocation}: help text should include the command description`);
+  assert.doesNotMatch(result.stdout, executed, `${invocation}: command must not execute on a help request`);
+  assert.doesNotMatch(result.stderr, /Error:/, `${invocation}: help request should not error`);
+}
+
+describe('CLI: help flags on DisableFlagParsing commands', () => {
+  // #422: bare -h/--help must print help, not an arg-count error
+  for (const cmd of Object.keys(COMMANDS)) {
+    for (const flag of ['-h', '--help']) {
+      test(`${cmd} ${flag} prints help`, () => {
+        assertHelp(run([cmd, flag]), cmd, `${cmd} ${flag}`);
+      });
+    }
+  }
+
+  // #423: --help alongside positionals must print help, not execute
+  test('sleep 5000 --help prints help without sleeping', () => {
+    assertHelp(run(['sleep', '5000', '--help']), 'sleep', 'sleep 5000 --help');
+  });
+
+  test('fill <selector> <text> --help prints help without filling', () => {
+    assertHelp(run(['fill', '#a', 'x', '--help']), 'fill', 'fill #a x --help');
+  });
+
+  test('fill --help <selector> <text> prints help (flag-first form)', () => {
+    assertHelp(run(['fill', '--help', '#a', 'x']), 'fill', 'fill --help #a x');
+  });
+
+  test('type <selector> <text> -h prints help without typing', () => {
+    assertHelp(run(['type', '#a', 'x', '-h']), 'type', 'type #a x -h');
+  });
+
+  test('geolocation 37 -122 --help prints help alongside a negative positional', () => {
+    assertHelp(run(['geolocation', '37', '-122', '--help']), 'geolocation', 'geolocation 37 -122 --help');
+  });
+
+  // Guardrails: the behaviors DisableFlagParsing exists for must survive the fix
+  test('negative numbers still parse as positionals, not flags', () => {
+    const result = run(['geolocation', '-122']);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /accepts 2 arg\(s\), received 1/);
+    assert.doesNotMatch(result.stderr, /unknown flag/);
+  });
+
+  test('unknown flags are still rejected', () => {
+    const result = run(['fill', '--bogusflag']);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /unknown flag: --bogusflag/);
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#422
Fixes VibiumDev/vibium#423

fill, type, geolocation, and sleep set DisableFlagParsing so negative-number positionals like `geolocation 37.8 -122.4` parse correctly. That also bypasses cobra's built-in help handling, so `-h`/`--help` was parsed into the flag set and then ignored: a bare `--help` returned an arg-count error, and `--help` alongside positionals ran the command for real. For `fill` that overwrites the target field on a help request, silently and with exit 0.

The fix checks the parsed help flag in parseFlagsAllowNegative, the helper all four commands share, and prints help before anything reaches the daemon.

Verified:
- New tests/cli/help-flags.test.js covers bare and with-positional `-h`/`--help` on all four commands, plus guardrails that negative positionals and unknown-flag rejection still work. The bare-help cases fail on main with `Error: accepts N arg(s), received 0`; all 15 pass with the fix, browser-free in ~300ms.
- `make test-go` green; gofmt and go vet clean.
- Added the new file to the no-daemon line of `make test-cli`.