### PR TITLE
Hit-test receivesEvents at the in-view center, not the rect center

### DIFF
--- a/clicker/cmd/clicker/is.go
+++ b/clicker/cmd/clicker/is.go
@@ -124,8 +124,8 @@ func newIsCmd() *cobra.Command {
 				const visible = rect.width > 0 && rect.height > 0 &&
 					style.visibility !== 'hidden' && style.display !== 'none';
 
-				const cx = rect.x + rect.width/2, cy = rect.y + rect.height/2;
-				const hit = document.elementFromPoint(cx, cy);
+				` + api.InViewCenterJS + `
+				const hit = document.elementFromPoint(px, py);
 				const receivesEvents = hit && (el === hit || el.contains(hit));
 
 				let enabled = true;

--- a/clicker/internal/api/actionability.go
+++ b/clicker/internal/api/actionability.go
@@ -12,7 +12,7 @@ type ActionCheck int
 const (
 	CheckVisible        ActionCheck = iota // non-zero bbox, not display:none/visibility:hidden
 	CheckStable                            // bbox unchanged after 50ms delay
-	CheckReceivesEvents                    // elementFromPoint at center hits element or descendant
+	CheckReceivesEvents                    // elementFromPoint at the in-view center hits element or descendant
 	CheckEnabled                           // not [disabled], aria-disabled, or in disabled fieldset
 	CheckEditable                          // enabled + not readonly + valid text input type
 )
@@ -28,12 +28,13 @@ var (
 
 // actionableResult is the JSON structure returned by the combined actionability script.
 type actionableResult struct {
-	Status string  `json:"status"` // "ok", "not_found", "failed"
-	Check  string  `json:"check,omitempty"`
-	Reason string  `json:"reason,omitempty"`
-	Tag    string  `json:"tag,omitempty"`
-	Text   string  `json:"text,omitempty"`
-	Box    BoxInfo `json:"box,omitempty"`
+	Status string    `json:"status"` // "ok", "not_found", "failed"
+	Check  string    `json:"check,omitempty"`
+	Reason string    `json:"reason,omitempty"`
+	Tag    string    `json:"tag,omitempty"`
+	Text   string    `json:"text,omitempty"`
+	Box    BoxInfo   `json:"box,omitempty"`
+	Point  PointInfo `json:"point,omitempty"`
 }
 
 // checksContain returns true if the check set includes the given check.
@@ -102,7 +103,8 @@ func buildCSSActionableScript(ep ElementParams, checkVisible, checkReceivesEvent
 				status:'ok',
 				tag: el.tagName.toLowerCase(),
 				text: (el.innerText || '').trim(),
-				box: { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+				box: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+				point: { x: px, y: py }
 			});
 		}
 	`
@@ -155,7 +157,8 @@ func buildSemanticActionableScript(ep ElementParams, checkVisible, checkReceives
 				status:'ok',
 				tag: el.tagName.toLowerCase(),
 				text: (el.innerText || '').trim(),
-				box: { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+				box: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+				point: { x: px, y: py }
 			});
 		}
 	`
@@ -184,8 +187,24 @@ const EditablePredicateJS = `(!el.disabled && !el.readOnly && el.getAttribute('a
 		: (el.tagName.toLowerCase() === 'textarea' || el.isContentEditable)
 ))`
 
+// InViewCenterJS is a JS statement block, evaluated with `rect` in scope, that
+// declares px/py as the pointer target: the in-view centre (centre of
+// rect ∩ viewport, per WebDriver). The full-rect centre sits off-screen for
+// any element taller or wider than twice the viewport, so hit-testing there
+// reported a false "obscured" and pointer actions landed out of bounds (#340).
+// Falls back to the rect centre when the element is entirely outside the
+// viewport, preserving the old failure mode.
+const InViewCenterJS = `
+			let px = rect.x + rect.width/2, py = rect.y + rect.height/2;
+			{
+				const il = Math.max(0, rect.x), it = Math.max(0, rect.y);
+				const ir = Math.min(window.innerWidth, rect.x + rect.width);
+				const ib = Math.min(window.innerHeight, rect.y + rect.height);
+				if (ir > il && ib > it) { px = (il + ir) / 2; py = (it + ib) / 2; }
+			}`
+
 func actionabilityCheckBody() string {
-	return `
+	return InViewCenterJS + `
 			if (chkVisible) {
 				if (rect.width === 0 || rect.height === 0)
 					return JSON.stringify({status:'failed', check:'visible', reason:'zero size'});
@@ -227,13 +246,12 @@ func actionabilityCheckBody() string {
 				}
 			}
 			if (chkEvents) {
-				const cx = rect.x + rect.width/2, cy = rect.y + rect.height/2;
 				// document.elementFromPoint stops at a shadow host, so an element
 				// inside a shadow root always looked obscured. Descend through
 				// each root at the same point to find what is really on top.
-				let hit = document.elementFromPoint(cx, cy);
+				let hit = document.elementFromPoint(px, py);
 				while (hit && hit.shadowRoot) {
-					const inner = hit.shadowRoot.elementFromPoint(cx, cy);
+					const inner = hit.shadowRoot.elementFromPoint(px, py);
 					if (!inner || inner === hit) break;
 					hit = inner;
 				}
@@ -295,7 +313,7 @@ func WaitForActionable(s Session, context string, ep ElementParams, checks []Act
 					result2, err2 := callActionableScript(s, context, script, args)
 					if err2 == nil && result2.Status == "ok" {
 						if result.Box == result2.Box {
-							return &ElementInfo{Tag: result2.Tag, Text: result2.Text, Box: result2.Box}, nil
+							return &ElementInfo{Tag: result2.Tag, Text: result2.Text, Box: result2.Box, Point: result2.Point}, nil
 						}
 						// Not stable — set lastResult to indicate instability and retry
 						lastResult = &actionableResult{
@@ -306,7 +324,7 @@ func WaitForActionable(s Session, context string, ep ElementParams, checks []Act
 					}
 					// If second call failed, retry the whole loop
 				} else {
-					return &ElementInfo{Tag: result.Tag, Text: result.Text, Box: result.Box}, nil
+					return &ElementInfo{Tag: result.Tag, Text: result.Text, Box: result.Box, Point: result.Point}, nil
 				}
 			}
 		}

--- a/clicker/internal/api/actionability.go
+++ b/clicker/internal/api/actionability.go
@@ -188,12 +188,12 @@ const EditablePredicateJS = `(!el.disabled && !el.readOnly && el.getAttribute('a
 ))`
 
 // InViewCenterJS is a JS statement block, evaluated with `rect` in scope, that
-// declares px/py as the pointer target: the in-view centre (centre of
-// rect ∩ viewport, per WebDriver). The full-rect centre sits off-screen for
-// any element taller or wider than twice the viewport, so hit-testing there
-// reported a false "obscured" and pointer actions landed out of bounds (#340).
-// Falls back to the rect centre when the element is entirely outside the
-// viewport, preserving the old failure mode.
+// declares px/py as the pointer target: the in-view center (the center of the
+// rect clamped to the viewport, per WebDriver). The full-rect center sits
+// off-screen for any element taller or wider than twice the viewport, so
+// hit-testing there reported a false "obscured" and pointer actions landed
+// out of bounds (#340). Falls back to the rect center when the element is
+// entirely outside the viewport, preserving the old failure mode.
 const InViewCenterJS = `
 			let px = rect.x + rect.width/2, py = rect.y + rect.height/2;
 			{

--- a/clicker/internal/api/handlers_elements.go
+++ b/clicker/internal/api/handlers_elements.go
@@ -12,6 +12,9 @@ type ElementInfo struct {
 	Tag  string  `json:"tag"`
 	Text string  `json:"text"`
 	Box  BoxInfo `json:"box"`
+	// Point is the in-view centre computed by the actionability script.
+	// Zero when the element was resolved without actionability checks.
+	Point PointInfo `json:"point"`
 }
 
 type BoxInfo struct {
@@ -19,6 +22,12 @@ type BoxInfo struct {
 	Y      float64 `json:"y"`
 	Width  float64 `json:"width"`
 	Height float64 `json:"height"`
+}
+
+// PointInfo is a viewport coordinate pair.
+type PointInfo struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
 }
 
 // handleVibiumFind handles the vibium:element.find / vibium:page.find command with wait-for-selector.

--- a/clicker/internal/api/handlers_elements.go
+++ b/clicker/internal/api/handlers_elements.go
@@ -12,7 +12,7 @@ type ElementInfo struct {
 	Tag  string  `json:"tag"`
 	Text string  `json:"text"`
 	Box  BoxInfo `json:"box"`
-	// Point is the in-view centre computed by the actionability script.
+	// Point is the in-view center computed by the actionability script.
 	// Zero when the element was resolved without actionability checks.
 	Point PointInfo `json:"point"`
 }

--- a/clicker/internal/api/handlers_input.go
+++ b/clicker/internal/api/handlers_input.go
@@ -325,8 +325,7 @@ func (r *Router) handlePageScroll(session *BrowserSession, cmd bidiCommand) {
 			r.sendError(session, cmd.ID, err)
 			return
 		}
-		x = int(info.Box.X + info.Box.Width/2)
-		y = int(info.Box.Y + info.Box.Height/2)
+		x, y = pointerTarget(info)
 	}
 
 	// Map direction to deltas (120 pixels per scroll "notch")

--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -383,10 +383,8 @@ func (r *Router) handleVibiumDragTo(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 
-	srcX := int(srcInfo.Box.X + srcInfo.Box.Width/2)
-	srcY := int(srcInfo.Box.Y + srcInfo.Box.Height/2)
-	dstX := int(targetInfo.Box.X + targetInfo.Box.Width/2)
-	dstY := int(targetInfo.Box.Y + targetInfo.Box.Height/2)
+	srcX, srcY := pointerTarget(srcInfo)
+	dstX, dstY := pointerTarget(targetInfo)
 
 	dragParams := map[string]interface{}{
 		"context": context,
@@ -588,10 +586,21 @@ func (r *Router) pressKey(session *BrowserSession, context, key string) error {
 // Exported standalone input primitives — usable from both proxy and MCP.
 // ---------------------------------------------------------------------------
 
+// pointerTarget returns the viewport coordinates for pointer actions on an
+// element: the in-view centre from the actionability script when present,
+// else the bounding-box centre (plain and forced resolutions). The box centre
+// sits outside the viewport for elements larger than twice the viewport, and
+// out-of-bounds pointer coordinates are a WebDriver error (#340).
+func pointerTarget(info *ElementInfo) (int, int) {
+	if info.Point.X != 0 || info.Point.Y != 0 {
+		return int(info.Point.X), int(info.Point.Y)
+	}
+	return int(info.Box.X + info.Box.Width/2), int(info.Box.Y + info.Box.Height/2)
+}
+
 // ClickAtCenter performs a mouse click at the center of an element.
 func ClickAtCenter(s Session, context string, info *ElementInfo) error {
-	x := int(info.Box.X + info.Box.Width/2)
-	y := int(info.Box.Y + info.Box.Height/2)
+	x, y := pointerTarget(info)
 
 	clickParams := map[string]interface{}{
 		"context": context,
@@ -617,8 +626,7 @@ func ClickAtCenter(s Session, context string, info *ElementInfo) error {
 
 // DblClickAtCenter performs a double-click at the center of an element.
 func DblClickAtCenter(s Session, context string, info *ElementInfo) error {
-	x := int(info.Box.X + info.Box.Width/2)
-	y := int(info.Box.Y + info.Box.Height/2)
+	x, y := pointerTarget(info)
 
 	dblclickParams := map[string]interface{}{
 		"context": context,
@@ -756,8 +764,7 @@ func Hover(s Session, context string, ep ElementParams) error {
 
 // HoverAtCenter moves the mouse to the center of an element without clicking.
 func HoverAtCenter(s Session, context string, info *ElementInfo) error {
-	x := int(info.Box.X + info.Box.Width/2)
-	y := int(info.Box.Y + info.Box.Height/2)
+	x, y := pointerTarget(info)
 
 	hoverParams := map[string]interface{}{
 		"context": context,
@@ -781,8 +788,7 @@ func HoverAtCenter(s Session, context string, info *ElementInfo) error {
 
 // TapAtCenter performs a touch tap at the center of an element.
 func TapAtCenter(s Session, context string, info *ElementInfo) error {
-	x := int(info.Box.X + info.Box.Width/2)
-	y := int(info.Box.Y + info.Box.Height/2)
+	x, y := pointerTarget(info)
 
 	tapParams := map[string]interface{}{
 		"context": context,
@@ -963,10 +969,8 @@ func DragTo(s Session, context string, source, target ElementParams) error {
 		return fmt.Errorf("target: %w", err)
 	}
 
-	srcX := int(srcInfo.Box.X + srcInfo.Box.Width/2)
-	srcY := int(srcInfo.Box.Y + srcInfo.Box.Height/2)
-	dstX := int(targetInfo.Box.X + targetInfo.Box.Width/2)
-	dstY := int(targetInfo.Box.Y + targetInfo.Box.Height/2)
+	srcX, srcY := pointerTarget(srcInfo)
+	dstX, dstY := pointerTarget(targetInfo)
 
 	dragParams := map[string]interface{}{
 		"context": context,

--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -587,8 +587,8 @@ func (r *Router) pressKey(session *BrowserSession, context, key string) error {
 // ---------------------------------------------------------------------------
 
 // pointerTarget returns the viewport coordinates for pointer actions on an
-// element: the in-view centre from the actionability script when present,
-// else the bounding-box centre (plain and forced resolutions). The box centre
+// element: the in-view center from the actionability script when present,
+// else the bounding-box center (plain and forced resolutions). The box center
 // sits outside the viewport for elements larger than twice the viewport, and
 // out-of-bounds pointer coordinates are a WebDriver error (#340).
 func pointerTarget(info *ElementInfo) (int, int) {

--- a/tests/cli/engine/actionability.test.js
+++ b/tests/cli/engine/actionability.test.js
@@ -211,3 +211,51 @@ describe('CLI: operation preconditions', () => {
     );
   });
 });
+
+describe('CLI: elements taller than the viewport (#340)', () => {
+  // The receivesEvents check used to hit-test at the full bounding-rect
+  // centre, which sits below the viewport for any element taller than twice
+  // the viewport height, so the only interactive element on the page was
+  // reported as permanently obscured. 5000px keeps the repro valid at any
+  // reasonable CI viewport size.
+  const tmpFile = path.join(os.tmpdir(), `vibium-tall-${process.pid}.html`);
+  const html =
+    '<html><body style="margin:0">' +
+    '<div style="position:relative;height:5000px;background:#ddd">x' +
+    '<div id="scrim" onclick="document.title=\'OK\'" ' +
+    'style="position:absolute;top:0;left:0;width:100%;height:100%;background:#333;opacity:.3;z-index:12"></div>' +
+    '</div></body></html>';
+  const fileURL = 'file://' + tmpFile;
+
+  test('setup: write tall-overlay fixture', () => {
+    fs.writeFileSync(tmpFile, html);
+  });
+
+  test('is actionable reports receivesEvents for a tall unobscured element', () => {
+    execSync(`${VIBIUM} go "${fileURL}"`, { encoding: 'utf-8', timeout: 30000 });
+    const result = execSync(`${VIBIUM} is actionable "#scrim"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /ReceivesEvents.*true/i, 'tall element must not read as obscured');
+  });
+
+  test('click succeeds on a tall element and lands inside the viewport', () => {
+    execSync(`${VIBIUM} go "${fileURL}"`, { encoding: 'utf-8', timeout: 30000 });
+    const result = execSync(`${VIBIUM} click "#scrim" --timeout 3s`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(result, /Clicked/i, 'click must not time out as obscured');
+
+    const title = execSync(`${VIBIUM} eval "document.title"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    assert.match(title, /OK/, 'click handler must have fired');
+  });
+
+  test('cleanup: remove tall-overlay fixture', () => {
+    fs.rmSync(tmpFile, { force: true });
+  });
+});

--- a/tests/cli/engine/actionability.test.js
+++ b/tests/cli/engine/actionability.test.js
@@ -214,7 +214,7 @@ describe('CLI: operation preconditions', () => {
 
 describe('CLI: elements taller than the viewport (#340)', () => {
   // The receivesEvents check used to hit-test at the full bounding-rect
-  // centre, which sits below the viewport for any element taller than twice
+  // center, which sits below the viewport for any element taller than twice
   // the viewport height, so the only interactive element on the page was
   // reported as permanently obscured. 5000px keeps the repro valid at any
   // reasonable CI viewport size.


### PR DESCRIPTION
Fixes VibiumDev/vibium#340

The receivesEvents actionability check calls elementFromPoint at the center of the element's full bounding rect. For an element taller than twice the viewport, that point is below the viewport, elementFromPoint returns null, and the check reports "element is obscured" when nothing obscures it. Since #173 the action retries for the whole actionability budget, so every occurrence burns the full timeout. The pointer path has the same defect: ClickAtCenter and friends target the rect center, which is an out-of-bounds coordinate for the same elements, so fixing only the check would have moved the failure from the hit-test to input.performActions.

The actionability script now computes the in-view center (rect clamped to the viewport, per the WebDriver in-view center definition) once, hit-tests there, and returns it as "point" alongside "box". The pointer helpers (click, dblclick, hover, tap, drag, scroll-at-element) use the returned point when present and keep the box-center fallback for elements resolved without actionability checks, whose behavior is unchanged. `vibium is actionable` had drifted into its own inline copy of the hit-test; both now share the InViewCenterJS snippet.

Verified:
- New tests in tests/cli/engine/actionability.test.js use the issue's overlay repro at 5000px height so the threshold (height > 2x viewport) holds at any CI viewport. On main, `is actionable` reports ReceivesEvents false and `click` times out obscured; with the fix all 4 pass, and `document.title` confirms the click handler fired inside the viewport.
- Full tests/cli/engine/actionability.test.js: 18/18. `go test ./...` in clicker/ green, gofmt and go vet clean on the touched files.