### PR TITLE
Keep the geolocation override across navigations

### DIFF
--- a/clicker/internal/api/handlers_emulation.go
+++ b/clicker/internal/api/handlers_emulation.go
@@ -400,38 +400,60 @@ func SetWindow(s Session, opts SetWindowOpts) error {
 	return checkBidiError(resp)
 }
 
-// geolocationScript is the JS that overrides navigator.geolocation.
-const geolocationScript = "(coordsJSON) => {\n" +
-	"const coords = JSON.parse(coordsJSON);\n" +
-	"const geo = navigator.geolocation;\n" +
-	"geo.getCurrentPosition = function(success, error, options) {\n" +
-	"  success({ coords: { latitude: coords.latitude, longitude: coords.longitude, accuracy: coords.accuracy,\n" +
-	"    altitude: null, altitudeAccuracy: null, heading: null, speed: null }, timestamp: Date.now() });\n" +
-	"};\n" +
-	"geo.watchPosition = function(success, error, options) {\n" +
-	"  success({ coords: { latitude: coords.latitude, longitude: coords.longitude, accuracy: coords.accuracy,\n" +
-	"    altitude: null, altitudeAccuracy: null, heading: null, speed: null }, timestamp: Date.now() });\n" +
-	"  return 0;\n" +
-	"};\n" +
-	"return 'ok';\n" +
-	"}"
+// geolocationScript returns the JS that overrides navigator.geolocation with
+// the given coordinates. The coordinates are baked into the declaration
+// because addPreloadScript passes no arguments to its function.
+//
+// The script is written to run any number of times in a document: the first
+// run installs an override that reads the coordinates from a window slot at
+// query time, later runs only update the slot. Repeated setGeolocation calls
+// stack one preload script each, and on a new document they all run in the
+// order they were added, so the last call wins without any script-removal
+// bookkeeping.
+func geolocationScript(coordsJSON string) string {
+	return "() => {\n" +
+		"window.__vibiumGeoCoords = " + coordsJSON + ";\n" +
+		"if (window.__vibiumGeoInstalled) return 'ok';\n" +
+		"window.__vibiumGeoInstalled = true;\n" +
+		"const pos = () => ({ coords: { latitude: window.__vibiumGeoCoords.latitude,\n" +
+		"  longitude: window.__vibiumGeoCoords.longitude, accuracy: window.__vibiumGeoCoords.accuracy,\n" +
+		"  altitude: null, altitudeAccuracy: null, heading: null, speed: null }, timestamp: Date.now() });\n" +
+		"const geo = navigator.geolocation;\n" +
+		"geo.getCurrentPosition = function(success, error, options) { success(pos()); };\n" +
+		"geo.watchPosition = function(success, error, options) { success(pos()); return 0; };\n" +
+		"return 'ok';\n" +
+		"}"
+}
 
-// SetGeolocation overrides the browser geolocation via a JS override.
+// SetGeolocation overrides the browser geolocation via a JS override, for the
+// current document and every later document in the context.
 func SetGeolocation(s Session, context string, lat, lon, accuracy float64) error {
 	coordsJSON, _ := json.Marshal(map[string]float64{
 		"latitude":  lat,
 		"longitude": lon,
 		"accuracy":  accuracy,
 	})
+	decl := geolocationScript(string(coordsJSON))
 
 	resp, err := s.SendBidiCommand("script.callFunction", map[string]interface{}{
-		"functionDeclaration": geolocationScript,
+		"functionDeclaration": decl,
 		"target":              map[string]interface{}{"context": context},
-		"arguments": []map[string]interface{}{
-			{"type": "string", "value": string(coordsJSON)},
-		},
-		"awaitPromise":    false,
-		"resultOwnership": "root",
+		"awaitPromise":        false,
+		"resultOwnership":     "root",
+	})
+	if err != nil {
+		return err
+	}
+	if err := checkBidiError(resp); err != nil {
+		return err
+	}
+
+	// The call above dies with the document, so a navigation or reload
+	// silently dropped the override (#345). Register the same script as a
+	// preload so every new document in this context gets it re-applied.
+	resp, err = s.SendBidiCommand("script.addPreloadScript", map[string]interface{}{
+		"functionDeclaration": decl,
+		"contexts":            []interface{}{context},
 	})
 	if err != nil {
 		return err

--- a/tests/js/async/engine/emulation.test.js
+++ b/tests/js/async/engine/emulation.test.js
@@ -181,4 +181,39 @@ describe('JS Emulation', () => {
     assert.ok(Math.abs(coords.lat - 51.5074) < 0.001, `latitude should be ~51.5074, got ${coords.lat}`);
     assert.ok(Math.abs(coords.lng - (-0.1278)) < 0.001, `longitude should be ~-0.1278, got ${coords.lng}`);
   });
+
+  const readCoords = `
+    new Promise((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(
+        pos => resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+        err => reject(new Error('geolocation error: ' + err.message)),
+        { timeout: 5000 }
+      );
+    })
+  `;
+
+  test('setGeolocation() survives a reload (#345)', async () => {
+    const vibe = await bro.page();
+    await vibe.setContent('<html><body></body></html>');
+    await vibe.setGeolocation({ latitude: 40.7128, longitude: -74.006 });
+
+    await vibe.reload();
+
+    const coords = await vibe.evaluate(readCoords);
+    assert.ok(Math.abs(coords.lat - 40.7128) < 0.001, `latitude should be ~40.7128 after reload, got ${coords.lat}`);
+    assert.ok(Math.abs(coords.lng - (-74.006)) < 0.001, `longitude should be ~-74.006 after reload, got ${coords.lng}`);
+  });
+
+  test('setGeolocation() survives a navigation, last call wins', async () => {
+    const vibe = await bro.page();
+    await vibe.setContent('<html><body></body></html>');
+    await vibe.setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+    await vibe.setGeolocation({ latitude: 35.6762, longitude: 139.6503 });
+
+    await vibe.go('about:blank');
+
+    const coords = await vibe.evaluate(readCoords);
+    assert.ok(Math.abs(coords.lat - 35.6762) < 0.001, `latitude should be ~35.6762 after navigation, got ${coords.lat}`);
+    assert.ok(Math.abs(coords.lng - 139.6503) < 0.001, `longitude should be ~139.6503 after navigation, got ${coords.lng}`);
+  });
 });


### PR DESCRIPTION
Fixes VibiumDev/vibium#345

setGeolocation injected its navigator.geolocation override with a one-shot script.callFunction, which dies with the document. After any navigation or reload the page silently returned to real geolocation behavior, exactly as the issue's browserleaks repro shows.

The override is now also registered as a preload script for the context, the same pattern clock and websocket monitoring already use, so every new document gets it re-applied. The script installs the override once per document and keeps the coordinates in a window slot read at query time: repeated setGeolocation calls each add one trivial preload entry, they run in add order on a new document, and the last call wins. That avoids script-removal bookkeeping, which would need per-context state that the shared SetGeolocation helper (also called directly by the MCP handler) has nowhere to keep.

Verified:
- Two new tests in tests/js/async/engine/emulation.test.js: override survives a reload, and survives a navigation with the last of two calls winning. Both fail on main (getCurrentPosition falls back to the real API and errors) and pass with the fix; the full emulation file is 19/19.
- go test ./internal/api/ green, gofmt and go vet clean on the touched file.