### PR TITLE
Add a timeout to tutorial test blocks

### DIFF
--- a/tests/py/helpers/tutorial_runner.py
+++ b/tests/py/helpers/tutorial_runner.py
@@ -13,8 +13,10 @@ Server blocks:
     starts an HTTP server from these definitions.
 """
 
+import asyncio
 import re
 import textwrap
+import threading
 from pathlib import Path
 
 # tests/py/helpers/ -> project root
@@ -176,15 +178,46 @@ def run_sync_block(code, vibe, base_url=None):
     exec(compile(code, "<tutorial>", "exec"), {"vibe": vibe, "base_url": base_url})
 
 
+# Bound for one standalone tutorial block. Generous against slow CI (a
+# healthy block runs in seconds) but far under the 600s phase watchdog: a
+# hung block must fail its own test so pytest still reports, which is what
+# prints the captured vibium stderr. The event-delivery hangs (#397,
+# incidents 9 and 10) died to the phase watchdog instead, taking every
+# captured diagnostic with them.
+TUTORIAL_TIMEOUT = 120
+
+
 async def run_async_standalone(code, base_url=None):
     """Exec a standalone async block that manages its own browser lifecycle."""
     indented = textwrap.indent(code, "    ")
     wrapped = f"async def _run(base_url):\n{indented}\n"
     ns = {}
     exec(compile(wrapped, "<tutorial>", "exec"), ns)
-    await ns["_run"](base_url)
+    try:
+        await asyncio.wait_for(ns["_run"](base_url), timeout=TUTORIAL_TIMEOUT)
+    except asyncio.TimeoutError:
+        # asyncio.TimeoutError is not the builtin TimeoutError before 3.11
+        raise TimeoutError(f"tutorial block still running after {TUTORIAL_TIMEOUT}s") from None
 
 
 def run_sync_standalone(code, base_url=None):
     """Exec a standalone sync block that manages its own browser lifecycle."""
-    exec(compile(code, "<tutorial>", "exec"), {"base_url": base_url})
+    # A hung sync block cannot be interrupted in place, so it runs on a
+    # scrap thread that gets abandoned on timeout; the leaked browser is
+    # cleaned by the suite's process cleanup, and the alternative was the
+    # watchdog killing the whole phase.
+    result = {}
+
+    def _target():
+        try:
+            exec(compile(code, "<tutorial>", "exec"), {"base_url": base_url})
+        except BaseException as e:
+            result["error"] = e
+
+    worker = threading.Thread(target=_target, daemon=True)
+    worker.start()
+    worker.join(TUTORIAL_TIMEOUT)
+    if worker.is_alive():
+        raise TimeoutError(f"tutorial block still running after {TUTORIAL_TIMEOUT}s")
+    if "error" in result:
+        raise result["error"]

--- a/tests/py/test_tutorial_runner_timeout.py
+++ b/tests/py/test_tutorial_runner_timeout.py
@@ -1,0 +1,45 @@
+"""The tutorial runners must bound a hung block so it fails its own test.
+
+The event-delivery hangs (#397 incidents 9 and 10) ran until the 600s phase
+watchdog killed pytest, which discarded the captured vibium stderr that
+would have said why. A block that fails inside the runner's own bound gets
+a normal pytest report, captured output included.
+"""
+
+import pytest
+
+from helpers import tutorial_runner
+from helpers.tutorial_runner import run_async_standalone, run_sync_standalone
+
+
+@pytest.fixture
+def short_timeout(monkeypatch):
+    monkeypatch.setattr(tutorial_runner, "TUTORIAL_TIMEOUT", 1)
+
+
+async def test_async_hung_block_times_out(short_timeout):
+    with pytest.raises(TimeoutError):
+        await run_async_standalone("import asyncio\nawait asyncio.sleep(30)")
+
+
+def test_sync_hung_block_times_out(short_timeout):
+    with pytest.raises(TimeoutError):
+        run_sync_standalone("import time\ntime.sleep(30)")
+
+
+async def test_async_block_still_runs_and_returns():
+    await run_async_standalone("assert base_url == 'x'", base_url="x")
+
+
+def test_sync_block_still_runs_and_returns():
+    run_sync_standalone("assert base_url == 'x'", base_url="x")
+
+
+def test_sync_block_failure_propagates():
+    with pytest.raises(AssertionError, match="tutorial says no"):
+        run_sync_standalone("assert False, 'tutorial says no'")
+
+
+async def test_async_block_failure_propagates():
+    with pytest.raises(AssertionError, match="tutorial says no"):
+        await run_async_standalone("assert False, 'tutorial says no'")


### PR DESCRIPTION
Part of VibiumDev/vibium#397 (diagnostics; does not fix the delivery bug)

The event-delivery hangs tracked in #397 share a shape: a download tutorial test waits forever for an event, the 600s phase watchdog kills pytest, and pytest's captured output dies with it. It happened again on PR #432's first chrome run (run 32902536996) and before that on run 32789877533. That captured output is exactly where the diagnostics live: CI forwards vibium stderr since #424, and the router logs slow event deliveries since #403, but only a normally-failing test makes pytest print them.

Standalone tutorial blocks now get a 120 second bound, generous against slow CI (a healthy block runs in seconds) but far under the phase watchdog. The async runner wraps the block in asyncio.wait_for, normalized to the builtin TimeoutError since asyncio's is a different type before Python 3.11. The sync runner executes the block on a scrap thread it abandons on timeout, since an exec cannot be interrupted in place; the leaked browser is covered by the suite's process cleanup, and the alternative was losing the whole phase. A block that fails or times out now produces a normal pytest report with captured stderr attached.

A side effect worth having: an event arriving minutes late and passing (seen once on firefox, where a download event landed after 8 minutes) now fails visibly instead.

Verified:
- New browser-free tests/py/test_tutorial_runner_timeout.py: hung async and sync blocks raise TimeoutError under a shortened bound, healthy blocks still run and see base_url, and block failures propagate with their original message. 6/6.
- All 27 tutorial tests (a11y + downloads, sync + async) pass against the local binary with the bounded runners, 110s total.