### PR TITLE
Reap orphaned browser processes before launching

### DIFF
--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -140,6 +140,12 @@ func Launch(opts LaunchOptions) (*LaunchResult, error) {
 	}
 	log.Debug("found chromedriver", "path", chromedriverPath)
 
+	// Browsers left behind by a killed vibium accumulate until launches
+	// starve (#382); nothing else will ever reap them.
+	if cacheDir, err := paths.GetChromeForTestingDir(); err == nil {
+		process.ReapOrphans(cacheDir)
+	}
+
 	chromePath, err := paths.GetChromeExecutable()
 	if err != nil {
 		return nil, fmt.Errorf("Chrome not found")

--- a/clicker/internal/process/orphans.go
+++ b/clicker/internal/process/orphans.go
@@ -1,0 +1,93 @@
+package process
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// procEntry is one row of the process table.
+type procEntry struct {
+	pid  int
+	ppid int
+	cmd  string
+}
+
+// parseProcTable parses `ps -axo pid=,ppid=,command=` output.
+func parseProcTable(out string) []procEntry {
+	var entries []procEntry
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err1 := strconv.Atoi(fields[0])
+		ppid, err2 := strconv.Atoi(fields[1])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		entries = append(entries, procEntry{pid: pid, ppid: ppid, cmd: strings.Join(fields[2:], " ")})
+	}
+	return entries
+}
+
+// isVibiumCmd reports whether a command line runs the vibium binary. It looks
+// at the executable's base name only: matching the whole line would also hit
+// unrelated processes whose paths or arguments merely mention vibium (a user
+// named vibiumdev, an editor with the repo open).
+func isVibiumCmd(cmd string) bool {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return false
+	}
+	base := filepath.Base(fields[0])
+	return base == "vibium" || base == "vibium.exe"
+}
+
+// orphanPIDs returns the pids of processes whose command line references
+// pathMarker (vibium's browser cache dir) and that have no live vibium
+// ancestor. Only vibium launches browsers out of that directory, so a
+// chromedriver or Chrome without a vibium ancestor lost its owner (killed
+// agent, crashed daemon) and nothing will ever clean it up. Enough of these
+// accumulate and browser_start starves (#382).
+//
+// The ancestry walk is what keeps concurrent sessions safe: another live
+// vibium's chromedriver has that vibium as its parent, and its Chrome and
+// helper processes reach it transitively.
+func orphanPIDs(entries []procEntry, pathMarker string, selfPID int) []int {
+	byPid := make(map[int]procEntry, len(entries))
+	for _, e := range entries {
+		byPid[e.pid] = e
+	}
+
+	hasVibiumAncestor := func(e procEntry) bool {
+		seen := map[int]bool{}
+		for cur := e; !seen[cur.pid]; {
+			seen[cur.pid] = true
+			parent, ok := byPid[cur.ppid]
+			if !ok {
+				return false
+			}
+			if isVibiumCmd(parent.cmd) {
+				return true
+			}
+			cur = parent
+		}
+		return false
+	}
+
+	var out []int
+	for _, e := range entries {
+		if e.pid <= 1 || e.pid == selfPID {
+			continue
+		}
+		if !strings.Contains(e.cmd, pathMarker) {
+			continue
+		}
+		if hasVibiumAncestor(e) {
+			continue
+		}
+		out = append(out, e.pid)
+	}
+	return out
+}

--- a/clicker/internal/process/orphans_test.go
+++ b/clicker/internal/process/orphans_test.go
@@ -1,0 +1,123 @@
+package process
+
+import (
+	"reflect"
+	"testing"
+)
+
+const marker = "/Users/u/Library/Caches/vibium/chrome-for-testing"
+
+func TestParseProcTable(t *testing.T) {
+	out := "  101     1 /usr/sbin/thing --flag\n" +
+		"  202   101 /Users/u/Library/Caches/vibium/chrome-for-testing/152.0/chromedriver --port=9515\n" +
+		"garbage line\n" +
+		"  303   202 /path with spaces/Google Chrome for Testing --type=renderer\n"
+	got := parseProcTable(out)
+	want := []procEntry{
+		{pid: 101, ppid: 1, cmd: "/usr/sbin/thing --flag"},
+		{pid: 202, ppid: 101, cmd: "/Users/u/Library/Caches/vibium/chrome-for-testing/152.0/chromedriver --port=9515"},
+		{pid: 303, ppid: 202, cmd: "/path with spaces/Google Chrome for Testing --type=renderer"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseProcTable:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+func TestOrphanPIDs(t *testing.T) {
+	cd := marker + "/152.0/chromedriver --port=9515"
+	chrome := marker + "/152.0/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing --remote-debugging-port=0"
+
+	tests := []struct {
+		name    string
+		entries []procEntry
+		want    []int
+	}{
+		{
+			name: "chromedriver reparented to init is an orphan, and so is its chrome",
+			entries: []procEntry{
+				{pid: 1, ppid: 0, cmd: "/sbin/launchd"},
+				{pid: 10, ppid: 1, cmd: cd},
+				{pid: 11, ppid: 10, cmd: chrome},
+			},
+			want: []int{10, 11},
+		},
+		{
+			name: "chain owned by a live vibium survives",
+			entries: []procEntry{
+				{pid: 1, ppid: 0, cmd: "/sbin/launchd"},
+				{pid: 5, ppid: 1, cmd: "/usr/local/bin/vibium serve"},
+				{pid: 10, ppid: 5, cmd: cd},
+				{pid: 11, ppid: 10, cmd: chrome},
+			},
+			want: nil,
+		},
+		{
+			name: "another tool's chromedriver outside the cache dir is ignored",
+			entries: []procEntry{
+				{pid: 1, ppid: 0, cmd: "/sbin/launchd"},
+				{pid: 20, ppid: 1, cmd: "/opt/selenium/chromedriver --port=4444"},
+			},
+			want: nil,
+		},
+		{
+			name: "vibium in an unrelated path does not confer ownership",
+			entries: []procEntry{
+				{pid: 1, ppid: 0, cmd: "/sbin/launchd"},
+				// e.g. a shell or editor belonging to a user named vibiumdev
+				{pid: 30, ppid: 1, cmd: "/bin/zsh /Users/vibiumdev/run.sh"},
+				{pid: 31, ppid: 30, cmd: cd},
+			},
+			want: []int{31},
+		},
+		{
+			name: "orphan reparented to a subreaper that is not vibium",
+			entries: []procEntry{
+				{pid: 1, ppid: 0, cmd: "/sbin/launchd"},
+				{pid: 40, ppid: 1, cmd: "/usr/lib/systemd/systemd --user"},
+				{pid: 41, ppid: 40, cmd: cd},
+			},
+			want: []int{41},
+		},
+		{
+			name: "ppid cycle terminates without owning anyone",
+			entries: []procEntry{
+				{pid: 50, ppid: 51, cmd: cd},
+				{pid: 51, ppid: 50, cmd: "/bin/thing"},
+			},
+			want: []int{50},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := orphanPIDs(tt.entries, marker, 999999)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrphanPIDsSkipsSelf(t *testing.T) {
+	entries := []procEntry{
+		{pid: 60, ppid: 1, cmd: marker + "/152.0/chromedriver"},
+	}
+	if got := orphanPIDs(entries, marker, 60); got != nil {
+		t.Fatalf("self pid must never be reaped, got %v", got)
+	}
+}
+
+func TestIsVibiumCmd(t *testing.T) {
+	yes := []string{"vibium serve", "/usr/local/bin/vibium daemon"}
+	no := []string{"", "/bin/zsh", "/Users/vibiumdev/notes vibium", "vibium-helper --x"}
+	for _, c := range yes {
+		if !isVibiumCmd(c) {
+			t.Errorf("isVibiumCmd(%q) = false, want true", c)
+		}
+	}
+	for _, c := range no {
+		if isVibiumCmd(c) {
+			t.Errorf("isVibiumCmd(%q) = true, want false", c)
+		}
+	}
+}

--- a/clicker/internal/process/orphans_unix.go
+++ b/clicker/internal/process/orphans_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/vibium/clicker/internal/log"
+)
+
+// ReapOrphans kills browser processes launched from pathMarker (vibium's
+// browser cache dir) that no longer have a live vibium ancestor. Best-effort:
+// a failure to scan or kill is logged and otherwise ignored, since the launch
+// this protects can still succeed.
+func ReapOrphans(pathMarker string) {
+	if pathMarker == "" {
+		return
+	}
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=,command=").Output()
+	if err != nil {
+		log.Debug("orphan scan failed", "error", err)
+		return
+	}
+	for _, pid := range orphanPIDs(parseProcTable(string(out)), pathMarker, os.Getpid()) {
+		log.Info("killing orphaned browser process", "pid", pid)
+		if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+			log.Debug("failed to kill orphaned process", "pid", pid, "error", err)
+		}
+	}
+}

--- a/clicker/internal/process/orphans_windows.go
+++ b/clicker/internal/process/orphans_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package process
+
+// ReapOrphans is a no-op on Windows: cleanup there kills by executable name
+// (see the daemon shutdown path), and the ps-based ancestry scan has no
+// direct equivalent.
+func ReapOrphans(pathMarker string) {}

--- a/tests/cli/process.test.js
+++ b/tests/cli/process.test.js
@@ -173,6 +173,54 @@ describe('CLI: Process Cleanup', () => {
     );
   });
 
+  test('launch reaps orphaned cache-dir browser processes (#382)', async (t) => {
+    // The reaper is ps-based and POSIX-only
+    if (process.platform === 'win32') {
+      t.skip('POSIX-only reap path');
+      return;
+    }
+
+    // A leaked chromedriver looks like: command line under vibium's
+    // chrome-for-testing cache dir, owning vibium process gone. Stand one up
+    // as a decoy script inside the real cache dir, orphaned.
+    const paths = JSON.parse(execSync(`${VIBIUM} paths --json`, { encoding: 'utf-8', timeout: 10000 }));
+    const dir = path.join(paths.result.cacheDir, 'chrome-for-testing', `test-orphan-${process.pid}`);
+    fs.mkdirSync(dir, { recursive: true });
+    const decoy = path.join(dir, 'chromedriver');
+    fs.writeFileSync(decoy, '#!/bin/sh\nsleep 120\n');
+    fs.chmodSync(decoy, 0o755);
+    const pid = Number(
+      spawnSync('sh', ['-c', `"${decoy}" > /dev/null 2>&1 & echo $!`], {
+        encoding: 'utf-8',
+        detached: true,
+      }).stdout.trim()
+    );
+    assert.ok(Number.isInteger(pid) && pid > 0, 'decoy failed to start');
+
+    try {
+      // Any launch triggers the reap; go through the daemon like a user would
+      execSync(`${VIBIUM} daemon stop`, { encoding: 'utf-8', timeout: 10000 });
+      execSync(`${VIBIUM} --headless go ${baseURL}/example`, { encoding: 'utf-8', timeout: 60000 });
+
+      await waitUntil(() => {
+        try {
+          process.kill(pid, 0);
+          return false;
+        } catch {
+          return true;
+        }
+      }, 'orphaned cache-dir decoy reaped by launch');
+
+      // The launch's own browser must have survived its reap
+      const result = execSync(`${VIBIUM} eval "1+1"`, { encoding: 'utf-8', timeout: 30000 });
+      assert.match(result, /2/, 'freshly launched browser should still answer');
+    } finally {
+      try { process.kill(pid, 'SIGKILL'); } catch {}
+      execSync(`${VIBIUM} daemon stop`, { encoding: 'utf-8', timeout: 30000 });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('shutdown cleanup ignores other tools\' chromedriver processes', async (t) => {
     // Cleanup on Windows kills by executable name, not command line
     if (process.platform === 'win32') {


### PR DESCRIPTION
Fixes VibiumDev/vibium#382

A vibium process that dies without cleanup (killed agent process, crashed daemon, disconnected MCP client) leaves its chromedriver and Chrome running, and nothing ever stops them. The reporter accumulated 12+ of these across two Chrome-for-Testing versions, at which point browser_start stopped responding. On current main the launch is time-bounded (#407), so this now presents as launches failing at their budget rather than a 10-minute hang, but the leaked processes still pile up and nothing cleans them.

Before each Chrome launch, the process table is scanned for entries whose command line is under vibium's chrome-for-testing cache dir and that have no live vibium ancestor. Only vibium launches browsers from that directory, so those are orphans by definition, and they are killed. The ancestry walk is what keeps concurrent sessions safe: a live vibium's chromedriver, its Chrome, and Chrome's helper processes all reach their owning vibium transitively, so they survive another session's reap. Ownership is judged by the executable's base name, never a substring of the whole command line, so a path that merely mentions vibium (a user named vibiumdev, another tool's chromedriver outside the cache dir) is not touched.

POSIX only (ps-based); Windows cleanup already kills by executable name and keeps its existing behavior.

Verified:
- Unit tests on the pure orphan-detection logic in clicker/internal/process/orphans_test.go: orphaned chromedriver plus its Chrome, vibium-owned chain survives, foreign chromedriver ignored, systemd-subreaper orphan, ppid cycle, self-pid guard, base-name ownership.
- New test in tests/cli/process.test.js plants an orphaned decoy inside the real cache dir, launches through the daemon, and asserts the decoy dies while the fresh browser still answers eval. Fails without the launcher wiring (decoy survives), passes with it.
- Manually verified on this machine that a second live session's browser survives another session's launch-time reap.
- go test ./internal/process/ green; gofmt and go vet clean.