### PR TITLE
Replace the npm bin shim with the platform binary at install time

### DIFF
--- a/packages/vibium/postinstall.js
+++ b/packages/vibium/postinstall.js
@@ -1,14 +1,10 @@
 #!/usr/bin/env node
-// Run vibium install to download Chrome for Testing
-
-if (process.env.VIBIUM_SKIP_BROWSER_DOWNLOAD === '1') {
-  console.log('Skipping browser download (VIBIUM_SKIP_BROWSER_DOWNLOAD=1)');
-  process.exit(0);
-}
+// Replace the bin shim with the platform binary, then download Chrome for Testing.
 
 const { execFileSync } = require('child_process');
 const path = require('path');
 const os = require('os');
+const { linkBinaryOverShim } = require('./scripts/link-binary');
 
 function getVibiumBinPath() {
   const platform = os.platform();
@@ -20,13 +16,37 @@ function getVibiumBinPath() {
     const packagePath = require.resolve(`${packageName}/package.json`);
     return path.join(path.dirname(packagePath), 'bin', binaryName);
   } catch {
-    // Binary not available for this platform - skip silently
-    process.exit(0);
+    // Binary not available for this platform
+    return null;
   }
 }
 
+const vibiumPath = getVibiumBinPath();
+
+// Every `vibium <cmd>` through the JS shim pays ~100ms of Node boot before
+// any real work (#356). npm requires the published bin entry to be a JS
+// file, so the shim ships and gets replaced with the real binary here.
+// The shim must stay a script on Windows (npm's cmd shims invoke node
+// explicitly) and under Yarn PnP (no node_modules layout to link into).
+if (os.platform() !== 'win32' && !process.versions.pnp) {
+  try {
+    linkBinaryOverShim(path.join(__dirname, 'bin', 'cli.js'), vibiumPath);
+  } catch (error) {
+    // The shim still works, it is just slower.
+    console.warn('Warning: could not replace the vibium shim with the binary:', error.message);
+  }
+}
+
+if (process.env.VIBIUM_SKIP_BROWSER_DOWNLOAD === '1') {
+  console.log('Skipping browser download (VIBIUM_SKIP_BROWSER_DOWNLOAD=1)');
+  process.exit(0);
+}
+
+if (!vibiumPath) {
+  process.exit(0);
+}
+
 try {
-  const vibiumPath = getVibiumBinPath();
   console.log('Installing Chrome for Testing...');
   execFileSync(vibiumPath, ['install'], { stdio: 'inherit' });
 } catch (error) {

--- a/packages/vibium/postinstall.js
+++ b/packages/vibium/postinstall.js
@@ -4,7 +4,7 @@
 const { execFileSync } = require('child_process');
 const path = require('path');
 const os = require('os');
-const { linkBinaryOverShim } = require('./scripts/link-binary');
+const { linkBinaryOverShim, shouldReplaceShim } = require('./scripts/link-binary');
 
 function getVibiumBinPath() {
   const platform = os.platform();
@@ -27,8 +27,9 @@ const vibiumPath = getVibiumBinPath();
 // any real work (#356). npm requires the published bin entry to be a JS
 // file, so the shim ships and gets replaced with the real binary here.
 // The shim must stay a script on Windows (npm's cmd shims invoke node
-// explicitly) and under Yarn PnP (no node_modules layout to link into).
-if (os.platform() !== 'win32' && !process.versions.pnp) {
+// explicitly) and under Yarn PnP (no node_modules layout to link into),
+// and a source checkout must keep its tracked shim (see shouldReplaceShim).
+if (shouldReplaceShim(os.platform(), process.versions.pnp, __dirname)) {
   try {
     linkBinaryOverShim(path.join(__dirname, 'bin', 'cli.js'), vibiumPath);
   } catch (error) {

--- a/packages/vibium/scripts/link-binary.js
+++ b/packages/vibium/scripts/link-binary.js
@@ -1,0 +1,36 @@
+// Replace the published JS bin shim with the platform binary, so running
+// `vibium <cmd>` executes the binary directly instead of booting Node first:
+// the shim costs ~100ms of runtime start per invocation, which dominates
+// scripted CLI use (#356). npm's bin links (global bin, node_modules/.bin,
+// npx) all point at the shim's path, so changing the file behind that path is
+// what switches every entry point at once. Same approach as esbuild.
+
+const fs = require('fs');
+
+// linkBinaryOverShim replaces shimPath with binaryPath via an atomic rename,
+// so the bin path always resolves to either the shim or the finished binary.
+// Returns false without touching anything when the binary is absent.
+function linkBinaryOverShim(shimPath, binaryPath) {
+  if (!binaryPath || !fs.existsSync(binaryPath)) {
+    return false;
+  }
+  const tmp = shimPath + '.link-tmp';
+  fs.rmSync(tmp, { force: true });
+  try {
+    // Hard link when possible; both files live in the same package tree, so
+    // the same filesystem is the normal case. Copy as the fallback.
+    try {
+      fs.linkSync(binaryPath, tmp);
+    } catch {
+      fs.copyFileSync(binaryPath, tmp);
+    }
+    fs.chmodSync(tmp, 0o755);
+    fs.renameSync(tmp, shimPath);
+    return true;
+  } catch (error) {
+    fs.rmSync(tmp, { force: true });
+    throw error;
+  }
+}
+
+module.exports = { linkBinaryOverShim };

--- a/packages/vibium/scripts/link-binary.js
+++ b/packages/vibium/scripts/link-binary.js
@@ -7,6 +7,16 @@
 
 const fs = require('fs');
 
+// shouldReplaceShim gates the replacement: POSIX only (npm's Windows cmd
+// shims invoke node explicitly), never under Yarn PnP (no node_modules
+// layout to link into), and only for a copy installed under node_modules.
+// A source checkout runs this same script through the repo's file: link,
+// and npm executes a symlinked dependency's scripts in its real directory,
+// which would overwrite the tracked shim in the working tree.
+function shouldReplaceShim(platform, pnpVersion, packageDir) {
+  return platform !== 'win32' && !pnpVersion && String(packageDir).includes('node_modules');
+}
+
 // linkBinaryOverShim replaces shimPath with binaryPath via an atomic rename,
 // so the bin path always resolves to either the shim or the finished binary.
 // Returns false without touching anything when the binary is absent.
@@ -33,4 +43,4 @@ function linkBinaryOverShim(shimPath, binaryPath) {
   }
 }
 
-module.exports = { linkBinaryOverShim };
+module.exports = { linkBinaryOverShim, shouldReplaceShim };

--- a/tests/cli/packaging.test.js
+++ b/tests/cli/packaging.test.js
@@ -111,3 +111,23 @@ describe('Packaging: postinstall shim replacement (#356)', () => {
     }
   });
 });
+
+describe('Packaging: shim replacement guard (#356)', () => {
+  const { shouldReplaceShim } = require('../../packages/vibium/scripts/link-binary');
+
+  test('replaces only installed copies on POSIX without PnP', () => {
+    assert.strictEqual(shouldReplaceShim('darwin', undefined, '/app/node_modules/vibium'), true);
+    assert.strictEqual(shouldReplaceShim('linux', undefined, '/x/node_modules/vibium'), true);
+  });
+
+  test('never replaces on Windows or under Yarn PnP', () => {
+    assert.strictEqual(shouldReplaceShim('win32', undefined, '/app/node_modules/vibium'), false);
+    assert.strictEqual(shouldReplaceShim('linux', '3.0.0', '/app/node_modules/vibium'), false);
+  });
+
+  test('never replaces a source checkout, whose shim is tracked', () => {
+    // The repo links packages/vibium as a file dependency; npm runs the
+    // symlinked dep's scripts in its real directory, outside node_modules.
+    assert.strictEqual(shouldReplaceShim('darwin', undefined, '/Users/dev/vibium/packages/vibium'), false);
+  });
+});

--- a/tests/cli/packaging.test.js
+++ b/tests/cli/packaging.test.js
@@ -49,3 +49,65 @@ describe('Packaging: npm tarball contents', () => {
     }
   });
 });
+
+describe('Packaging: postinstall shim replacement (#356)', () => {
+  const { linkBinaryOverShim } = require('../../packages/vibium/scripts/link-binary');
+  const { spawnSync } = require('node:child_process');
+
+  function makeFixture() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-link-'));
+    const shim = path.join(dir, 'cli.js');
+    const binary = path.join(dir, 'vibium');
+    fs.writeFileSync(shim, '#!/usr/bin/env node\nconsole.log("shim");\n');
+    // Stands in for the platform binary: prints a marker and exits 0
+    fs.writeFileSync(binary, '#!/bin/sh\necho REAL_BINARY\n');
+    fs.chmodSync(binary, 0o755);
+    return { dir, shim, binary };
+  }
+
+  test('replaces the shim with the binary and the bin path stays runnable', (t) => {
+    if (process.platform === 'win32') {
+      t.skip('replacement is POSIX-only');
+      return;
+    }
+    const { dir, shim, binary } = makeFixture();
+    try {
+      assert.strictEqual(linkBinaryOverShim(shim, binary), true);
+      assert.strictEqual(fs.readFileSync(shim, 'utf-8'), fs.readFileSync(binary, 'utf-8'),
+        'shim path must now hold the binary bytes');
+      const run = spawnSync(shim, [], { encoding: 'utf-8' });
+      assert.strictEqual(run.status, 0);
+      assert.match(run.stdout, /REAL_BINARY/, 'running the bin path must run the binary');
+      assert.ok(!fs.existsSync(shim + '.link-tmp'), 'no temp file left behind');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('missing binary leaves the shim untouched', () => {
+    const { dir, shim } = makeFixture();
+    try {
+      const before = fs.readFileSync(shim, 'utf-8');
+      assert.strictEqual(linkBinaryOverShim(shim, path.join(dir, 'nope')), false);
+      assert.strictEqual(linkBinaryOverShim(shim, null), false);
+      assert.strictEqual(fs.readFileSync(shim, 'utf-8'), before);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('prefers a hard link so no extra copy is stored', (t) => {
+    if (process.platform === 'win32') {
+      t.skip('replacement is POSIX-only');
+      return;
+    }
+    const { dir, shim, binary } = makeFixture();
+    try {
+      linkBinaryOverShim(shim, binary);
+      assert.strictEqual(fs.statSync(shim).ino, fs.statSync(binary).ino,
+        'same filesystem should get a hard link, not a copy');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#356

Every vibium CLI invocation through the npm shim pays about 100ms of Node boot before the binary runs. The issue measured 118ms via the shim against 10ms calling the platform binary directly, about 700ms over a seven-command journey, and validated the esbuild-style fix over 710 reps. This implements the same approach from our packaging.

npm requires the published bin entry to be a JS file, so the shim still ships, and postinstall now replaces the file behind npm's bin links with the platform binary: hard link when possible (same package tree, so same filesystem), copy as fallback, atomic rename so the bin path always resolves to either the shim or the finished binary. Skipped where the shim must stay a script: Windows, whose npm cmd shims invoke node explicitly, and Yarn PnP, which has no node_modules layout to link into. If replacement fails, postinstall warns and the shim keeps working as before.

Interaction with the Node version check from the #17 PR: after a successful replacement, the POSIX CLI path involves no Node at all, so that check matters on Windows and PnP installs, where the shim remains. The two changes touch different files and merge independently.

Verified:
- Unit tests on scripts/link-binary.js in tests/cli/packaging.test.js: the replaced bin path holds the binary bytes and runs it, a missing binary or null path leaves the shim untouched, same-filesystem replacement is a hard link, and no temp file is left behind.
- Full-install simulation: copied the package to a temp tree with a stub @vibium/darwin-arm64 holding the real binary, ran postinstall with VIBIUM_SKIP_BROWSER_DOWNLOAD=1, and the bin path became a Mach-O executable that answers --version directly.
- The postinstall reorder keeps existing behavior: browser download still skips on VIBIUM_SKIP_BROWSER_DOWNLOAD=1 and still never fails the install; the shim replacement happens either way.

Worth knowing for rollout: this changes install-time behavior, so the nightly's npm public-smoke is the real proof; the packaged tarball itself is unchanged.