### PR TITLE
Check the Java, CLI, and MCP surfaces for API drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,7 @@ mtlshim:
 
 test: build install-browser $(FAST_LAUNCH_DEP)
 	@START_TIME=$$(date +%s); \
+	"$(MAKE)" check-api-drift && \
 	"$(MAKE)" test-go && \
 	"$(MAKE)" test-cli test-cleanup && \
 	"$(MAKE)" test-js-process test-cleanup && \

--- a/Makefile
+++ b/Makefile
@@ -497,13 +497,18 @@ test-firefox-capabilities: build-go install-firefox
 # Browser-free cross-surface API drift check. docs/reference/api.md is the
 # spec: fails on a malformed doc or on a client column claiming a symbol the
 # client does not export. Undocumented extras are reported but do not fail.
-check-api-drift: python-venv build-js
-	@echo "--- API Drift Check (spec + js + python) ---"
+check-api-drift: python-venv build-js build-go
+	@echo "--- API Drift Check (spec + all surfaces) ---"
 	cd clicker && go run ./cmd/apidrift validate -spec ../docs/reference/api.md
 	@cd clients/python && . $(VENV_ACTIVATE) && python ../../scripts/apidrift_python.py | \
 		(cd ../../clicker && go run ./cmd/apidrift check -surface python -spec ../docs/reference/api.md -actual -)
 	@node scripts/apidrift_js.js | \
 		(cd clicker && go run ./cmd/apidrift check -surface js -spec ../docs/reference/api.md -actual -)
+	@cd clients/java && ./gradlew -q compileJava && cd ../.. && $(PYTHON) scripts/apidrift_java.py | \
+		(cd clicker && go run ./cmd/apidrift check -surface java -spec ../docs/reference/api.md -actual -)
+	@./clicker/bin/vibium$(EXE) commands | \
+		(cd clicker && go run ./cmd/apidrift check -surface cli -spec ../docs/reference/api.md -actual -)
+	@cd clicker && go run ./cmd/apidrift mcp-surface | go run ./cmd/apidrift check -surface mcp -spec ../docs/reference/api.md -actual -
 
 test-capability-audit: build-js python-venv
 	@echo "--- Browser-free Chrome Capability Audit ---"

--- a/clicker/cmd/apidrift/main.go
+++ b/clicker/cmd/apidrift/main.go
@@ -17,14 +17,27 @@ import (
 	"io"
 	"os"
 
+	"github.com/vibium/clicker/internal/agent"
 	"github.com/vibium/clicker/internal/apidrift"
 )
 
 func main() {
 	if len(os.Args) < 2 {
-		fail("usage: apidrift <validate|check> [flags]")
+		fail("usage: apidrift <validate|check|mcp-surface> [flags]")
 	}
 	switch os.Args[1] {
+	case "mcp-surface":
+		// The MCP tool list is a Go literal in internal/agent, so the
+		// extractor is a direct import rather than a script.
+		names := map[string][]string{"": nil}
+		for _, tool := range agent.GetToolSchemas() {
+			names[""] = append(names[""], tool.Name)
+		}
+		out, err := json.Marshal(names)
+		if err != nil {
+			fail(err.Error())
+		}
+		fmt.Println(string(out))
 	case "validate":
 		fs := flag.NewFlagSet("validate", flag.ExitOnError)
 		spec := fs.String("spec", "", "path to api.md")

--- a/clicker/cmd/clicker/commands_cmd.go
+++ b/clicker/cmd/clicker/commands_cmd.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// newCommandsCmd lists every runnable command path as JSON, for the API
+// drift checker (cmd/apidrift) and any tooling that wants the real command
+// tree instead of parsed help text.
+func newCommandsCmd(root *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:    "commands",
+		Short:  "List every command path as JSON",
+		Hidden: true,
+		Example: `  vibium commands
+  # {"":["a11y-tree","attr","back", ... ,"page new","wait","wait fn", ...]}`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			var paths []string
+			var walk func(c *cobra.Command, prefix string)
+			walk = func(c *cobra.Command, prefix string) {
+				for _, sub := range c.Commands() {
+					if sub.Hidden || sub.Name() == "help" || sub.Name() == "completion" {
+						continue
+					}
+					path := strings.TrimSpace(prefix + " " + sub.Name())
+					// A parent that groups subcommands (is, page) runs only
+					// to print help; one that also takes arguments (wait
+					// <sel> beside wait fn/url/load) or says so explicitly
+					// (storage) is a real command too.
+					standalone := !sub.HasSubCommands() ||
+						strings.ContainsAny(sub.Use, "[<") ||
+						sub.Annotations["standalone"] == "true"
+					if sub.Runnable() && standalone {
+						paths = append(paths, path)
+					}
+					walk(sub, path)
+				}
+			}
+			walk(root, "")
+			sort.Strings(paths)
+			out, _ := json.Marshal(map[string][]string{"": paths})
+			fmt.Println(string(out))
+		},
+	}
+}

--- a/clicker/cmd/clicker/main.go
+++ b/clicker/cmd/clicker/main.go
@@ -120,6 +120,7 @@ func main() {
 	rootCmd.AddCommand(newCompletionCmd(rootCmd))
 
 	// Register all commands
+	rootCmd.AddCommand(newCommandsCmd(rootCmd))
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(newPathsCmd())
 	rootCmd.AddCommand(newIsInstalledCmd())

--- a/clicker/cmd/clicker/storage.go
+++ b/clicker/cmd/clicker/storage.go
@@ -12,6 +12,9 @@ func newStorageCmd() *cobra.Command {
 	storageCmd := &cobra.Command{
 		Use:   "storage",
 		Short: "Export or restore browser state (cookies, localStorage, sessionStorage)",
+		// Unlike other subcommand parents, running this bare does real work
+		// (prints the state); the annotation keeps it in `vibium commands`.
+		Annotations: map[string]string{"standalone": "true"},
 		Example: `  vibium storage
   # Print state as JSON
 

--- a/clicker/internal/apidrift/diff.go
+++ b/clicker/internal/apidrift/diff.go
@@ -36,8 +36,13 @@ func Compare(rows []Row, surface string, actual ClientSurface) Findings {
 			continue
 		}
 		recv, method := Receiver(cell.Name)
+		// Undotted symbols (CLI subcommands, MCP tool names) live under the
+		// extractor's "" key as one flat namespace. A client column's
+		// module-level name has nothing to look up.
 		if recv == "" {
-			continue // not a dotted client symbol, nothing to look up
+			if _, flat := actual[""]; !flat {
+				continue
+			}
 		}
 		members, ok := actual[recv]
 		if !ok {
@@ -49,8 +54,8 @@ func Compare(rows []Row, surface string, actual ClientSurface) Findings {
 		}
 		claimed[recv][method] = true
 		if !contains(members, method) {
-			f.Missing = append(f.Missing, fmt.Sprintf("row %d (%s): %s claims %s, client has no %s.%s",
-				row.Num, row.Desc, surface, cell.Name, recv, method))
+			f.Missing = append(f.Missing, fmt.Sprintf("row %d (%s): %s claims %s, surface has no %s",
+				row.Num, row.Desc, surface, cell.Name, strings.TrimPrefix(recv+"."+method, ".")))
 		}
 	}
 
@@ -59,7 +64,7 @@ func Compare(rows []Row, surface string, actual ClientSurface) Findings {
 			if claimed[recv] != nil && claimed[recv][m] {
 				continue
 			}
-			f.Extra = append(f.Extra, recv+"."+m)
+			f.Extra = append(f.Extra, strings.TrimPrefix(recv+"."+m, "."))
 		}
 	}
 	for recv := range unmapped {

--- a/clicker/internal/apidrift/spec.go
+++ b/clicker/internal/apidrift/spec.go
@@ -175,6 +175,9 @@ func symbolFrom(surface, name string) string {
 		}
 		return strings.Join(words, " ")
 	default: // js, python, java
+		// Java's fluent accessors read page.capture().response(...): the
+		// empty parens are part of the path, not the call being named.
+		name = strings.ReplaceAll(name, "()", "")
 		if i := strings.Index(name, "("); i >= 0 {
 			name = name[:i]
 		}

--- a/clicker/internal/apidrift/spec_test.go
+++ b/clicker/internal/apidrift/spec_test.go
@@ -135,3 +135,41 @@ func TestCompare(t *testing.T) {
 		t.Errorf("js Unmapped = %v, want route", f.Unmapped)
 	}
 }
+
+func TestSymbolFromFluentAndFlat(t *testing.T) {
+	row := "## X\n" +
+		"| # | Description | Wire Command | CLI | MCP | JS | Python | Java |\n" +
+		"|---|---|---|---|---|---|---|---|\n" +
+		"| 1 | Capture | — | `vibium diff map` | `browser_diff_map` | — | — | `page.capture().response(pat, action)` |\n"
+	rows, problems := Parse(row)
+	if len(problems) != 0 {
+		t.Fatalf("problems: %v", problems)
+	}
+	if got := rows[0].Cells["java"].Name; got != "page.capture.response" {
+		t.Errorf("fluent java cell: got %q, want page.capture.response", got)
+	}
+	if got := rows[0].Cells["cli"].Name; got != "diff map" {
+		t.Errorf("cli subcommand path: got %q, want %q", got, "diff map")
+	}
+}
+
+func TestCompareFlatNamespace(t *testing.T) {
+	rows, _ := Parse("## X\n" +
+		"| # | Description | Wire Command | CLI | MCP | JS | Python | Java |\n" +
+		"|---|---|---|---|---|---|---|---|\n" +
+		"| 1 | A | — | `vibium daemon start` | `browser_pdf` | — | — | — |\n" +
+		"| 2 | B | — | `vibium gone` | `browser_gone` | — | — | — |\n")
+
+	f := Compare(rows, "cli", ClientSurface{"": {"daemon start", "extra thing"}})
+	if len(f.Missing) != 1 || !strings.Contains(f.Missing[0], "gone") {
+		t.Errorf("cli Missing = %v, want the gone claim", f.Missing)
+	}
+	if len(f.Extra) != 1 || f.Extra[0] != "extra thing" {
+		t.Errorf("cli Extra = %v, want [extra thing] without a leading dot", f.Extra)
+	}
+
+	f = Compare(rows, "mcp", ClientSurface{"": {"browser_pdf"}})
+	if len(f.Missing) != 1 || !strings.Contains(f.Missing[0], "browser_gone") {
+		t.Errorf("mcp Missing = %v, want browser_gone", f.Missing)
+	}
+}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -258,7 +258,7 @@ MCP/CLI-only tools with no direct client API equivalent.
 | # | Description | Wire Command | CLI | MCP | JS | Python | Java |
 |---|---|---|---|---|---|---|---|
 | 162 | Map interactive page elements with @refs | — | `vibium map` | `browser_map` | — | — | — |
-| 163 | Diff page state vs last map | — | `vibium diff` | `browser_diff_map` | — | — | — |
+| 163 | Diff page state vs last map | — | `vibium diff map` | `browser_diff_map` | — | — | — |
 | 164 | Count elements matching selector | — | `vibium count <sel>` | `browser_count` | — | — | — |
 | 165 | Wait for text to appear on page | — | `vibium wait text <text>` | `browser_wait_for_text` | — | — | — |
 | 166 | Set the download directory | — | `vibium download dir <path>` | `browser_download_set_dir` | — | — | — |

--- a/scripts/apidrift_java.py
+++ b/scripts/apidrift_java.py
@@ -1,0 +1,76 @@
+"""Dump the Java client's public surface as JSON for the apidrift checker.
+
+Reads the compiled classes with javap, so what gets compared is what the
+class files actually expose. Requires a JDK and a prior gradle compileJava:
+
+    python scripts/apidrift_java.py | apidrift check -surface java -spec docs/reference/api.md -actual -
+"""
+
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CLASSES = ROOT / "clients" / "java" / "build" / "classes" / "java" / "main"
+
+# Receiver names api.md uses in its Java column, to the classes behind them.
+RECEIVERS = {
+    "Vibium": "com.vibium.Vibium",
+    "browser": "com.vibium.Browser",
+    "page": "com.vibium.Page",
+    "page.capture": "com.vibium.Capture",
+    "el": "com.vibium.Element",
+    "context": "com.vibium.BrowserContext",
+    "keyboard": "com.vibium.Keyboard",
+    "mouse": "com.vibium.Mouse",
+    "touch": "com.vibium.Touch",
+    "clock": "com.vibium.Clock",
+    "route": "com.vibium.Route",
+    "dialog": "com.vibium.Dialog",
+    "download": "com.vibium.Download",
+    "request": "com.vibium.Request",
+    "response": "com.vibium.Response",
+    "message": "com.vibium.ConsoleMessage",
+    "socket": "com.vibium.WebSocketInfo",
+    "recording": "com.vibium.Recording",
+}
+
+# javap member lines look like "  public void go(java.lang.String);" or
+# "  public byte[] pdf();". Constructors carry the class name and no return
+# type, so requiring a space-separated word before the member name skips them.
+MEMBER = re.compile(r"^\s+public\s+(?:static\s+|final\s+)*\S+\s+(\w+)\(")
+
+
+def members(class_name):
+    out = subprocess.run(
+        ["javap", "-public", "-classpath", str(CLASSES), class_name],
+        capture_output=True,
+        text=True,
+    )
+    if out.returncode != 0:
+        sys.stderr.write(f"javap {class_name}: {out.stderr}")
+        sys.exit(1)
+    names = set()
+    for line in out.stdout.splitlines():
+        # Generic return types contain spaces (Map<String, String>), which
+        # would split the type across the regex's word boundaries.
+        while re.search(r"<[^<>]*>", line):
+            line = re.sub(r"<[^<>]*>", "", line)
+        m = MEMBER.match(line)
+        if m and m.group(1) not in ("toString", "equals", "hashCode"):
+            names.add(m.group(1))
+    return sorted(names)
+
+
+def main():
+    if not CLASSES.is_dir():
+        sys.stderr.write(f"{CLASSES} missing: run gradle compileJava first\n")
+        sys.exit(1)
+    surface = {recv: members(cls) for recv, cls in RECEIVERS.items()}
+    json.dump(surface, sys.stdout, indent=1, sort_keys=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of VibiumDev/vibium#435 (third increment, stacked on the checker PR; retargets to main when that merges)

Extends the drift checker to the remaining three columns, so all six surfaces of api.md are now verified:

- Java: scripts/apidrift_java.py reads the compiled classes with javap, so the comparison sees exactly what the class files expose. Generic return types (Map<String, String> broke the first parse and hid headers()) and Object overrides like toString are handled.
- CLI: a hidden vibium commands subcommand dumps the real cobra command tree as JSON, instead of parsing help text. Parents that exist only to group subcommands (is, page, diff) are excluded; storage, which does real work when run bare, carries an annotation saying so.
- MCP: apidrift mcp-surface imports the tool schema directly and dumps the tool names.
- The comparison learns two grammar cases: undotted symbols (CLI paths like "daemon start", MCP tool names) compare against a flat namespace, and Java's fluent accessors like page.capture().response(...) parse as dotted paths.

make check-api-drift now validates the spec and checks all five surfaces, still browser-free.

What the first runs found:
- MCP is fully in sync, both directions.
- api.md row 163 claimed vibium diff; the real command is vibium diff map. Fixed.
- Java and CLI are in sync on claims. Remaining warnings across surfaces: 10 Python, 15 JS, 15 Java, 24 CLI exported-but-undocumented entries, which the follow-up doc-rows change addresses. The CLI list includes deliberate candidates for discussion: the dev diagnostics (launch-test, ws-test, bidi-test) could be documented or hidden.

Verified:
- New unit tests for the fluent-parens parse, CLI subcommand paths, and flat-namespace comparison in both directions.
- make check-api-drift runs clean end to end locally across all five surfaces; go test on cmd/clicker and internal/apidrift green.