### PR TITLE
Dismiss sync-captured dialogs on arrival to unblock blocking triggers

### DIFF
--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -504,7 +504,7 @@ class Page:
         auto_dismiss dismisses the dialog the moment it is captured. The sync
         wrappers use it: they return only the dialog's data, so the caller has
         no handle to close the dialog with, and a dialog left open blocks the
-        page — including a trigger fn stuck inside evaluate("alert(...)"),
+        page, including a trigger fn stuck inside evaluate("alert(...)"),
         which otherwise deadlocks the capture (#146).
         """
         timeout_ms = timeout or 10000

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -498,8 +498,15 @@ class Page:
                 self._dialog_callbacks.remove(handler)
             raise errors.TimeoutError("Timeout waiting for dialog")
 
-    async def _setup_capture_dialog(self, timeout: Optional[int] = None) -> Any:
-        """Internal: set up dialog listener and return a coroutine to await later."""
+    async def _setup_capture_dialog(self, timeout: Optional[int] = None, auto_dismiss: bool = False) -> Any:
+        """Internal: set up dialog listener and return a coroutine to await later.
+
+        auto_dismiss dismisses the dialog the moment it is captured. The sync
+        wrappers use it: they return only the dialog's data, so the caller has
+        no handle to close the dialog with, and a dialog left open blocks the
+        page — including a trigger fn stuck inside evaluate("alert(...)"),
+        which otherwise deadlocks the capture (#146).
+        """
         timeout_ms = timeout or 10000
         future: asyncio.Future = asyncio.get_running_loop().create_future()
 
@@ -507,6 +514,8 @@ class Page:
             self._dialog_callbacks.remove(handler)
             if not future.done():
                 future.set_result(dialog)
+            if auto_dismiss:
+                asyncio.ensure_future(dialog.dismiss())
 
         self._dialog_callbacks.append(handler)
 

--- a/clients/python/src/vibium/sync_api/page.py
+++ b/clients/python/src/vibium/sync_api/page.py
@@ -717,7 +717,7 @@ class _SyncCapturedDialog:
 
     def __enter__(self) -> _SyncCapturedDialog:
         self._wait_coro = self._page._loop.run(
-            self._page._async._setup_capture_dialog(self._timeout)
+            self._page._async._setup_capture_dialog(self._timeout, auto_dismiss=True)
         )
         return self
 
@@ -813,10 +813,12 @@ class _SyncCaptureNamespace:
         return _SyncCapturedDownload(self._page, timeout)
 
     def dialog(self, fn: Optional[Callable] = None, timeout: Optional[int] = None) -> Union[Dict[str, Any], _SyncCapturedDialog]:
-        """Wait for a dialog event."""
+        """Wait for a dialog event. The dialog is dismissed as soon as it is
+        captured, so a fn that blocks on it (e.g. a synchronous alert() via
+        evaluate) gets unblocked instead of deadlocking."""
         if fn is not None:
             wait_coro = self._page._loop.run(
-                self._page._async._setup_capture_dialog(timeout)
+                self._page._async._setup_capture_dialog(timeout, auto_dismiss=True)
             )
             fn()
             dialog = self._page._loop.run(wait_coro)

--- a/tests/py/engine/test_sync_api.py
+++ b/tests/py/engine/test_sync_api.py
@@ -779,6 +779,37 @@ def test_capture_dialog(bro, test_server):
     vibe.close()
 
 
+@pytest.mark.capability("dialogs")
+def test_capture_dialog_fn_blocking_alert(bro, test_server):
+    """A fn that blocks inside evaluate("alert(...)") must not deadlock (#146).
+
+    alert() halts the page until the dialog is handled, so the capture has to
+    dismiss the dialog on arrival for the evaluate call to ever return.
+    """
+    vibe = bro.new_page()
+    vibe.go(test_server)
+    result = vibe.capture.dialog(lambda: vibe.evaluate('alert("blocking fn")'))
+    assert result["type"] == "alert"
+    assert result["message"] == "blocking fn"
+    # The dialog was dismissed, so the page must answer again.
+    assert vibe.evaluate("1 + 1") == 2
+    vibe.close()
+
+
+@pytest.mark.capability("dialogs")
+def test_capture_dialog_cm_blocking_alert(bro, test_server):
+    """Context-manager form of the same deadlock (#146)."""
+    vibe = bro.new_page()
+    vibe.go(test_server)
+    with vibe.capture.dialog() as info:
+        vibe.evaluate('alert("blocking cm")')
+    assert info.value is not None
+    assert info.value["type"] == "alert"
+    assert info.value["message"] == "blocking cm"
+    assert vibe.evaluate("1 + 1") == 2
+    vibe.close()
+
+
 # ===========================================================================
 # Capture event (1)
 # ===========================================================================


### PR DESCRIPTION
Fixes VibiumDev/vibium#146

The Python sync API's capture.dialog(fn) arms the dialog listener, runs fn on the calling thread, then awaits the captured dialog. When fn blocks until the dialog is handled, as evaluate("alert(...)") does, it never returns: registering a capture callback suppresses the client's auto-dismiss, the sync forms return only a dict of the dialog's data so the caller never gets a handle to accept or dismiss with, and the page stays blocked until the engine's 60s command timeout kills the evaluate. The with-block form deadlocks the same way. (The original report predates the engine's prompt tracker; today it surfaces as a 60s hang followed by a command timeout rather than an unbounded hang.)

The sync capture paths now pass auto_dismiss=True to _setup_capture_dialog, which dismisses the dialog as soon as the userPromptOpened event is captured. Dismissal unblocks the in-flight evaluate, fn completes, and the capture returns its dict. Since the sync forms cannot express accept-with-text anyway, dismissing matches the client's existing no-handler default. The async API is untouched and still yields a live Dialog for accept()/dismiss().

Verified:
- New tests test_capture_dialog_fn_blocking_alert and test_capture_dialog_cm_blocking_alert in tests/py/engine/test_sync_api.py, both asserting the page answers evaluate again afterwards. On main both fail with "Command 'vibium:page.eval' timed out after 60s"; with the fix they pass in under a second.
- All 36 dialog-related Python tests (pytest -k dialog across tests/py/) pass with the fix, including the async capture tests, which keep the live-Dialog behavior.