### PR TITLE
Add a Node version check to the npm shim

### DIFF
--- a/packages/vibium/bin/cli.js
+++ b/packages/vibium/bin/cli.js
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 // Find vibium binary from platform package and run it.
 
+const { nodeVersionError } = require('./node-version-check');
+const versionError = nodeVersionError(process.versions.node, process.execPath);
+if (versionError) {
+  console.error(versionError);
+  process.exit(1);
+}
+
 const { execFileSync } = require('child_process');
 const path = require('path');
 const os = require('os');

--- a/packages/vibium/bin/node-version-check.js
+++ b/packages/vibium/bin/node-version-check.js
@@ -1,0 +1,27 @@
+// Old Node versions fail far from the real cause (#17): a Node 16 install
+// surfaced as "Chrome failed to launch" with no mention of Node. Check the
+// version up front and name the actual problem. Kept to older syntax so the
+// check itself still parses on the versions it rejects.
+
+var pkg = require('../package.json');
+
+// The supported floor comes from the package's own engines field, so the two
+// cannot drift apart.
+var match = /\d+/.exec((pkg.engines && pkg.engines.node) || '');
+var MIN_NODE_MAJOR = match ? parseInt(match[0], 10) : 18;
+
+// nodeVersionError returns an error message when versionString (for example
+// "16.20.2") is below the supported floor, else null.
+function nodeVersionError(versionString, execPath) {
+  var major = parseInt(String(versionString).split('.')[0], 10);
+  if (isNaN(major) || major >= MIN_NODE_MAJOR) {
+    return null;
+  }
+  return (
+    'vibium requires Node.js ' + MIN_NODE_MAJOR + ' or newer; this is Node ' +
+    versionString + (execPath ? ' at ' + execPath : '') + '.\n' +
+    'Upgrade Node or switch versions (for example: nvm use ' + MIN_NODE_MAJOR + ') and run again.'
+  );
+}
+
+module.exports = { nodeVersionError: nodeVersionError, MIN_NODE_MAJOR: MIN_NODE_MAJOR };

--- a/tests/cli/wrapper.test.js
+++ b/tests/cli/wrapper.test.js
@@ -32,6 +32,45 @@ describe('CLI: npm wrapper error handling', () => {
   });
 });
 
+describe('CLI: npm wrapper Node version check (#17)', () => {
+  const { nodeVersionError, MIN_NODE_MAJOR } =
+    require('../../packages/vibium/bin/node-version-check');
+
+  test('an old Node version gets an error naming versions and the fix', () => {
+    const msg = nodeVersionError('16.20.2', '/usr/local/bin/node');
+    assert.ok(msg, 'Node 16 should be rejected');
+    assert.match(msg, /requires Node\.js \d+ or newer/, 'should name the floor');
+    assert.match(msg, /16\.20\.2/, 'should name the running version');
+    assert.match(msg, /\/usr\/local\/bin\/node/, 'should name which node ran, for multi-install setups');
+    assert.match(msg, /nvm use/, 'should say how to fix it');
+  });
+
+  test('supported versions pass', () => {
+    assert.strictEqual(nodeVersionError(`${MIN_NODE_MAJOR}.0.0`, ''), null);
+    assert.strictEqual(nodeVersionError('25.1.0', ''), null);
+    assert.strictEqual(nodeVersionError(process.versions.node, ''), null,
+      'the Node running this test suite must pass its own check');
+  });
+
+  test('an unparseable version does not block execution', () => {
+    assert.strictEqual(nodeVersionError('weird', ''), null);
+  });
+
+  test('the floor comes from the package engines field', () => {
+    const pkg = require('../../packages/vibium/package.json');
+    const engines = parseInt(/\d+/.exec(pkg.engines.node)[0], 10);
+    assert.strictEqual(MIN_NODE_MAJOR, engines, 'check and engines field must agree');
+  });
+
+  test('the wrapper still runs commands on the current Node', () => {
+    const result = spawnSync(process.execPath, [CLI_JS, '--version'], { encoding: 'utf-8' });
+    assert.strictEqual(result.status, 0, `--version should exit 0, stderr: ${result.stderr}`);
+    // argv0 is the invoking name ("cli" here, "vibium" via the npm symlink),
+    // so match the version format rather than the name.
+    assert.match(result.stdout, /v\d+\.\d+\.\d+/, 'should print the version through the shim');
+  });
+});
+
 describe('CLI: ws-test scheme hint', () => {
   test('names the ws:// form when given http:// (#196)', () => {
     try {


### PR DESCRIPTION
Fixes VibiumDev/vibium#17

Running vibium under an unsupported Node version failed far from the cause: the reporter's Node 16 (left over from an Intel-to-M4 migration, alongside a Node 20) surfaced as Chrome failing to launch, with no mention of Node anywhere.

The npm wrapper now checks the running Node version before doing anything else. On an unsupported version it exits with a message naming the required floor, the running version, the path of the node binary that ran (the reported setup had two installs, so which one matters), and how to switch. The floor is read from the package's own engines field so the check and the metadata cannot drift apart. The check module keeps to older syntax so it still parses on the versions it rejects.

Verified:
- New tests in tests/cli/wrapper.test.js: Node 16 gets a message naming the floor, the version, the node path, and the nvm hint; supported and current versions pass; unparseable versions do not block; the floor equals the engines field; and the wrapper still runs --version through to the binary on the current Node. 9/9 in the file.
- The check is pure and required by cli.js at the top, before binary resolution, so nothing else runs first.