### PR TITLE
Add an API drift checker for api.md and the JS and Python clients

### DIFF
--- a/.github/workflows/test-docs-only.yml
+++ b/.github/workflows/test-docs-only.yml
@@ -4,7 +4,8 @@
 # required chrome/firefox/test checks "Expected, waiting for status" forever
 # and grey out the merge button. This workflow reports the same check names
 # as immediate successes instead. Keep the paths list below identical to
-# test.yml's paths-ignore list: a path present there but missing here blocks
+# test.yml's paths-ignore list (which names docs/reference files singly so
+# api.md, the drift check's spec, always gets real CI): a path present there but missing here blocks
 # docs-only PRs again; a path present here but missing there double-reports.
 name: Test
 
@@ -16,7 +17,12 @@ on:
       - 'docs/how-to-guides/**'
       - 'docs/images/**'
       - 'docs/plans/**'
-      - 'docs/reference/**'
+      - 'docs/reference/WebDriver-Bidi-Spec.md'
+      - 'docs/reference/mac-system-requirements.md'
+      - 'docs/reference/recording-format.md'
+      - 'docs/reference/selectors.md'
+      - 'docs/reference/webdriver-bidi-overview.md'
+      - 'docs/reference/webdriver-classic.md'
       - 'docs/specs/**'
       - 'docs/trackers/**'
       - 'docs/updates/**'
@@ -32,7 +38,12 @@ on:
       - 'docs/how-to-guides/**'
       - 'docs/images/**'
       - 'docs/plans/**'
-      - 'docs/reference/**'
+      - 'docs/reference/WebDriver-Bidi-Spec.md'
+      - 'docs/reference/mac-system-requirements.md'
+      - 'docs/reference/recording-format.md'
+      - 'docs/reference/selectors.md'
+      - 'docs/reference/webdriver-bidi-overview.md'
+      - 'docs/reference/webdriver-classic.md'
       - 'docs/specs/**'
       - 'docs/trackers/**'
       - 'docs/updates/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,18 @@ on:
       # Documentation that nothing builds or tests reads. Deliberately NOT
       # docs/tutorials/**: tests/py and tests/js extract code from those and
       # run it, so editing one can break the suite. Also not skills/**, whose
-      # SKILL.md is copied into the binary by build-go.
+      # SKILL.md is copied into the binary by build-go, and not
+      # docs/reference/api.md, which the API drift check parses as its spec.
       - 'docs/explanation/**'
       - 'docs/how-to-guides/**'
       - 'docs/images/**'
       - 'docs/plans/**'
-      - 'docs/reference/**'
+      - 'docs/reference/WebDriver-Bidi-Spec.md'
+      - 'docs/reference/mac-system-requirements.md'
+      - 'docs/reference/recording-format.md'
+      - 'docs/reference/selectors.md'
+      - 'docs/reference/webdriver-bidi-overview.md'
+      - 'docs/reference/webdriver-classic.md'
       - 'docs/specs/**'
       - 'docs/trackers/**'
       - 'docs/updates/**'
@@ -31,12 +37,18 @@ on:
       # Documentation that nothing builds or tests reads. Deliberately NOT
       # docs/tutorials/**: tests/py and tests/js extract code from those and
       # run it, so editing one can break the suite. Also not skills/**, whose
-      # SKILL.md is copied into the binary by build-go.
+      # SKILL.md is copied into the binary by build-go, and not
+      # docs/reference/api.md, which the API drift check parses as its spec.
       - 'docs/explanation/**'
       - 'docs/how-to-guides/**'
       - 'docs/images/**'
       - 'docs/plans/**'
-      - 'docs/reference/**'
+      - 'docs/reference/WebDriver-Bidi-Spec.md'
+      - 'docs/reference/mac-system-requirements.md'
+      - 'docs/reference/recording-format.md'
+      - 'docs/reference/selectors.md'
+      - 'docs/reference/webdriver-bidi-overview.md'
+      - 'docs/reference/webdriver-classic.md'
       - 'docs/specs/**'
       - 'docs/trackers/**'
       - 'docs/updates/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,11 @@ jobs:
       - name: Build
         run: make
 
+      # Browser-free: fails when api.md is malformed or a client column
+      # claims a symbol the client does not export.
+      - name: API drift check
+        run: make check-api-drift
+
       # xvfb: the Python suite's headed tests need a display.
       # The NODE_TEST_TIMEOUT override is gone with Node 20: --test-timeout is
       # per test now, not per file, so the Makefile's 30s default applies and a

--- a/Makefile
+++ b/Makefile
@@ -497,11 +497,13 @@ test-firefox-capabilities: build-go install-firefox
 # Browser-free cross-surface API drift check. docs/reference/api.md is the
 # spec: fails on a malformed doc or on a client column claiming a symbol the
 # client does not export. Undocumented extras are reported but do not fail.
-check-api-drift: python-venv
-	@echo "--- API Drift Check (spec + python) ---"
+check-api-drift: python-venv build-js
+	@echo "--- API Drift Check (spec + js + python) ---"
 	cd clicker && go run ./cmd/apidrift validate -spec ../docs/reference/api.md
 	@cd clients/python && . $(VENV_ACTIVATE) && python ../../scripts/apidrift_python.py | \
 		(cd ../../clicker && go run ./cmd/apidrift check -surface python -spec ../docs/reference/api.md -actual -)
+	@node scripts/apidrift_js.js | \
+		(cd clicker && go run ./cmd/apidrift check -surface js -spec ../docs/reference/api.md -actual -)
 
 test-capability-audit: build-js python-venv
 	@echo "--- Browser-free Chrome Capability Audit ---"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
   endif
 endif
 
-.PHONY: all build build-go build-js build-go-all package package-js package-python install-browser install-firefox install-engine deps clean clean-go clean-js clean-npm-packages clean-python-packages clean-packages clean-cache clean-all serve test test-go test-cli test-cli-shared test-js test-js-async test-js-sync test-js-process test-js-engine test-mcp test-daemon test-python test-python-engine python-venv test-browser-modes test-firefox test-firefox-core test-firefox-capabilities test-engine test-java test-java-engine test-capability-audit test-cleanup mtlshim double-tap get-version set-version build-java package-java verify-staged-java clean-java jshell help
+.PHONY: all build build-go build-js build-go-all package package-js package-python install-browser install-firefox install-engine deps clean clean-go clean-js clean-npm-packages clean-python-packages clean-packages clean-cache clean-all serve test test-go test-cli test-cli-shared test-js test-js-async test-js-sync test-js-process test-js-engine test-mcp test-daemon test-python test-python-engine python-venv test-browser-modes test-firefox test-firefox-core test-firefox-capabilities test-engine test-java test-java-engine check-api-drift test-capability-audit test-cleanup mtlshim double-tap get-version set-version build-java package-java verify-staged-java clean-java jshell help
 
 # Version from VERSION file
 # Note: GnuWin32 Make 3.81 runs $(shell) via CreateProcess, not SHELL,
@@ -493,6 +493,15 @@ test-engine: test-cli-shared test-js-engine test-python-engine test-java-engine
 
 test-firefox-capabilities: build-go install-firefox
 	@"$(MAKE)" test-engine ENGINE=firefox
+
+# Browser-free cross-surface API drift check. docs/reference/api.md is the
+# spec: fails on a malformed doc or on a client column claiming a symbol the
+# client does not export. Undocumented extras are reported but do not fail.
+check-api-drift: python-venv
+	@echo "--- API Drift Check (spec + python) ---"
+	cd clicker && go run ./cmd/apidrift validate -spec ../docs/reference/api.md
+	@cd clients/python && . $(VENV_ACTIVATE) && python ../../scripts/apidrift_python.py | \
+		(cd ../../clicker && go run ./cmd/apidrift check -surface python -spec ../docs/reference/api.md -actual -)
 
 test-capability-audit: build-js python-venv
 	@echo "--- Browser-free Chrome Capability Audit ---"

--- a/clicker/cmd/apidrift/main.go
+++ b/clicker/cmd/apidrift/main.go
@@ -1,0 +1,92 @@
+// apidrift checks docs/reference/api.md, the canonical cross-surface API
+// spec, for internal consistency and against what a client actually exports.
+//
+//	apidrift validate -spec docs/reference/api.md
+//	# Parse the spec and fail on malformed rows.
+//	# api.md: 187 rows, 16 sections, spec is well-formed
+//
+//	apidrift check -spec docs/reference/api.md -surface python -actual surface.json
+//	# Compare one client column against an extractor dump ("-" reads stdin).
+//	# python: in sync with api.md
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/vibium/clicker/internal/apidrift"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fail("usage: apidrift <validate|check> [flags]")
+	}
+	switch os.Args[1] {
+	case "validate":
+		fs := flag.NewFlagSet("validate", flag.ExitOnError)
+		spec := fs.String("spec", "", "path to api.md")
+		fs.Parse(os.Args[2:])
+		rows := load(*spec)
+		sections := map[string]bool{}
+		for _, r := range rows {
+			sections[r.Section] = true
+		}
+		fmt.Printf("%s: %d rows, %d sections, spec is well-formed\n", *spec, len(rows), len(sections))
+	case "check":
+		fs := flag.NewFlagSet("check", flag.ExitOnError)
+		spec := fs.String("spec", "", "path to api.md")
+		surface := fs.String("surface", "", "spec column to check (js, python, java)")
+		actualPath := fs.String("actual", "-", "extractor JSON dump, - for stdin")
+		fs.Parse(os.Args[2:])
+		rows := load(*spec)
+
+		var data []byte
+		var err error
+		if *actualPath == "-" {
+			data, err = io.ReadAll(os.Stdin)
+		} else {
+			data, err = os.ReadFile(*actualPath)
+		}
+		if err != nil {
+			fail(fmt.Sprintf("reading actual surface: %v", err))
+		}
+		var actual apidrift.ClientSurface
+		if err := json.Unmarshal(data, &actual); err != nil {
+			fail(fmt.Sprintf("parsing actual surface: %v", err))
+		}
+
+		report, ok := apidrift.Compare(rows, *surface, actual).Report(*surface)
+		fmt.Print(report)
+		if !ok {
+			os.Exit(1)
+		}
+	default:
+		fail(fmt.Sprintf("unknown command %q (want validate or check)", os.Args[1]))
+	}
+}
+
+func load(specPath string) []apidrift.Row {
+	if specPath == "" {
+		fail("-spec is required")
+	}
+	content, err := os.ReadFile(specPath)
+	if err != nil {
+		fail(fmt.Sprintf("reading spec: %v", err))
+	}
+	rows, problems := apidrift.Parse(string(content))
+	if len(problems) > 0 {
+		for _, p := range problems {
+			fmt.Fprintln(os.Stderr, p)
+		}
+		fail(fmt.Sprintf("%d spec problems", len(problems)))
+	}
+	return rows
+}
+
+func fail(msg string) {
+	fmt.Fprintln(os.Stderr, "Error: "+msg)
+	os.Exit(1)
+}

--- a/clicker/internal/apidrift/diff.go
+++ b/clicker/internal/apidrift/diff.go
@@ -1,0 +1,112 @@
+package apidrift
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ClientSurface is what a client extractor reports: dotted receiver path
+// ("page", "page.capture", "el") to the public members it exports.
+type ClientSurface map[string][]string
+
+// Findings is the result of one client-vs-spec comparison.
+type Findings struct {
+	// Missing: the spec claims the symbol is implemented, the client does
+	// not export it. These fail the check.
+	Missing []string
+	// Extra: the client exports it, no spec row names it. Reported so new
+	// methods get documented, but they do not fail the check: the doc rot
+	// this catches is loud already (the method is visible in the client).
+	Extra []string
+	// Unmapped: spec receivers the extractor did not report at all,
+	// usually a missing entry in the extractor's receiver map.
+	Unmapped []string
+}
+
+// Compare checks one client surface column against what the client exports.
+func Compare(rows []Row, surface string, actual ClientSurface) Findings {
+	var f Findings
+	claimed := map[string]map[string]bool{}
+	unmapped := map[string]bool{}
+
+	for _, row := range rows {
+		cell := row.Cells[surface]
+		if cell.Status != Implemented || row.Planned {
+			continue
+		}
+		recv, method := Receiver(cell.Name)
+		if recv == "" {
+			continue // not a dotted client symbol, nothing to look up
+		}
+		members, ok := actual[recv]
+		if !ok {
+			unmapped[recv] = true
+			continue
+		}
+		if claimed[recv] == nil {
+			claimed[recv] = map[string]bool{}
+		}
+		claimed[recv][method] = true
+		if !contains(members, method) {
+			f.Missing = append(f.Missing, fmt.Sprintf("row %d (%s): %s claims %s, client has no %s.%s",
+				row.Num, row.Desc, surface, cell.Name, recv, method))
+		}
+	}
+
+	for recv, members := range actual {
+		for _, m := range members {
+			if claimed[recv] != nil && claimed[recv][m] {
+				continue
+			}
+			f.Extra = append(f.Extra, recv+"."+m)
+		}
+	}
+	for recv := range unmapped {
+		f.Unmapped = append(f.Unmapped, recv)
+	}
+
+	sort.Strings(f.Missing)
+	sort.Strings(f.Extra)
+	sort.Strings(f.Unmapped)
+	return f
+}
+
+// Report renders findings for humans. ok reports whether the check passes.
+func (f Findings) Report(surface string) (string, bool) {
+	var b strings.Builder
+	ok := true
+	if len(f.Missing) > 0 {
+		ok = false
+		fmt.Fprintf(&b, "%s: %d symbols the spec claims but the client does not export:\n", surface, len(f.Missing))
+		for _, m := range f.Missing {
+			fmt.Fprintf(&b, "  %s\n", m)
+		}
+	}
+	if len(f.Unmapped) > 0 {
+		ok = false
+		fmt.Fprintf(&b, "%s: %d spec receivers the extractor did not report (extend its receiver map):\n", surface, len(f.Unmapped))
+		for _, r := range f.Unmapped {
+			fmt.Fprintf(&b, "  %s\n", r)
+		}
+	}
+	if len(f.Extra) > 0 {
+		fmt.Fprintf(&b, "%s: %d exported members with no api.md row (document or alias them):\n", surface, len(f.Extra))
+		for _, e := range f.Extra {
+			fmt.Fprintf(&b, "  %s\n", e)
+		}
+	}
+	if ok && len(f.Extra) == 0 {
+		fmt.Fprintf(&b, "%s: in sync with api.md\n", surface)
+	}
+	return b.String(), ok
+}
+
+func contains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/clicker/internal/apidrift/spec.go
+++ b/clicker/internal/apidrift/spec.go
@@ -1,0 +1,183 @@
+// Package apidrift parses docs/reference/api.md as the canonical description
+// of every Vibium surface (wire, CLI, MCP, JS, Python, Java) and compares it
+// against what a client actually exports. The doc is the spec on purpose:
+// the checker fails when the doc is malformed, so api.md cannot rot, and a
+// client cannot silently drift from what the doc promises.
+package apidrift
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Surfaces are the api.md table columns after # and Description, in order.
+var Surfaces = []string{"wire", "cli", "mcp", "js", "python", "java"}
+
+// Status classifies one table cell.
+type Status int
+
+const (
+	// Implemented: a backticked name, e.g. `page.pdf(opts?)`.
+	Implemented Status = iota
+	// Planned: the ⬜ marker.
+	Planned
+	// NotApplicable: the — marker.
+	NotApplicable
+	// Note: italic prose, e.g. *client-side event listener*. Real behavior
+	// with no nameable symbol on this surface.
+	Note
+)
+
+// Cell is one parsed table cell.
+type Cell struct {
+	Raw    string
+	Status Status
+	// Name is the parsed symbol for Implemented cells: a dotted path for
+	// clients ("page.capture.response"), the command for wire
+	// ("vibium:page.pdf"), the subcommand path for cli ("page new"), the
+	// tool name for mcp ("browser_pdf"). Empty otherwise.
+	Name string
+}
+
+// Row is one api.md table row.
+type Row struct {
+	Section string
+	Num     int
+	Desc    string
+	Cells   map[string]Cell
+	// Planned marks rows from a "(Planned)" section: their cells may show
+	// intended signatures, which are design, not implementation claims.
+	Planned bool
+}
+
+// Receiver returns the dotted receiver path and method name of a client
+// cell name ("page.capture.response" -> "page.capture", "response").
+func Receiver(name string) (string, string) {
+	i := strings.LastIndex(name, ".")
+	if i < 0 {
+		return "", name
+	}
+	return name[:i], name[i+1:]
+}
+
+// Parse reads api.md content into rows. Problems are collected rather than
+// aborting at the first, so one run reports every defect in the doc.
+func Parse(content string) ([]Row, []string) {
+	var rows []Row
+	var problems []string
+	seen := map[int]string{}
+	section := ""
+
+	for lineNo, line := range strings.Split(content, "\n") {
+		loc := fmt.Sprintf("api.md:%d", lineNo+1)
+		if strings.HasPrefix(line, "## ") {
+			section = strings.TrimSpace(strings.TrimPrefix(line, "## "))
+			continue
+		}
+		if !strings.HasPrefix(line, "| ") {
+			continue
+		}
+		fields := strings.Split(line, "|")
+		// "| a | b |" splits into empty, cells..., empty.
+		if len(fields) != len(Surfaces)+4 {
+			problems = append(problems, fmt.Sprintf("%s: %d columns, want %d", loc, len(fields)-2, len(Surfaces)+2))
+			continue
+		}
+		cells := fields[1 : len(fields)-1]
+		for i := range cells {
+			cells[i] = strings.TrimSpace(cells[i])
+		}
+		if cells[0] == "#" {
+			continue // header
+		}
+
+		num, err := strconv.Atoi(cells[0])
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("%s: row number %q is not a number", loc, cells[0]))
+			continue
+		}
+		if prev, dup := seen[num]; dup {
+			problems = append(problems, fmt.Sprintf("%s: row number %d already used at %s", loc, num, prev))
+		}
+		seen[num] = loc
+
+		row := Row{Section: section, Num: num, Desc: cells[1], Cells: map[string]Cell{},
+			Planned: strings.Contains(section, "(Planned)")}
+		if row.Desc == "" {
+			problems = append(problems, fmt.Sprintf("%s: empty description", loc))
+		}
+		for i, surface := range Surfaces {
+			cell, err := parseCell(surface, cells[2+i])
+			if err != nil {
+				problems = append(problems, fmt.Sprintf("%s: %s cell: %v", loc, surface, err))
+			}
+			row.Cells[surface] = cell
+		}
+		rows = append(rows, row)
+	}
+
+	if len(rows) == 0 {
+		problems = append(problems, "no table rows found")
+	}
+	return rows, problems
+}
+
+func parseCell(surface, raw string) (Cell, error) {
+	cell := Cell{Raw: raw}
+	switch {
+	case raw == "":
+		return cell, fmt.Errorf("empty")
+	case raw == "—":
+		cell.Status = NotApplicable
+		return cell, nil
+	case raw == "⬜":
+		cell.Status = Planned
+		return cell, nil
+	case strings.HasPrefix(raw, "*") && strings.HasSuffix(raw, "*"):
+		cell.Status = Note
+		return cell, nil
+	}
+
+	start := strings.Index(raw, "`")
+	end := strings.LastIndex(raw, "`")
+	if start < 0 || end == start {
+		return cell, fmt.Errorf("expected `name`, ⬜, —, or *note*, got %q", raw)
+	}
+	// Trailing prose after the backticks is allowed: `route.request` (property)
+	name := raw[start+1 : end]
+	cell.Status = Implemented
+	cell.Name = symbolFrom(surface, name)
+	if cell.Name == "" {
+		return cell, fmt.Errorf("no symbol in %q", raw)
+	}
+	return cell, nil
+}
+
+// symbolFrom reduces a backticked cell to a comparable symbol.
+func symbolFrom(surface, name string) string {
+	switch surface {
+	case "wire", "mcp":
+		return name
+	case "cli":
+		// `vibium find --all <sel>` -> "find": the leading binary name goes,
+		// then subcommand words up to the first flag or placeholder.
+		fields := strings.Fields(name)
+		if len(fields) == 0 || fields[0] != "vibium" {
+			return ""
+		}
+		var words []string
+		for _, f := range fields[1:] {
+			if strings.HasPrefix(f, "<") || strings.HasPrefix(f, "-") || strings.HasPrefix(f, "[") || strings.HasPrefix(f, "@") {
+				break
+			}
+			words = append(words, f)
+		}
+		return strings.Join(words, " ")
+	default: // js, python, java
+		if i := strings.Index(name, "("); i >= 0 {
+			name = name[:i]
+		}
+		return strings.TrimSpace(name)
+	}
+}

--- a/clicker/internal/apidrift/spec_test.go
+++ b/clicker/internal/apidrift/spec_test.go
@@ -1,0 +1,137 @@
+package apidrift
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const fixture = "## Page\n" +
+	"| # | Description | Wire Command | CLI | MCP | JS | Python | Java |\n" +
+	"|---|---|---|---|---|---|---|---|\n" +
+	"| 1 | Generate PDF | `vibium:page.pdf` | `vibium pdf` | `browser_pdf` | `page.pdf(opts?)` | `page.pdf(**opts)` | `page.pdf(options?)` |\n" +
+	"| 2 | Find all | `vibium:page.findAll` | `vibium find --all <sel>` | `browser_find_all` | `page.findAll(sel)` | `page.find_all(sel)` | `page.findAll(sel)` |\n" +
+	"| 3 | Capture a response | `vibium:capture` | — | ⬜ | `page.capture.response(pat)` | `page.capture.response(pat)` | `page.capture().response(pat)` |\n" +
+	"| 4 | Request handle | — | — | — | `route.request` (property) | *passed via callback args* | `route.request()` |\n"
+
+func TestParseFixture(t *testing.T) {
+	rows, problems := Parse(fixture)
+	if len(problems) != 0 {
+		t.Fatalf("unexpected problems: %v", problems)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("got %d rows, want 4", len(rows))
+	}
+
+	pdf := rows[0]
+	if pdf.Section != "Page" || pdf.Desc != "Generate PDF" {
+		t.Fatalf("row 1 parsed wrong: %+v", pdf)
+	}
+	for surface, want := range map[string]string{
+		"wire": "vibium:page.pdf", "cli": "pdf", "mcp": "browser_pdf",
+		"js": "page.pdf", "python": "page.pdf", "java": "page.pdf",
+	} {
+		if got := pdf.Cells[surface].Name; got != want {
+			t.Errorf("row 1 %s name = %q, want %q", surface, got, want)
+		}
+	}
+
+	if got := rows[1].Cells["cli"].Name; got != "find" {
+		t.Errorf("cli with flag: got %q, want %q", got, "find")
+	}
+	if got := rows[2].Cells["python"].Name; got != "page.capture.response" {
+		t.Errorf("nested receiver: got %q", got)
+	}
+	if rows[2].Cells["cli"].Status != NotApplicable || rows[2].Cells["mcp"].Status != Planned {
+		t.Errorf("markers parsed wrong: %+v", rows[2].Cells)
+	}
+	if got := rows[3].Cells["js"].Name; got != "route.request" {
+		t.Errorf("property with trailing note: got %q", got)
+	}
+	if rows[3].Cells["python"].Status != Note {
+		t.Errorf("italic note parsed as %v", rows[3].Cells["python"].Status)
+	}
+}
+
+func TestParseReportsProblems(t *testing.T) {
+	bad := "## X\n" +
+		"| # | Description | Wire Command | CLI | MCP | JS | Python | Java |\n" +
+		"|---|---|---|---|---|---|---|---|\n" +
+		"| 1 | Ok | `w` | — | — | `a.b()` | `a.b()` | `a.b()` |\n" +
+		"| 1 | Dup num | `w` | — | — | `a.c()` | `a.c()` | `a.c()` |\n" +
+		"| x | Bad num | `w` | — | — | `a.d()` | `a.d()` | `a.d()` |\n" +
+		"| 4 | Bad cell | plain text | — | — | `a.e()` | `a.e()` | `a.e()` |\n" +
+		"| 5 | Short row | `w` | — | — |\n"
+	_, problems := Parse(bad)
+	for _, want := range []string{"already used", "not a number", "expected", "columns"} {
+		found := false
+		for _, p := range problems {
+			if strings.Contains(p, want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("no problem mentioning %q in %v", want, problems)
+		}
+	}
+}
+
+func TestReceiver(t *testing.T) {
+	for name, want := range map[string][2]string{
+		"page.pdf":              {"page", "pdf"},
+		"page.capture.response": {"page.capture", "response"},
+		"start":                 {"", "start"},
+	} {
+		recv, method := Receiver(name)
+		if recv != want[0] || method != want[1] {
+			t.Errorf("Receiver(%q) = %q,%q want %q,%q", name, recv, method, want[0], want[1])
+		}
+	}
+}
+
+// The real spec must always parse clean: this is the doc-rot gate.
+func TestParseRealSpec(t *testing.T) {
+	content, err := os.ReadFile("../../../docs/reference/api.md")
+	if err != nil {
+		t.Fatalf("reading api.md: %v", err)
+	}
+	rows, problems := Parse(string(content))
+	if len(problems) != 0 {
+		t.Fatalf("api.md has %d problems:\n%s", len(problems), strings.Join(problems, "\n"))
+	}
+	if len(rows) < 150 {
+		t.Fatalf("only %d rows parsed, the spec has ~165+", len(rows))
+	}
+}
+
+func TestCompare(t *testing.T) {
+	rows, _ := Parse(fixture)
+	actual := ClientSurface{
+		"page":         {"pdf", "screenshot"},
+		"page.capture": {"response"},
+	}
+	f := Compare(rows, "python", actual)
+
+	if len(f.Missing) != 1 || !strings.Contains(f.Missing[0], "find_all") {
+		t.Errorf("Missing = %v, want the find_all claim", f.Missing)
+	}
+	if len(f.Extra) != 1 || f.Extra[0] != "page.screenshot" {
+		t.Errorf("Extra = %v, want page.screenshot", f.Extra)
+	}
+	if len(f.Unmapped) != 0 {
+		t.Errorf("Unmapped = %v, want none", f.Unmapped)
+	}
+
+	// route.* is claimed by the JS column but the extractor reported no
+	// route receiver: that is an extractor gap, not silence.
+	f = Compare(rows, "js", actual)
+	found := false
+	for _, r := range f.Unmapped {
+		if r == "route" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("js Unmapped = %v, want route", f.Unmapped)
+	}
+}

--- a/clients/javascript/src/element.ts
+++ b/clients/javascript/src/element.ts
@@ -170,6 +170,13 @@ export class Element {
     }));
   }
 
+  /** Highlight the element with a brief outline, for visual debugging. */
+  async highlight(options?: ActionOptions): Promise<void> {
+    await this.client.send('vibium:element.highlight', this.commandParams({
+      timeout: options?.timeout,
+    }));
+  }
+
   /** Drag this element to a target element. */
   async dragTo(target: Element, options?: ActionOptions): Promise<void> {
     await this.client.send('vibium:element.dragTo', this.commandParams({

--- a/clients/javascript/src/sync/element.ts
+++ b/clients/javascript/src/sync/element.ts
@@ -86,6 +86,11 @@ export class ElementSync {
     this.bridge.call('element.focus', [this.elementId, options]);
   }
 
+  /** Highlight the element with a brief outline, for visual debugging. */
+  highlight(options?: ActionOptions): void {
+    this.bridge.call('element.highlight', [this.elementId, options]);
+  }
+
   /** Drag this element to a target element. */
   dragTo(target: ElementSync, options?: ActionOptions): void {
     this.bridge.call('element.dragTo', [this.elementId, (target as any).elementId, options]);

--- a/clients/javascript/src/sync/worker.ts
+++ b/clients/javascript/src/sync/worker.ts
@@ -1223,6 +1223,12 @@ const handlers: Record<string, Handler> = {
     return { success: true };
   },
 
+  'element.highlight': async (args) => {
+    const [elementId, options] = args as [number, any];
+    await getElement(elementId).highlight(options);
+    return { success: true };
+  },
+
   'element.dragTo': async (args) => {
     const [elementId, targetId, options] = args as [number, number, any];
     const target = getElement(targetId);

--- a/scripts/apidrift_js.js
+++ b/scripts/apidrift_js.js
@@ -1,0 +1,103 @@
+// Dump the JS client's public surface as JSON for the apidrift checker.
+//
+// The built dist/index.d.ts is the source: TypeScript's private markers only
+// exist there (at runtime every member is a plain property), so the .d.ts is
+// what actually describes the public API. Keys are the receiver names api.md
+// uses in its JS column.
+//
+//   node scripts/apidrift_js.js | apidrift check -surface js -spec docs/reference/api.md -actual -
+
+const fs = require('fs');
+const path = require('path');
+
+const DTS = path.join(__dirname, '..', 'clients', 'javascript', 'dist', 'index.d.ts');
+
+// classMembers parses `declare class X { ... }` blocks into public member
+// names. Inline object types (Page's capture namespace) surface as their own
+// pseudo-class keyed "X.member".
+function parse(dts) {
+  const classes = {};
+  let current = null; // class name
+  let depth = 0;
+  let inlineKey = null; // "Page.capture" while inside its object type
+  let inlineDepth = 0;
+
+  for (const raw of dts.split('\n')) {
+    const line = raw.trim();
+
+    const cls = line.match(/^declare (?:abstract )?class (\w+)/);
+    if (cls) {
+      current = cls[1];
+      classes[current] = classes[current] || new Set();
+      depth = 0;
+    }
+    if (!current) continue;
+
+    if (depth === 1 && !line.startsWith('private') && !line.startsWith('protected')) {
+      const member = line.match(/^(?:readonly\s+)?(?:get\s+|set\s+)?([A-Za-z_$][\w$]*)\??\s*[(:<]/);
+      if (member && !member[1].startsWith('_') && member[1] !== 'constructor') {
+        if (inlineKey === null) {
+          classes[current].add(member[1]);
+          // An inline object type opens a nested namespace: its members
+          // belong to "Class.member", not the class.
+          if (/[:{]\s*{\s*$/.test(line)) {
+            inlineKey = `${current}.${member[1]}`;
+            classes[inlineKey] = classes[inlineKey] || new Set();
+            inlineDepth = depth;
+          }
+        }
+      }
+    } else if (inlineKey !== null && depth === 2) {
+      const member = line.match(/^([A-Za-z_$][\w$]*)\??\s*[(<]/);
+      if (member && !member[1].startsWith('_')) {
+        classes[inlineKey].add(member[1]);
+      }
+    }
+
+    for (const ch of line) {
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (inlineKey !== null && depth <= inlineDepth) inlineKey = null;
+        if (depth <= 0) current = null;
+      }
+    }
+  }
+
+  const out = {};
+  for (const [name, members] of Object.entries(classes)) {
+    out[name] = [...members].sort();
+  }
+  return out;
+}
+
+function main() {
+  const classes = parse(fs.readFileSync(DTS, 'utf-8'));
+  const dist = require(path.join(__dirname, '..', 'clients', 'javascript', 'dist'));
+
+  const surface = {
+    // browser is a module-level namespace (start/connect), merged with the
+    // Browser instance methods the same rows describe.
+    browser: [...new Set([...Object.keys(dist.browser), ...(classes.Browser || [])])].sort(),
+    page: classes.Page || [],
+    'page.capture': classes['Page.capture'] || [],
+    el: classes.Element || [],
+    context: classes.BrowserContext || [],
+    keyboard: classes.Keyboard || [],
+    mouse: classes.Mouse || [],
+    touch: classes.Touch || [],
+    clock: classes.Clock || [],
+    route: classes.Route || [],
+    dialog: classes.Dialog || [],
+    download: classes.Download || [],
+    request: classes.Request || [],
+    response: classes.Response || [],
+    message: classes.ConsoleMessage || [],
+    socket: classes.WebSocketInfo || [],
+    recording: classes.Recording || [],
+  };
+
+  process.stdout.write(JSON.stringify(surface, null, 1));
+}
+
+main();

--- a/scripts/apidrift_python.py
+++ b/scripts/apidrift_python.py
@@ -1,0 +1,90 @@
+"""Dump the Python client's public surface as JSON for the apidrift checker.
+
+Keys are the receiver names api.md uses in its Python column; values are the
+public members the sync client actually exports. Run from an environment
+where vibium is importable:
+
+    python scripts/apidrift_python.py | apidrift check -surface python -spec docs/reference/api.md -actual -
+"""
+
+import inspect
+import json
+import sys
+
+
+def members(obj):
+    out = set()
+    for name, value in inspect.getmembers(obj):
+        if name.startswith("_"):
+            continue
+        if not (callable(value) or isinstance(value, property)):
+            continue
+        if inspect.isclass(obj) and not defined_by_vibium(obj, name):
+            continue  # inherited from dict or another stdlib base
+        out.add(name)
+    return sorted(out)
+
+
+def defined_by_vibium(cls, name):
+    for klass in inspect.getmro(cls):
+        if name in vars(klass):
+            return getattr(klass, "__module__", "").startswith("vibium")
+    return False
+
+
+def main():
+    from vibium import browser
+    from vibium.sync_api import page as page_mod
+    from vibium.sync_api.page import (
+        Page,
+        Keyboard,
+        Mouse,
+        Touch,
+        _SyncCaptureNamespace,
+    )
+    from vibium.sync_api.element import Element
+    from vibium.sync_api.context import BrowserContext
+    from vibium.sync_api.clock import Clock
+    from vibium.sync_api.route import Route
+    from vibium.sync_api.browser import Browser
+
+    surface = {
+        "browser": sorted(set(members(browser)) | set(members(Browser))),
+        "page": members(Page),
+        "page.capture": members(_SyncCaptureNamespace),
+        "el": members(Element),
+        "context": members(BrowserContext),
+        "keyboard": members(Keyboard),
+        "mouse": members(Mouse),
+        "touch": members(Touch),
+        "clock": members(Clock),
+        "route": members(Route),
+    }
+
+    # Wrapper classes for events and recordings live beside Page or in their
+    # own modules depending on the client's layout; resolve what exists and
+    # report the rest as absent receivers so the checker flags the gap
+    # instead of this script crashing on a refactor.
+    optional = {
+        "dialog": ("vibium.sync_api.dialog", "Dialog"),
+        # The sync API hands back these wrapper objects from the async
+        # modules (and a dict-backed SyncDownload defined beside Page).
+        "download": ("vibium.sync_api.page", "SyncDownload"),
+        "request": ("vibium.async_api.network", "Request"),
+        "response": ("vibium.async_api.network", "Response"),
+        "message": ("vibium.async_api.console", "ConsoleMessage"),
+        "socket": ("vibium.async_api.websocket_info", "WebSocketInfo"),
+        "recording": ("vibium.sync_api.recording", "Recording"),
+    }
+    for key, (mod_name, cls_name) in optional.items():
+        try:
+            mod = __import__(mod_name, fromlist=[cls_name])
+            surface[key] = members(getattr(mod, cls_name))
+        except (ImportError, AttributeError):
+            pass  # absent receiver -> checker reports it as unmapped
+
+    json.dump(surface, sys.stdout, indent=1, sort_keys=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/js/async/engine/elements.test.js
+++ b/tests/js/async/engine/elements.test.js
@@ -178,3 +178,16 @@ describe('Element Finding', () => {
     assert.strictEqual(count, paragraphs.length, 'Iterator count should match length');
   });
 });
+
+describe('Element highlight', () => {
+  test('highlight() outlines the element (#435 drift find)', async () => {
+    const vibe = await bro.page();
+    await vibe.go(baseURL);
+
+    const el = await vibe.find('p');
+    await el.highlight();
+
+    const outline = await vibe.evaluate('document.querySelector("p").style.outline');
+    assert.match(outline, /solid/, `highlight should set an outline, got "${outline}"`);
+  });
+});


### PR DESCRIPTION
Part of VibiumDev/vibium#435 (first two increments; the Java, CLI, and MCP extractors follow on the same contract)

docs/reference/api.md lists every command across all six surfaces (wire, CLI, MCP, JS, Python, Java) but nothing verified it, so staying in sync meant reading the doc and the clients side by side. Recent examples of what that misses: the Java client's expose was documented and completely non-functional (#298), and the findAll info snapshot existed in all three clients with no doc row (#338).

The apidrift tool treats api.md as the spec:
- apidrift validate parses every table row and fails on malformed rows, duplicate numbers, or unparseable cells, so the doc itself cannot rot. Cell grammar covered: backticked signatures, ⬜ planned, — not-applicable, italic notes, trailing notes like (property), and (Planned) sections whose signatures are design rather than implementation claims.
- apidrift check compares one client column against a JSON dump of what that client exports. A symbol the spec claims but the client lacks fails the check; exported members with no doc row are listed but do not fail, since the method itself is already visible.

Extractors:
- scripts/apidrift_python.py introspects the Python sync surface, keyed by the receiver names the doc uses (page, el, page.capture, ...), with stdlib-inherited members filtered.
- scripts/apidrift_js.js parses the built dist/index.d.ts, since TypeScript's private markers only exist there: at runtime every member is a plain property, and runtime introspection misreported eleven internal handlers as public. Inline object types (the page.capture namespace) parse as their own receiver.

make check-api-drift chains spec validation and both client checks, browser-free, and runs as a step in the chrome CI job.

The first real runs both paid off:
- Python is fully in sync on implementation claims, with ten undocumented members reported (aliases like page.eval and el.get_attribute, properties like route.request).
- The JS column had real drift: api.md row 79 claims el.highlight(), Python and Java both have it, the JS client never did. This PR adds it to the async client, sync client, and sync worker, with an engine test asserting the outline appears. The JS run also reports fifteen undocumented members, including el.info and page.routeWebSocket.

Verified:
- Go unit tests cover the cell grammar, problem reporting, receiver splitting, and compare semantics including the unmapped-receiver case; one test parses the real api.md and fails if it ever stops being well-formed.
- make check-api-drift runs clean end to end locally; the new el.highlight engine test passes against the local binary.