### PR TITLE
Ship scripts/link-binary.js in the npm package

### DIFF
--- a/packages/vibium/package.json
+++ b/packages/vibium/package.json
@@ -51,6 +51,7 @@
     "dist",
     "bin",
     "postinstall.js",
+    "scripts/link-binary.js",
     "LICENSE",
     "NOTICE"
   ],

--- a/tests/cli/packaging.test.js
+++ b/tests/cli/packaging.test.js
@@ -131,3 +131,49 @@ describe('Packaging: shim replacement guard (#356)', () => {
     assert.strictEqual(shouldReplaceShim('darwin', undefined, '/Users/dev/vibium/packages/vibium'), false);
   });
 });
+
+describe('Packaging: postinstall and bin scripts are self-contained', () => {
+  // The nightly local-smoke on 2026-08-26 failed on every platform because
+  // postinstall.js required scripts/link-binary.js, which the files
+  // allowlist did not ship. Every relative require reachable from the
+  // packaged entry scripts must itself be in the tarball.
+  test('every relative require of packaged scripts ships in the tarball', () => {
+    const dest = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-pack-req-'));
+    const useShell = process.platform === 'win32';
+    const destArg = useShell ? `"${dest}"` : dest;
+    const out = execFileSync(NPM, ['pack', '--json', '--pack-destination', destArg], {
+      cwd: PKG_DIR,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+      shell: useShell,
+    });
+
+    try {
+      const files = new Set(JSON.parse(out)[0].files.map((f) => f.path));
+      // Walk relative requires transitively from the executable entries.
+      const queue = ['postinstall.js', 'bin/cli.js'];
+      const seen = new Set();
+
+      while (queue.length > 0) {
+        const entry = queue.shift();
+        if (seen.has(entry)) continue;
+        seen.add(entry);
+
+        assert.ok(files.has(entry), `tarball must include ${entry}`);
+        if (!entry.endsWith('.js')) continue;
+        const source = fs.readFileSync(path.join(PKG_DIR, entry), 'utf-8');
+        for (const match of source.matchAll(/require\(['"](\.[^'"]+)['"]\)/g)) {
+          let dep = path.posix.join(path.posix.dirname(entry), match[1]);
+          if (!dep.endsWith('.js') && !dep.endsWith('.json')) dep += '.js';
+          assert.ok(
+            files.has(dep),
+            `${entry} requires ${match[1]}, but ${dep} is not in the tarball; add it to the files allowlist`
+          );
+          queue.push(dep);
+        }
+      }
+    } finally {
+      fs.rmSync(dest, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#436

Fixes the nightly release failure of run 32955683254 (2026-08-26), where local-smoke failed on all five platforms.

postinstall.js requires scripts/link-binary.js since the shim replacement landed (#432), but the package's files allowlist never got the new path. The published tarball omits the file, so every fresh npm install of the package crashes in postinstall with MODULE_NOT_FOUND before anything else runs. CI did not catch it because the repo installs packages/vibium through a symlinked file dependency, where every repo file is visible; only a real pack-and-install exercises the allowlist.

Two changes:
- packages/vibium/package.json adds scripts/link-binary.js to files.
- tests/cli/packaging.test.js gains a test that runs npm pack, walks every relative require transitively reachable from postinstall.js and bin/cli.js, and asserts each resolved file is in the tarball. A packaged script gaining a dependency without a files entry now fails in CI instead of in the nightly.

Verified:
- The new test fails against the current allowlist with "postinstall.js requires ./scripts/link-binary, but scripts/link-binary.js is not in the tarball" and passes with the fix.
- Reproduced the smoke flow end to end: npm pack, then a fresh npm install of the tarball in an empty directory with VIBIUM_SKIP_BROWSER_DOWNLOAD=1. Before the fix it crashes exactly like the nightly; after, postinstall completes, scripts/link-binary.js is present, and the bin path holds the platform binary.