### PR TITLE
Make Java expose work by taking JS source like the other clients

### DIFF
--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -12,7 +12,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Represents a browser tab. The primary interface for page automation.
@@ -280,30 +279,19 @@ public class Page {
         return params;
     }
 
-    /** Expose a function to the page context. */
-    public void expose(String name, Function<Object[], Object> fn) {
+    /**
+     * Define window[name] in the page from JS function source, in the current
+     * document and every later one, matching the JS and Python clients:
+     * page.expose("double", "(n) => n * 2"). This replaces a callback-taking
+     * overload that sent no fn, which the server rejected on every call, and
+     * subscribed to an event the server never emits. Host-side callbacks,
+     * where the page calls back into the Java program, are tracked in #298.
+     */
+    public void expose(String name, String fn) {
         JsonObject params = contextParams();
         params.addProperty("name", name);
+        params.addProperty("fn", fn);
         client.send("vibium:page.expose", params);
-
-        // Listen for calls from the page
-        client.onEvent(event -> {
-            String method = event.has("method") ? event.get("method").getAsString() : "";
-            if ("vibium:page.exposedFunction".equals(method)) {
-                JsonObject p = event.getAsJsonObject("params");
-                if (p != null && name.equals(p.has("name") ? p.get("name").getAsString() : "")) {
-                    JsonArray args = p.has("args") ? p.getAsJsonArray("args") : new JsonArray();
-                    Object[] javaArgs = new Object[args.size()];
-                    for (int i = 0; i < args.size(); i++) {
-                        javaArgs[i] = jsonToJava(args.get(i));
-                    }
-                    try {
-                        Object result = fn.apply(javaArgs);
-                        // TODO: send result back if bidirectional exposed functions are supported
-                    } catch (Exception ignored) {}
-                }
-            }
-        });
     }
 
     // ── Waiting ─────────────────────────────────────────────────

--- a/clients/java/src/test/java/com/vibium/engine/ExposeTest.java
+++ b/clients/java/src/test/java/com/vibium/engine/ExposeTest.java
@@ -21,6 +21,9 @@ class ExposeTest {
     @BeforeAll
     static void setup() {
         browser = Vibium.start(new StartOptions().headless(true));
+        // Firefox keeps the startup tab in the parent process until a
+        // navigation, where script-backed commands are refused.
+        browser.page().go("about:blank");
     }
 
     @AfterAll

--- a/clients/java/src/test/java/com/vibium/engine/ExposeTest.java
+++ b/clients/java/src/test/java/com/vibium/engine/ExposeTest.java
@@ -1,0 +1,53 @@
+package com.vibium.engine;
+
+import com.vibium.Browser;
+import com.vibium.Page;
+import com.vibium.Vibium;
+import com.vibium.types.StartOptions;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * page.expose defines a named JS function in the page, matching the JS and
+ * Python clients. The previous Java signature was non-functional (#298).
+ */
+@RequiresCapability("core")
+class ExposeTest {
+
+    static Browser browser;
+    Page page;
+
+    @BeforeAll
+    static void setup() {
+        browser = Vibium.start(new StartOptions().headless(true));
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (browser != null) browser.stop();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        page = browser.page();
+    }
+
+    @Test
+    void exposeDefinesAFunctionThePageCanCall() {
+        page.setContent("<p>x</p>");
+        page.expose("vibiumDouble", "(n) => n * 2");
+
+        Object result = page.evaluate("window.vibiumDouble(4)");
+        assertEquals(8.0, ((Number) result).doubleValue());
+    }
+
+    @Test
+    void exposeSurvivesAReload() {
+        page.setContent("<p>x</p>");
+        page.expose("vibiumMark", "() => 'marked'");
+        page.reload();
+
+        assertEquals("marked", page.evaluate("window.vibiumMark()"));
+    }
+}


### PR DESCRIPTION
Part of VibiumDev/vibium#298 (does not close it: host-side callbacks remain open)

Java's expose(String, Function<Object[], Object>) promised a Playwright-style host callback but was non-functional, exactly as the issue catalogs: it sent no fn, so the server rejected every call, and it subscribed to a vibium:page.exposedFunction event the server has never emitted. I re-verified the server behavior directly: vibium:page.expose without fn answers "error: fn is required".

The signature is now expose(String name, String fn), where fn is JS function source, matching the JS and Python clients: the function is defined as window[name] in the current document and persists across navigations via the engine's preload script. Replacing the signature is safe because the old one never worked, so no caller can depend on it. The dead event listener and its argument-conversion plumbing are removed.

Verified:
- New com.vibium.engine.ExposeTest: the page can call an exposed function and get its result, and the function survives a reload. Both pass against the local binary; the file would not compile on main, where the broken signature exists, and the old form failed at runtime with the server error above.
- Full compile of main and test sources clean; unused java.util.function.Function import removed.