### PR TITLE
Tell a stale findAll handle apart from a bad selector

### DIFF
--- a/clicker/internal/api/actionability.go
+++ b/clicker/internal/api/actionability.go
@@ -337,5 +337,5 @@ func resolveWithActionability(s Session, context string, ep ElementParams, check
 	if err == nil && info != nil {
 		s.SetLastElementBox(&info.Box)
 	}
-	return info, err
+	return info, staleIndexHint(err, ep)
 }

--- a/clicker/internal/api/handlers_a11y.go
+++ b/clicker/internal/api/handlers_a11y.go
@@ -51,7 +51,7 @@ func (r *Router) handleVibiumElRole(session *BrowserSession, cmd bidiCommand) {
 	})()`)
 	val, err := r.evalElementScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"role": val})
@@ -96,7 +96,7 @@ func (r *Router) handleVibiumElLabel(session *BrowserSession, cmd bidiCommand) {
 	})()`)
 	val, err := r.evalElementScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"label": val})

--- a/clicker/internal/api/handlers_state.go
+++ b/clicker/internal/api/handlers_state.go
@@ -48,7 +48,7 @@ func (r *Router) handleVibiumElHighlight(session *BrowserSession, cmd bidiComman
 	})()`)
 	val, err := r.evalElementScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	if val != "ok" {
@@ -87,7 +87,7 @@ func (r *Router) handleVibiumElHTML(session *BrowserSession, cmd bidiCommand) {
 	script, args := buildElStateScript(ep, `el.innerHTML`)
 	val, err := r.evalElementScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"html": val})
@@ -105,7 +105,7 @@ func (r *Router) handleVibiumElValue(session *BrowserSession, cmd bidiCommand) {
 	script, args := buildElStateScript(ep, `el.value || ''`)
 	val, err := r.evalElementScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"value": val})
@@ -193,7 +193,7 @@ func (r *Router) handleVibiumElAttr(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 	if result.Error != "" {
-		r.sendError(session, cmd.ID, fmt.Errorf("attr: %s", result.Error))
+		r.sendError(session, cmd.ID, staleIndexHint(fmt.Errorf("attr: %s", result.Error), ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"value": result.Value})
@@ -227,7 +227,7 @@ func (r *Router) handleVibiumElBounds(session *BrowserSession, cmd bidiCommand) 
 
 	val, err := parseScriptResult(resp)
 	if err != nil {
-		r.sendError(session, cmd.ID, fmt.Errorf("bounds failed: %w", err))
+		r.sendError(session, cmd.ID, staleIndexHint(fmt.Errorf("bounds failed: %w", err), ep))
 		return
 	}
 
@@ -261,7 +261,7 @@ func (r *Router) handleVibiumElIsVisible(session *BrowserSession, cmd bidiComman
 
 	visible, err := r.evalBoolScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"visible": visible})
@@ -287,7 +287,7 @@ func (r *Router) handleVibiumElIsHidden(session *BrowserSession, cmd bidiCommand
 
 	hidden, err := r.evalBoolScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"hidden": hidden})
@@ -305,7 +305,7 @@ func (r *Router) handleVibiumElIsEnabled(session *BrowserSession, cmd bidiComman
 	script, args := buildElBoolScript(ep, `return !el.disabled;`)
 	enabled, err := r.evalBoolScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"enabled": enabled})
@@ -344,7 +344,7 @@ func (r *Router) handleVibiumElIsEditable(session *BrowserSession, cmd bidiComma
 	script, args := buildElBoolScript(ep, `return `+EditablePredicateJS+`;`)
 	editable, err := r.evalBoolScript(session, context, script, args)
 	if err != nil {
-		r.sendError(session, cmd.ID, err)
+		r.sendError(session, cmd.ID, staleIndexHint(err, ep))
 		return
 	}
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"editable": editable})
@@ -832,31 +832,36 @@ func (r *Router) resolveElementNoWait(session *BrowserSession, context string, e
 // rendered-text variant; keeping both on innerText made them the same command.
 func GetText(s Session, context string, ep ElementParams) (string, error) {
 	script, args := buildElStateScript(ep, `(el.textContent || '').trim()`)
-	return EvalElementScript(s, context, script, args)
+	val, err := EvalElementScript(s, context, script, args)
+	return val, staleIndexHint(err, ep)
 }
 
 // GetInnerText returns the innerText of an element.
 func GetInnerText(s Session, context string, ep ElementParams) (string, error) {
 	script, args := buildElStateScript(ep, `(el.innerText || '').trim()`)
-	return EvalElementScript(s, context, script, args)
+	val, err := EvalElementScript(s, context, script, args)
+	return val, staleIndexHint(err, ep)
 }
 
 // GetInnerHTML returns the innerHTML of an element.
 func GetInnerHTML(s Session, context string, ep ElementParams) (string, error) {
 	script, args := buildElStateScript(ep, `el.innerHTML`)
-	return EvalElementScript(s, context, script, args)
+	val, err := EvalElementScript(s, context, script, args)
+	return val, staleIndexHint(err, ep)
 }
 
 // GetOuterHTML returns the outerHTML of an element.
 func GetOuterHTML(s Session, context string, ep ElementParams) (string, error) {
 	script, args := buildElStateScript(ep, `el.outerHTML`)
-	return EvalElementScript(s, context, script, args)
+	val, err := EvalElementScript(s, context, script, args)
+	return val, staleIndexHint(err, ep)
 }
 
 // GetValue returns the value property of a form element.
 func GetValue(s Session, context string, ep ElementParams) (string, error) {
 	script, args := buildElStateScript(ep, `el.value || ''`)
-	return EvalElementScript(s, context, script, args)
+	val, err := EvalElementScript(s, context, script, args)
+	return val, staleIndexHint(err, ep)
 }
 
 // GetAttribute returns the value of an HTML attribute, or nil when the

--- a/clicker/internal/api/helpers.go
+++ b/clicker/internal/api/helpers.go
@@ -405,6 +405,18 @@ func CallScript(s Session, context, fn string, args []map[string]interface{}) (j
 	return s.SendBidiCommand("script.callFunction", params)
 }
 
+// staleIndexHint explains a not-found error for an index-addressed element:
+// those come from findAll handles, so "not found" can mean the page changed
+// after findAll rather than a selector that never matched, and the two read
+// identically without the hint (#338).
+func staleIndexHint(err error, ep ElementParams) error {
+	if err == nil || !ep.HasIndex || !strings.Contains(err.Error(), "not found") {
+		return err
+	}
+	return fmt.Errorf("%w (element %d of a findAll result: the page may have changed since findAll; "+
+		"re-run findAll, or read the snapshot the findAll returned)", err, ep.Index)
+}
+
 // ResolveElement finds an element using the given params, polling until found or timeout.
 func ResolveElement(s Session, context string, ep ElementParams) (*ElementInfo, error) {
 	ep = ep.withDefaultTimeout()
@@ -413,7 +425,7 @@ func ResolveElement(s Session, context string, ep ElementParams) (*ElementInfo, 
 	if err == nil && info != nil {
 		s.SetLastElementBox(&info.Box)
 	}
-	return info, err
+	return info, staleIndexHint(err, ep)
 }
 
 // ResolveElementRef finds an element and returns its BiDi sharedId.

--- a/clicker/internal/api/stale_index_test.go
+++ b/clicker/internal/api/stale_index_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A not-found error on an index-addressed element must say the handle came
+// from findAll and may be stale; everything else passes through (#338).
+func TestStaleIndexHint(t *testing.T) {
+	notFound := errors.New("timeout after 5s: element not found")
+
+	t.Run("indexed not-found gets the findAll explanation", func(t *testing.T) {
+		got := staleIndexHint(notFound, ElementParams{HasIndex: true, Index: 2})
+		if !strings.Contains(got.Error(), "element 2 of a findAll result") {
+			t.Fatalf("expected the findAll hint, got: %v", got)
+		}
+		if !errors.Is(got, notFound) {
+			t.Fatal("the original error must stay wrapped")
+		}
+	})
+
+	t.Run("non-indexed not-found is unchanged", func(t *testing.T) {
+		if got := staleIndexHint(notFound, ElementParams{}); got != notFound {
+			t.Fatalf("expected the error untouched, got: %v", got)
+		}
+	})
+
+	t.Run("indexed errors that are not not-found are unchanged", func(t *testing.T) {
+		other := errors.New("context is blocked by an open alert dialog")
+		if got := staleIndexHint(other, ElementParams{HasIndex: true, Index: 1}); got != other {
+			t.Fatalf("expected the error untouched, got: %v", got)
+		}
+	})
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		if got := staleIndexHint(nil, ElementParams{HasIndex: true}); got != nil {
+			t.Fatalf("expected nil, got: %v", got)
+		}
+	})
+}

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -178,6 +178,12 @@ public class Page {
     /**
      * Find all matching elements by CSS selector. Waits up to the timeout
      * for at least one match, then returns an empty list if there is none.
+     *
+     * Each element carries a snapshot of its tag, text, and bounding box
+     * taken at findAll time, readable via {@link Element#info()} with no
+     * further round trips: els.stream().map(e -> e.info().text()). Live
+     * reads like {@link Element#text()} re-resolve the element and fail if
+     * the page has changed since findAll.
      */
     public List<Element> findAll(String selector) {
         return findAll(selector, (FindOptions) null);

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -676,6 +676,11 @@ export class Page {
    * Find all elements matching a CSS selector or semantic options. Waits up
    * to the timeout for at least one match, then returns an empty array if
    * there is none. A timeout of 0 checks once without waiting.
+   *
+   * Each element carries a snapshot of its tag, text, and box taken at
+   * findAll time, readable via `el.info` with no further round trips:
+   * els.map(el => el.info.text). Live reads like el.text() re-resolve the
+   * element and fail if the page has changed since findAll.
    */
   async findAll(selector: string | SelectorOptions, options?: FindOptions): Promise<Element[]> {
     const params: Record<string, unknown> = {

--- a/clients/python/src/vibium/sync_api/page.py
+++ b/clients/python/src/vibium/sync_api/page.py
@@ -173,6 +173,13 @@ class Page:
         near: Optional[str] = None,
         timeout: Optional[int] = None,
     ) -> List[Element]:
+        """Find all matching elements.
+
+        Each element carries a snapshot of its tag, text, and box taken at
+        find_all time, readable via el.info with no further round trips:
+        [el.info.text for el in els]. Live reads like el.text() re-resolve
+        the element and fail if the page has changed since find_all.
+        """
         async_elements = self._loop.run(self._async.find_all(
             selector, role=role, text=text, label=label, placeholder=placeholder,
             alt=alt, title=title, testid=testid, xpath=xpath, near=near, timeout=timeout,

--- a/tests/js/async/engine/elements.test.js
+++ b/tests/js/async/engine/elements.test.js
@@ -178,3 +178,44 @@ describe('Element Finding', () => {
     assert.strictEqual(count, paragraphs.length, 'Iterator count should match length');
   });
 });
+
+describe('Stale findAll handles (#338)', () => {
+  test('the info snapshot reads all matches with no extra round trips', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL);
+
+    const paragraphs = await vibe.findAll('p');
+    const texts = paragraphs.map((el) => el.info.text);
+    assert.strictEqual(texts.length, 3);
+    assert.match(texts[0], /First paragraph/);
+    // The snapshot stays readable even after the elements are gone
+    await vibe.evaluate('document.querySelectorAll("p").forEach(p => p.remove())');
+    assert.match(paragraphs[1].info.text, /Second paragraph/);
+  });
+
+  test('a live read on a vanished handle names findAll, a bad selector does not', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL);
+
+    const paragraphs = await vibe.findAll('p');
+    await vibe.evaluate('document.querySelectorAll("p").forEach(p => p.remove())');
+
+    await assert.rejects(
+      () => paragraphs[2].text(),
+      (err) => {
+        assert.match(err.message, /findAll/, `stale-handle error should name findAll, got: ${err.message}`);
+        assert.match(err.message, /element 2/, `should name which element, got: ${err.message}`);
+        return true;
+      }
+    );
+
+    // A plain bad selector must not get the findAll explanation
+    await assert.rejects(
+      () => vibe.find('#never-existed', { timeout: 500 }).then((el) => el.text()),
+      (err) => {
+        assert.doesNotMatch(err.message, /findAll/, `bad-selector error must stay plain, got: ${err.message}`);
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#338

Reading through elements from findAll runs one round trip per element, and when the page repaints between the findAll and a read, the vanished handle fails with the same "element not found" a mistyped selector produces. The issue measured 25% failures on a page reached straight after a form submit, with nothing in the error pointing at the actual cause.

Two changes:

1. Index-addressed element errors now say the handle came from findAll, name which element, and point at the two fixes: re-run findAll, or use the snapshot findAll already returned. The hint is applied at the resolution choke points (resolveWithActionability covers every interaction, ResolveElement covers plain resolutions) and at the read handlers (text, value, html, attr, bounds, visibility checks, a11y). Non-indexed errors and errors that are not "not found" are untouched, so a plain bad selector reads exactly as before.

2. The single-round-trip bulk read the issue asks for already exists and is now documented: every client's findAll captures a tag/text/box snapshot per element at findAll time, readable with no further round trips as el.info in JS and Python and Element.info() in Java. The findAll doc comments in all three clients now name the idiom, since nothing previously pointed at it. The snapshot stays readable after the elements are gone.

Verified:
- Go unit tests on the hint: indexed not-found gets the explanation with the original error wrapped, non-indexed and non-not-found errors pass through, nil stays nil.
- New JS engine tests: reading el.info.text across all matches costs no round trips and survives element removal; a live read on a vanished indexed handle rejects with an error naming findAll and the element index, while a bad-selector error stays plain. The error-message test fails on main and passes with the change.
- go test ./internal/api/ green; JS and Java clients build clean.

Not covered here: reporting the live match count in the message would need the miss to be detected inside the element scripts, which use three different error protocols across five builders; that consolidation is better done as its own change (it would also serve the API drift checker work).