### PR TITLE
Add print options to PDF generation

### DIFF
--- a/clicker/cmd/clicker/pdf.go
+++ b/clicker/cmd/clicker/pdf.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -14,7 +15,14 @@ func newPDFCmd() *cobra.Command {
   # Save current page as PDF
 
   vibium pdf https://example.com -o page.pdf
-  # Navigate to URL first, then save as PDF`,
+  # Navigate to URL first, then save as PDF
+
+  vibium pdf https://example.com -o report.pdf --landscape --scale 0.8 --background
+  # Landscape at 80% scale with background graphics
+  # PDF saved to report.pdf (183940 bytes)
+
+  vibium pdf -o excerpt.pdf --page-ranges 1,3-5 --margin 2
+  # Pages 1 and 3-5 with 2cm margins on all sides`,
 		Args: cobra.RangeArgs(0, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			output, _ := cmd.Flags().GetString("output")
@@ -34,7 +42,42 @@ func newPDFCmd() *cobra.Command {
 				}
 			}
 
-			result, err := daemonCall("browser_pdf", map[string]interface{}{"filename": output})
+			callArgs := map[string]interface{}{"filename": output}
+			if v, _ := cmd.Flags().GetBool("landscape"); v {
+				callArgs["landscape"] = true
+			}
+			if cmd.Flags().Changed("scale") {
+				v, _ := cmd.Flags().GetFloat64("scale")
+				callArgs["scale"] = v
+			}
+			if v, _ := cmd.Flags().GetBool("background"); v {
+				callArgs["background"] = true
+			}
+			if cmd.Flags().Changed("margin") {
+				v, _ := cmd.Flags().GetFloat64("margin")
+				for _, side := range []string{"marginTop", "marginBottom", "marginLeft", "marginRight"} {
+					callArgs[side] = v
+				}
+			}
+			if cmd.Flags().Changed("page-width") {
+				v, _ := cmd.Flags().GetFloat64("page-width")
+				callArgs["pageWidth"] = v
+			}
+			if cmd.Flags().Changed("page-height") {
+				v, _ := cmd.Flags().GetFloat64("page-height")
+				callArgs["pageHeight"] = v
+			}
+			if ranges, _ := cmd.Flags().GetString("page-ranges"); ranges != "" {
+				var list []interface{}
+				for _, r := range strings.Split(ranges, ",") {
+					if r = strings.TrimSpace(r); r != "" {
+						list = append(list, r)
+					}
+				}
+				callArgs["pageRanges"] = list
+			}
+
+			result, err := daemonCall("browser_pdf", callArgs)
 			if err != nil {
 				printError(err)
 				return
@@ -43,5 +86,12 @@ func newPDFCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP("output", "o", "page.pdf", "Output file path")
+	cmd.Flags().Bool("landscape", false, "Landscape orientation")
+	cmd.Flags().Float64("scale", 1, "Print scale, 0.1-2")
+	cmd.Flags().Bool("background", false, "Print background graphics")
+	cmd.Flags().Float64("margin", 1, "Margin on all sides in cm")
+	cmd.Flags().Float64("page-width", 21.59, "Page width in cm")
+	cmd.Flags().Float64("page-height", 27.94, "Page height in cm")
+	cmd.Flags().String("page-ranges", "", "Pages to print, e.g. 1,3-5 (default all)")
 	return cmd
 }

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -3016,7 +3016,9 @@ func (h *Handlers) browserPDF(args map[string]interface{}) (*ToolsCallResult, er
 	if err != nil {
 		return nil, err
 	}
-	base64Data, err := api.PrintToPDF(s, ctx)
+	// args carries the print options under the same keys the wire command
+	// uses; extra keys like filename are ignored by the translation.
+	base64Data, err := api.PrintToPDF(s, ctx, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to print PDF: %w", err)
 	}

--- a/clicker/internal/agent/schema.go
+++ b/clicker/internal/agent/schema.go
@@ -818,6 +818,51 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "Output filename for the PDF (e.g., page.pdf)",
 					},
+					"landscape": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Landscape orientation (default: portrait)",
+					},
+					"scale": map[string]interface{}{
+						"type":        "number",
+						"description": "Print scale, 0.1-2 (default: 1)",
+					},
+					"background": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Print background graphics (default: false)",
+					},
+					"marginTop": map[string]interface{}{
+						"type":        "number",
+						"description": "Top margin in cm (default: 1)",
+					},
+					"marginBottom": map[string]interface{}{
+						"type":        "number",
+						"description": "Bottom margin in cm (default: 1)",
+					},
+					"marginLeft": map[string]interface{}{
+						"type":        "number",
+						"description": "Left margin in cm (default: 1)",
+					},
+					"marginRight": map[string]interface{}{
+						"type":        "number",
+						"description": "Right margin in cm (default: 1)",
+					},
+					"pageWidth": map[string]interface{}{
+						"type":        "number",
+						"description": "Page width in cm (default: 21.59)",
+					},
+					"pageHeight": map[string]interface{}{
+						"type":        "number",
+						"description": "Page height in cm (default: 27.94)",
+					},
+					"pageRanges": map[string]interface{}{
+						"type":        "array",
+						"items":       map[string]interface{}{"type": []string{"string", "integer"}},
+						"description": "Pages to print, e.g. [1, \"3-5\"] (default: all)",
+					},
+					"shrinkToFit": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Shrink content to fit the page width (default: true)",
+					},
 				},
 				"additionalProperties": false,
 			},

--- a/clicker/internal/api/handlers_capture.go
+++ b/clicker/internal/api/handlers_capture.go
@@ -58,6 +58,56 @@ func (r *Router) handlePageScreenshot(session *BrowserSession, cmd bidiCommand) 
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"data": ssResult.Result.Data})
 }
 
+// printParams translates vibium:page.pdf options into browsingContext.print
+// parameters. Only options the caller set are sent, so everything else keeps
+// the browser's own default (portrait, scale 1, 1cm margins, no background,
+// letter-size page, all pages, shrink to fit).
+func printParams(context string, opts map[string]interface{}) map[string]interface{} {
+	p := map[string]interface{}{"context": context}
+
+	if v, ok := opts["landscape"].(bool); ok && v {
+		p["orientation"] = "landscape"
+	}
+	if v, ok := opts["scale"].(float64); ok {
+		p["scale"] = v
+	}
+	if v, ok := opts["background"].(bool); ok {
+		p["background"] = v
+	}
+	if v, ok := opts["shrinkToFit"].(bool); ok {
+		p["shrinkToFit"] = v
+	}
+
+	margin := map[string]interface{}{}
+	for wire, bidi := range map[string]string{
+		"marginTop": "top", "marginBottom": "bottom",
+		"marginLeft": "left", "marginRight": "right",
+	} {
+		if v, ok := opts[wire].(float64); ok {
+			margin[bidi] = v
+		}
+	}
+	if len(margin) > 0 {
+		p["margin"] = margin
+	}
+
+	page := map[string]interface{}{}
+	if v, ok := opts["pageWidth"].(float64); ok {
+		page["width"] = v
+	}
+	if v, ok := opts["pageHeight"].(float64); ok {
+		page["height"] = v
+	}
+	if len(page) > 0 {
+		p["page"] = page
+	}
+
+	if v, ok := opts["pageRanges"].([]interface{}); ok && len(v) > 0 {
+		p["pageRanges"] = v
+	}
+	return p
+}
+
 // handlePagePDF handles vibium:page.pdf — prints the page to PDF.
 // Returns base64-encoded PDF data.
 func (r *Router) handlePagePDF(session *BrowserSession, cmd bidiCommand) {
@@ -67,11 +117,7 @@ func (r *Router) handlePagePDF(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 
-	printParams := map[string]interface{}{
-		"context": context,
-	}
-
-	resp, err := r.sendInternalCommand(session, "browsingContext.print", printParams)
+	resp, err := r.sendInternalCommand(session, "browsingContext.print", printParams(context, cmd.Params))
 	if err != nil {
 		r.sendError(session, cmd.ID, err)
 		return
@@ -128,10 +174,11 @@ func Screenshot(s Session, context string, fullPage bool) (string, error) {
 }
 
 // PrintToPDF prints the page to PDF and returns base64-encoded PDF data.
-func PrintToPDF(s Session, context string) (string, error) {
-	resp, err := s.SendBidiCommand("browsingContext.print", map[string]interface{}{
-		"context": context,
-	})
+// opts takes the same keys as vibium:page.pdf (landscape, scale, background,
+// marginTop/Bottom/Left/Right, pageWidth, pageHeight, pageRanges,
+// shrinkToFit); nil means all defaults.
+func PrintToPDF(s Session, context string, opts map[string]interface{}) (string, error) {
+	resp, err := s.SendBidiCommand("browsingContext.print", printParams(context, opts))
 	if err != nil {
 		return "", err
 	}

--- a/clicker/internal/api/print_params_test.go
+++ b/clicker/internal/api/print_params_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+// vibium:page.pdf options must translate to browsingContext.print parameters,
+// and options the caller did not set must not appear at all, so the browser's
+// own defaults stay in charge (#72).
+func TestPrintParams(t *testing.T) {
+	t.Run("no options sends only the context", func(t *testing.T) {
+		got := printParams("ctx1", nil)
+		want := map[string]interface{}{"context": "ctx1"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unrelated wire keys are ignored", func(t *testing.T) {
+		got := printParams("ctx1", map[string]interface{}{"filename": "x.pdf", "context": "ctx1"})
+		want := map[string]interface{}{"context": "ctx1"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("all options translate to the BiDi shapes", func(t *testing.T) {
+		got := printParams("ctx1", map[string]interface{}{
+			"landscape":    true,
+			"scale":        0.8,
+			"background":   true,
+			"marginTop":    2.0,
+			"marginBottom": 2.0,
+			"marginLeft":   1.5,
+			"marginRight":  1.5,
+			"pageWidth":    29.7,
+			"pageHeight":   21.0,
+			"pageRanges":   []interface{}{float64(1), "3-5"},
+			"shrinkToFit":  false,
+		})
+		want := map[string]interface{}{
+			"context":     "ctx1",
+			"orientation": "landscape",
+			"scale":       0.8,
+			"background":  true,
+			"margin":      map[string]interface{}{"top": 2.0, "bottom": 2.0, "left": 1.5, "right": 1.5},
+			"page":        map[string]interface{}{"width": 29.7, "height": 21.0},
+			"pageRanges":  []interface{}{float64(1), "3-5"},
+			"shrinkToFit": false,
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v\nwant %v", got, want)
+		}
+	})
+
+	t.Run("landscape false is portrait, the default, so nothing is sent", func(t *testing.T) {
+		got := printParams("ctx1", map[string]interface{}{"landscape": false})
+		if _, ok := got["orientation"]; ok {
+			t.Fatalf("landscape:false must not send an orientation, got %v", got)
+		}
+	})
+
+	t.Run("partial margins send only the set sides", func(t *testing.T) {
+		got := printParams("ctx1", map[string]interface{}{"marginTop": 3.0})
+		want := map[string]interface{}{"context": "ctx1", "margin": map[string]interface{}{"top": 3.0}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+}

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -240,7 +240,36 @@ public class Page {
 
     /** Generate a PDF, returns PDF bytes (headless only). */
     public byte[] pdf() {
-        JsonObject result = client.send("vibium:page.pdf", contextParams());
+        return pdf(null);
+    }
+
+    /** Generate a PDF with print options, returns PDF bytes (headless only). */
+    public byte[] pdf(PdfOptions options) {
+        JsonObject params = contextParams();
+        if (options != null) {
+            if (options.landscape() != null) params.addProperty("landscape", options.landscape());
+            if (options.scale() != null) params.addProperty("scale", options.scale());
+            if (options.background() != null) params.addProperty("background", options.background());
+            if (options.marginTop() != null) params.addProperty("marginTop", options.marginTop());
+            if (options.marginBottom() != null) params.addProperty("marginBottom", options.marginBottom());
+            if (options.marginLeft() != null) params.addProperty("marginLeft", options.marginLeft());
+            if (options.marginRight() != null) params.addProperty("marginRight", options.marginRight());
+            if (options.pageWidth() != null) params.addProperty("pageWidth", options.pageWidth());
+            if (options.pageHeight() != null) params.addProperty("pageHeight", options.pageHeight());
+            if (options.shrinkToFit() != null) params.addProperty("shrinkToFit", options.shrinkToFit());
+            if (options.pageRanges() != null && !options.pageRanges().isEmpty()) {
+                JsonArray ranges = new JsonArray();
+                for (Object r : options.pageRanges()) {
+                    if (r instanceof Number) {
+                        ranges.add((Number) r);
+                    } else {
+                        ranges.add(String.valueOf(r));
+                    }
+                }
+                params.add("pageRanges", ranges);
+            }
+        }
+        JsonObject result = client.send("vibium:page.pdf", params);
         String data = result.get("data").getAsString();
         return Base64.getDecoder().decode(data);
     }

--- a/clients/java/src/main/java/com/vibium/types/PdfOptions.java
+++ b/clients/java/src/main/java/com/vibium/types/PdfOptions.java
@@ -1,0 +1,51 @@
+package com.vibium.types;
+
+import java.util.List;
+
+/**
+ * Options for printing a page to PDF. Unset options keep the browser's print
+ * defaults (portrait, scale 1, 1cm margins, no background, letter-size page,
+ * all pages, shrink to fit). Margins and page size are in cm.
+ */
+public class PdfOptions {
+    private Boolean landscape;
+    private Double scale;
+    private Boolean background;
+    private Double marginTop;
+    private Double marginBottom;
+    private Double marginLeft;
+    private Double marginRight;
+    private Double pageWidth;
+    private Double pageHeight;
+    private List<Object> pageRanges;
+    private Boolean shrinkToFit;
+
+    public PdfOptions landscape(boolean landscape) { this.landscape = landscape; return this; }
+    public PdfOptions scale(double scale) { this.scale = scale; return this; }
+    public PdfOptions background(boolean background) { this.background = background; return this; }
+    public PdfOptions marginTop(double cm) { this.marginTop = cm; return this; }
+    public PdfOptions marginBottom(double cm) { this.marginBottom = cm; return this; }
+    public PdfOptions marginLeft(double cm) { this.marginLeft = cm; return this; }
+    public PdfOptions marginRight(double cm) { this.marginRight = cm; return this; }
+    /** Set all four margins at once, in cm. */
+    public PdfOptions margin(double cm) {
+        return marginTop(cm).marginBottom(cm).marginLeft(cm).marginRight(cm);
+    }
+    public PdfOptions pageWidth(double cm) { this.pageWidth = cm; return this; }
+    public PdfOptions pageHeight(double cm) { this.pageHeight = cm; return this; }
+    /** Pages to print: integers and range strings, e.g. List.of(1, "3-5"). */
+    public PdfOptions pageRanges(List<Object> pageRanges) { this.pageRanges = pageRanges; return this; }
+    public PdfOptions shrinkToFit(boolean shrinkToFit) { this.shrinkToFit = shrinkToFit; return this; }
+
+    public Boolean landscape() { return landscape; }
+    public Double scale() { return scale; }
+    public Boolean background() { return background; }
+    public Double marginTop() { return marginTop; }
+    public Double marginBottom() { return marginBottom; }
+    public Double marginLeft() { return marginLeft; }
+    public Double marginRight() { return marginRight; }
+    public Double pageWidth() { return pageWidth; }
+    public Double pageHeight() { return pageHeight; }
+    public List<Object> pageRanges() { return pageRanges; }
+    public Boolean shrinkToFit() { return shrinkToFit; }
+}

--- a/clients/java/src/test/java/com/vibium/engine/PdfTest.java
+++ b/clients/java/src/test/java/com/vibium/engine/PdfTest.java
@@ -25,6 +25,9 @@ class PdfTest {
     @BeforeAll
     static void setup() {
         browser = Vibium.start(new StartOptions().headless(true));
+        // Firefox keeps the startup tab in the parent process until a
+        // navigation, where script-backed commands are refused.
+        browser.page().go("about:blank");
     }
 
     @AfterAll

--- a/clients/java/src/test/java/com/vibium/engine/PdfTest.java
+++ b/clients/java/src/test/java/com/vibium/engine/PdfTest.java
@@ -1,0 +1,58 @@
+package com.vibium.engine;
+
+import com.vibium.Browser;
+import com.vibium.Page;
+import com.vibium.Vibium;
+import com.vibium.types.PdfOptions;
+import com.vibium.types.StartOptions;
+import org.junit.jupiter.api.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * PDF print options (#72).
+ */
+@RequiresCapability("pdf")
+class PdfTest {
+
+    static Browser browser;
+    Page page;
+
+    @BeforeAll
+    static void setup() {
+        browser = Vibium.start(new StartOptions().headless(true));
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (browser != null) browser.stop();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        page = browser.page();
+    }
+
+    // The page dimensions land uncompressed in "/MediaBox [0 0 <w> <h>]".
+    private static double[] mediaBox(byte[] pdf) {
+        Matcher m = Pattern.compile("/MediaBox \\[0 0 ([\\d.]+) ([\\d.]+)\\]")
+            .matcher(new String(pdf, StandardCharsets.ISO_8859_1));
+        assertTrue(m.find(), "PDF should contain a parseable /MediaBox");
+        return new double[]{Double.parseDouble(m.group(1)), Double.parseDouble(m.group(2))};
+    }
+
+    @Test
+    void landscapeOptionSwapsOrientation() {
+        page.setContent("<p>hello</p>");
+
+        double[] portrait = mediaBox(page.pdf());
+        double[] landscape = mediaBox(page.pdf(new PdfOptions().landscape(true)));
+
+        assertTrue(portrait[1] > portrait[0], "portrait should be taller than wide");
+        assertTrue(landscape[0] > landscape[1], "landscape should be wider than tall");
+    }
+}

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -23,6 +23,32 @@ export interface ScreenshotOptions {
   clip?: { x: number; y: number; width: number; height: number };
 }
 
+/** Options for pdf(). Unset options keep the browser's print defaults. */
+export interface PdfOptions {
+  /** Landscape orientation (default: portrait). */
+  landscape?: boolean;
+  /** Print scale, 0.1-2 (default: 1). */
+  scale?: number;
+  /** Print background graphics (default: false). */
+  background?: boolean;
+  /** Top margin in cm (default: 1). */
+  marginTop?: number;
+  /** Bottom margin in cm (default: 1). */
+  marginBottom?: number;
+  /** Left margin in cm (default: 1). */
+  marginLeft?: number;
+  /** Right margin in cm (default: 1). */
+  marginRight?: number;
+  /** Page width in cm (default: 21.59). */
+  pageWidth?: number;
+  /** Page height in cm (default: 27.94). */
+  pageHeight?: number;
+  /** Pages to print, e.g. [1, '3-5'] (default: all). */
+  pageRanges?: Array<number | string>;
+  /** Shrink content to fit the page width (default: true). */
+  shrinkToFit?: boolean;
+}
+
 interface VibiumFindResult {
   tag: string;
   text: string;
@@ -533,9 +559,10 @@ export class Page {
   }
 
   /** Print the page to PDF. Returns a PDF buffer. Only works in headless mode. */
-  async pdf(): Promise<Buffer> {
+  async pdf(options?: PdfOptions): Promise<Buffer> {
     const result = await this.client.send<{ data: string }>('vibium:page.pdf', {
       context: this.contextId,
+      ...options,
     });
     return Buffer.from(result.data, 'base64');
   }

--- a/clients/javascript/src/sync/page.ts
+++ b/clients/javascript/src/sync/page.ts
@@ -8,7 +8,7 @@ import { BrowserContextSync } from './context';
 import { RouteSync, RouteRequest } from './route';
 import { DialogSync, DialogData } from './dialog';
 import { ElementInfo, SelectorOptions } from '../element';
-import { A11yNode, ScreenshotOptions, FindOptions } from '../page';
+import { A11yNode, ScreenshotOptions, PdfOptions, FindOptions } from '../page';
 
 const customInspect = Symbol.for('nodejs.util.inspect.custom');
 
@@ -292,8 +292,8 @@ export class PageSync {
     return Buffer.from(result.data, 'base64');
   }
 
-  pdf(): Buffer {
-    const result = this._bridge.call<{ data: string }>('page.pdf', [this._pageId]);
+  pdf(options?: PdfOptions): Buffer {
+    const result = this._bridge.call<{ data: string }>('page.pdf', [this._pageId, options]);
     return Buffer.from(result.data, 'base64');
   }
 

--- a/clients/javascript/src/sync/worker.ts
+++ b/clients/javascript/src/sync/worker.ts
@@ -345,8 +345,8 @@ const handlers: Record<string, Handler> = {
   },
 
   'page.pdf': async (args) => {
-    const [pageId] = args as [number];
-    const buffer = await getPage(pageId).pdf();
+    const [pageId, options] = args as [number, unknown];
+    const buffer = await getPage(pageId).pdf(options as any);
     return { data: buffer.toString('base64') };
   },
 

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -601,9 +601,39 @@ class Page:
         })
         return base64.b64decode(result["data"])
 
-    async def pdf(self) -> bytes:
-        """Print the page to PDF. Returns PDF bytes. Only works in headless mode."""
-        result = await self._client.send("vibium:page.pdf", {"context": self._context_id})
+    async def pdf(
+        self,
+        *,
+        landscape: Optional[bool] = None,
+        scale: Optional[float] = None,
+        background: Optional[bool] = None,
+        margin_top: Optional[float] = None,
+        margin_bottom: Optional[float] = None,
+        margin_left: Optional[float] = None,
+        margin_right: Optional[float] = None,
+        page_width: Optional[float] = None,
+        page_height: Optional[float] = None,
+        page_ranges: Optional[List[Union[int, str]]] = None,
+        shrink_to_fit: Optional[bool] = None,
+    ) -> bytes:
+        """Print the page to PDF. Returns PDF bytes. Only works in headless mode.
+
+        Unset options keep the browser's print defaults (portrait, scale 1,
+        1cm margins, no background, letter-size page, all pages). Margins and
+        page size are in cm; page_ranges takes ints and range strings, e.g.
+        [1, "3-5"].
+        """
+        params: Dict[str, Any] = {"context": self._context_id}
+        for key, val in [
+            ("landscape", landscape), ("scale", scale), ("background", background),
+            ("marginTop", margin_top), ("marginBottom", margin_bottom),
+            ("marginLeft", margin_left), ("marginRight", margin_right),
+            ("pageWidth", page_width), ("pageHeight", page_height),
+            ("pageRanges", page_ranges), ("shrinkToFit", shrink_to_fit),
+        ]:
+            if val is not None:
+                params[key] = val
+        result = await self._client.send("vibium:page.pdf", params)
         return base64.b64decode(result["data"])
 
     # --- Evaluation ---

--- a/clients/python/src/vibium/sync_api/page.py
+++ b/clients/python/src/vibium/sync_api/page.py
@@ -220,8 +220,11 @@ class Page:
     ) -> bytes:
         return self._loop.run(self._async.screenshot(full_page=full_page, clip=clip))
 
-    def pdf(self) -> bytes:
-        return self._loop.run(self._async.pdf())
+    def pdf(self, **options: Any) -> bytes:
+        """Print the page to PDF. Same keyword options as the async API:
+        landscape, scale, background, margin_top/bottom/left/right,
+        page_width, page_height, page_ranges, shrink_to_fit."""
+        return self._loop.run(self._async.pdf(**options))
 
     # --- Evaluation ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -36,7 +36,7 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 17 | Find a single element | `vibium:page.find` | `vibium find <sel>` | `browser_find` | `page.find(sel, opts?)` | `page.find(sel, **opts)` | `page.find(sel, options?)` |
 | 18 | Find all matching elements | `vibium:page.findAll` | `vibium find --all <sel>` | `browser_find_all` | `page.findAll(sel, opts?)` | `page.find_all(sel, **opts)` | `page.findAll(sel, options?)` |
 | 19 | Take a page screenshot | `vibium:page.screenshot` | `vibium screenshot` | `browser_screenshot` | `page.screenshot(opts?)` | `page.screenshot(opts?)` | `page.screenshot(options?)` |
-| 20 | Generate PDF | `vibium:page.pdf` | `vibium pdf` | `browser_pdf` | `page.pdf()` | `page.pdf()` | `page.pdf()` |
+| 20 | Generate PDF | `vibium:page.pdf` | `vibium pdf` | `browser_pdf` | `page.pdf(opts?)` | `page.pdf(**opts)` | `page.pdf(options?)` |
 | 21 | Evaluate JavaScript | `vibium:page.eval` | `vibium eval <expr>` | `browser_evaluate` | `page.evaluate(expr)` | `page.evaluate(expr)` | `page.evaluate(expr)` |
 | 22 | Add a script tag | `vibium:page.addScript` | ⬜ | ⬜ | `page.addScript(src)` | `page.add_script(src)` | `page.addScript(src)` |
 | 23 | Add a style tag | `vibium:page.addStyle` | ⬜ | ⬜ | `page.addStyle(src)` | `page.add_style(src)` | `page.addStyle(src)` |

--- a/tests/js/async/engine/input-eval.test.js
+++ b/tests/js/async/engine/input-eval.test.js
@@ -189,6 +189,51 @@ describe('Screenshots: options', () => {
     const header = buf.subarray(0, 5).toString('ascii');
     assert.ok(header.startsWith('%PDF'), `PDF should start with %PDF, got: ${header}`);
   });
+
+  // The page dimensions land uncompressed in the PDF's /MediaBox entry:
+  // "/MediaBox [0 0 <width> <height>]" in PDF points.
+  function mediaBox(buf) {
+    const match = buf.toString('latin1').match(/\/MediaBox \[0 0 ([\d.]+) ([\d.]+)\]/);
+    assert.ok(match, 'PDF should contain a parseable /MediaBox');
+    return { width: parseFloat(match[1]), height: parseFloat(match[2]) };
+  }
+
+  test.requires('pdf')('pdf({ landscape: true }) swaps the page orientation (#72)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(`${baseURL}/example`);
+
+    const portrait = mediaBox(await vibe.pdf());
+    const landscape = mediaBox(await vibe.pdf({ landscape: true }));
+
+    assert.ok(portrait.height > portrait.width, `portrait should be taller than wide, got ${JSON.stringify(portrait)}`);
+    assert.ok(landscape.width > landscape.height, `landscape should be wider than tall, got ${JSON.stringify(landscape)}`);
+  });
+
+  test.requires('pdf')('pdf({ pageWidth, pageHeight }) sets the page size (#72)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(`${baseURL}/example`);
+
+    // 10cm x 15cm; MediaBox is in points (1 cm = 28.35pt)
+    const box = mediaBox(await vibe.pdf({ pageWidth: 10, pageHeight: 15 }));
+    assert.ok(Math.abs(box.width - 10 * 28.35) < 2, `width should be ~283pt, got ${box.width}`);
+    assert.ok(Math.abs(box.height - 15 * 28.35) < 2, `height should be ~425pt, got ${box.height}`);
+  });
+
+  test.requires('pdf')('pdf({ pageRanges }) limits the printed pages (#72)', async () => {
+    const vibe = await bro.page();
+    // Three forced pages so ranges have something to cut
+    await vibe.setContent(
+      '<div style="page-break-after:always">one</div>' +
+      '<div style="page-break-after:always">two</div>' +
+      '<div>three</div>'
+    );
+
+    const all = await vibe.pdf();
+    const first = await vibe.pdf({ pageRanges: [1] });
+    const countPages = (buf) => (buf.toString('latin1').match(/\/Type\s*\/Page[^s]/g) || []).length;
+    assert.strictEqual(countPages(all), 3, 'unrestricted print should have 3 pages');
+    assert.strictEqual(countPages(first), 1, 'pageRanges [1] should print 1 page');
+  });
 });
 
 // --- Evaluation ---

--- a/tests/py/engine/test_sync_api.py
+++ b/tests/py/engine/test_sync_api.py
@@ -6,6 +6,7 @@ context, dialog handlers, route handlers, console/error collection,
 expect request/response, and full checkpoint.
 """
 
+import re
 import time
 
 import pytest
@@ -113,6 +114,23 @@ def test_pdf(bro, test_server):
     data = vibe.pdf()
     assert isinstance(data, bytes)
     assert data[:2] == b"%P"
+
+
+def _media_box(pdf_bytes):
+    # The page dimensions land uncompressed in "/MediaBox [0 0 <w> <h>]"
+    m = re.search(rb"/MediaBox \[0 0 ([\d.]+) ([\d.]+)\]", pdf_bytes)
+    assert m is not None, "PDF should contain a parseable /MediaBox"
+    return float(m.group(1)), float(m.group(2))
+
+
+@pytest.mark.capability("pdf")
+def test_pdf_landscape_option(bro, test_server):
+    vibe = bro.page()
+    vibe.go(test_server)
+    pw, ph = _media_box(vibe.pdf())
+    lw, lh = _media_box(vibe.pdf(landscape=True))
+    assert ph > pw, "portrait should be taller than wide"
+    assert lw > lh, "landscape should be wider than tall"
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes VibiumDev/vibium#72

PDF generation shipped in v26.2 with defaults only, while browsingContext.print supports orientation, scale, margins, page size, background graphics, page ranges, and shrink-to-fit. The vibium:page.pdf wire command now accepts all of them as flat keys, and a single translation in the engine builds the nested BiDi parameters. Options the caller does not set are never sent, so unset options keep the browser's own defaults and existing calls behave exactly as before.

Each surface gets the same options:
- CLI: vibium pdf --landscape --scale --background --margin --page-width --page-height --page-ranges (margins and page size in cm, ranges like 1,3-5)
- MCP: browser_pdf schema gains the option properties
- JS: pdf(options?) on the async and sync clients, PdfOptions exported
- Python: pdf(landscape=..., scale=..., page_ranges=[1, "3-5"], ...) on sync and async
- Java: pdf(PdfOptions) with a fluent builder, existing pdf() unchanged

Verified:
- Go unit tests on the wire-to-BiDi translation: full option set, empty and unrelated keys, landscape:false sends nothing, partial margins.
- JS engine tests parse the PDF's /MediaBox and page objects: landscape swaps orientation (612x792 becomes 792x612), pageWidth/pageHeight set the size in points, pageRanges [1] cuts a 3-page document to 1 page.
- Python engine test asserts landscape swaps the MediaBox; Java PdfTest does the same through PdfOptions. Both pass locally against the rebuilt binary.
- CLI checked by hand: --landscape produces /MediaBox [0 0 792 612], default stays [0 0 612 792].
- api.md row updated to show the option-taking signatures.