### PR TITLE
Warn when a PATH vibium shadows the jar's packaged binary

### DIFF
--- a/clients/java/src/main/java/com/vibium/internal/BinaryResolver.java
+++ b/clients/java/src/main/java/com/vibium/internal/BinaryResolver.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Finds or extracts the vibium binary.
@@ -37,6 +38,7 @@ public final class BinaryResolver {
         // 2. PATH lookup
         String pathResult = findOnPath();
         if (pathResult != null) {
+            warnIfShadowingJar(pathResult);
             return pathResult;
         }
 
@@ -50,6 +52,79 @@ public final class BinaryResolver {
             "vibium binary not found. Install it via npm (npm install vibium), " +
             "set VIBIUM_BIN_PATH, or ensure it's on your PATH."
         );
+    }
+
+    private static volatile boolean shadowChecked = false;
+
+    /**
+     * A PATH install wins over the jar's packaged binary by the documented
+     * resolution order, but the jar version is the only thing a Maven build
+     * controls, and a version mismatch surfaces as protocol errors that do
+     * not point at versions at all. When the versions differ, say which
+     * binary actually runs (#331). Checked once per JVM.
+     */
+    private static void warnIfShadowingJar(String pathBinary) {
+        if (shadowChecked) {
+            return;
+        }
+        shadowChecked = true;
+
+        String jarVersion = readVersion();
+        boolean jarHasBinary = BinaryResolver.class.getClassLoader()
+            .getResource("natives/" + PlatformDetector.binaryName()) != null;
+        if (!jarHasBinary || "unknown".equals(jarVersion)) {
+            return;
+        }
+        String warning = shadowWarning(pathBinary, binaryVersion(pathBinary), jarVersion);
+        if (warning != null) {
+            System.err.println(warning);
+        }
+    }
+
+    /**
+     * The warning for a PATH binary shadowing the jar's packaged one, or null
+     * when the versions match or the PATH binary's version could not be read.
+     * Visible for testing.
+     */
+    static String shadowWarning(String pathBinary, String pathVersion, String jarVersion) {
+        if (pathVersion == null || pathVersion.equals(jarVersion)) {
+            return null;
+        }
+        return "[vibium] Using vibium " + pathVersion + " from PATH (" + pathBinary
+            + "), not the " + jarVersion + " binary packaged in this jar."
+            + " Set VIBIUM_BIN_PATH to pick one explicitly.";
+    }
+
+    /** Version reported by {@code binary --version}, or null when it cannot be read. */
+    private static String binaryVersion(String binary) {
+        try {
+            Process p = new ProcessBuilder(binary, "--version")
+                .redirectErrorStream(true)
+                .start();
+            if (!p.waitFor(5, TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+                return null;
+            }
+            return parseVersion(new String(readAllBytes(p.getInputStream())).trim());
+        } catch (IOException e) {
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+    }
+
+    /**
+     * Extracts the version number from {@code --version} output such as
+     * "vibium v26.8.21". Visible for testing.
+     */
+    static String parseVersion(String output) {
+        if (output == null) {
+            return null;
+        }
+        String firstLine = output.split("\\R", 2)[0];
+        String version = firstLine.replaceAll("^[^0-9]*", "");
+        return version.isEmpty() ? null : version;
     }
 
     private static String findOnPath() {

--- a/clients/java/src/test/java/com/vibium/internal/BinaryShadowWarningTest.java
+++ b/clients/java/src/test/java/com/vibium/internal/BinaryShadowWarningTest.java
@@ -1,0 +1,47 @@
+package com.vibium.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A PATH install shadowing the jar's packaged binary must be called out when
+ * the versions differ, and stay silent when they match or cannot be compared
+ * (#331).
+ */
+class BinaryShadowWarningTest {
+
+    @Test
+    void differingVersionsProduceAWarningNamingBoth() {
+        String w = BinaryResolver.shadowWarning("/usr/local/bin/vibium", "26.5.31", "26.8.21");
+        assertNotNull(w);
+        assertTrue(w.contains("26.5.31"), "warning should name the PATH binary's version");
+        assertTrue(w.contains("26.8.21"), "warning should name the jar's version");
+        assertTrue(w.contains("/usr/local/bin/vibium"), "warning should name the binary that runs");
+        assertTrue(w.contains("VIBIUM_BIN_PATH"), "warning should say how to override");
+    }
+
+    @Test
+    void matchingVersionsStaySilent() {
+        assertNull(BinaryResolver.shadowWarning("/usr/local/bin/vibium", "26.8.21", "26.8.21"));
+    }
+
+    @Test
+    void unreadablePathVersionStaysSilent() {
+        assertNull(BinaryResolver.shadowWarning("/usr/local/bin/vibium", null, "26.8.21"));
+    }
+
+    @Test
+    void parseVersionHandlesTypicalOutput() {
+        assertEquals("26.8.21", BinaryResolver.parseVersion("vibium v26.8.21"));
+        assertEquals("26.8.21", BinaryResolver.parseVersion("vibium 26.8.21"));
+        assertEquals("26.8.21", BinaryResolver.parseVersion("vibium v26.8.21\nextra line"));
+    }
+
+    @Test
+    void parseVersionReturnsNullWhenThereIsNoNumber() {
+        assertNull(BinaryResolver.parseVersion(""));
+        assertNull(BinaryResolver.parseVersion("command not found"));
+        assertNull(BinaryResolver.parseVersion(null));
+    }
+}


### PR DESCRIPTION
Fixes VibiumDev/vibium#331

The Java client resolves the binary as VIBIUM_BIN_PATH, then PATH, then the jar's packaged binary. A Maven consumer controls only the jar version, yet a PATH install (usually npm, on its own upgrade cycle) silently wins. The issue describes the result: a build pinned to a locally published jar kept running /usr/bin/vibium, and every failure looked like a protocol bug rather than a version mismatch.

When resolution picks a PATH binary, the jar packages a binary for this platform, and their versions differ, the client now prints one warning per JVM naming both versions, the path of the binary that actually runs, and VIBIUM_BIN_PATH as the explicit override. The version of the PATH binary comes from running it with --version once, capped at five seconds; if that fails the warning is skipped rather than guessed. Resolution order is unchanged.

Two decisions to confirm:
- The issue's first-choice fix was flipping the order so the jar wins for Maven consumers. That changes documented behavior, so this PR does the warning only; the flip is a two-line follow-up if wanted.
- The --version probe is a shell-out to the vibium binary. The launch-code rule in CLAUDE.md exists to route installs through pipe; a version query does not launch or install anything, but flagging it since the rule reads broader than that. The fallback is warning unconditionally whenever PATH shadows a packaged binary, with no version comparison.

Verified:
- New BinaryShadowWarningTest covers the pure logic: differing versions produce a warning naming both versions, the running binary, and the override; matching or unreadable versions stay silent; --version output parsing including multi-line and no-number cases. 5/5 pass.
- Full com.vibium.internal.* unit suite green. The tests pin new behavior, so there is no fails-on-main repro; the change is a request for visibility, not a defect fix.