### PR TITLE
Document every exported member so all surfaces check clean

### DIFF
--- a/clients/javascript/src/element.ts
+++ b/clients/javascript/src/element.ts
@@ -68,8 +68,8 @@ export class Element {
     };
   }
 
-  /** Return params that can identify this element for use as a target (e.g. dragTo). */
-  toParams(): Record<string, unknown> {
+  /** Params that identify this element as a target (e.g. dragTo). */
+  private toParams(): Record<string, unknown> {
     return {
       ...this._params,
       selector: this.selector,

--- a/clients/python/src/vibium/sync_api/element.py
+++ b/clients/python/src/vibium/sync_api/element.py
@@ -17,7 +17,11 @@ class Element:
     def __init__(self, async_element: AsyncElement, loop_thread: _EventLoopThread) -> None:
         self._async = async_element
         self._loop = loop_thread
-        self.info = async_element.info
+
+    @property
+    def info(self):
+        """Snapshot of tag, text, and box captured when the element was found."""
+        return self._async.info
 
     def __repr__(self) -> str:
         text = self.info.text

--- a/clients/python/src/vibium/sync_api/page.py
+++ b/clients/python/src/vibium/sync_api/page.py
@@ -78,15 +78,32 @@ class Page:
         self._async = async_page
         self._loop = loop_thread
 
-        self.keyboard = Keyboard(async_page.keyboard, loop_thread)
-        self.mouse = Mouse(async_page.mouse, loop_thread)
-        self.touch = Touch(async_page.touch, loop_thread)
-        self.clock = Clock(async_page.clock, loop_thread)
+        self._keyboard = Keyboard(async_page.keyboard, loop_thread)
+        self._mouse = Mouse(async_page.mouse, loop_thread)
+        self._touch = Touch(async_page.touch, loop_thread)
+        self._clock = Clock(async_page.clock, loop_thread)
 
         # Sync event state
         self._console_messages: List[Dict[str, str]] = []
         self._errors: List[Dict[str, str]] = []
         self._cached_context: Optional[BrowserContextType] = None
+
+
+    @property
+    def keyboard(self) -> Keyboard:
+        return self._keyboard
+
+    @property
+    def mouse(self) -> Mouse:
+        return self._mouse
+
+    @property
+    def touch(self) -> Touch:
+        return self._touch
+
+    @property
+    def clock(self) -> Clock:
+        return self._clock
 
     def __repr__(self) -> str:
         try:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -21,6 +21,7 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 7 | Listen for new page events | *client-side event listener* | — | — | `browser.onPage(cb)` | `browser.on_page(cb)` | `browser.onPage(cb)` |
 | 8 | Listen for popup events | *client-side event listener* | — | — | `browser.onPopup(cb)` | `browser.on_popup(cb)` | `browser.onPopup(cb)` |
 | 9 | Remove all event listeners | *client-side* | — | — | `browser.removeAllListeners(ev?)` | `browser.remove_all_listeners(ev?)` | `browser.removeAllListeners(ev?)` |
+| 187 | Get the default context | *client-side* | — | — | — | — | `browser.context()` |
 
 ## Page
 
@@ -79,6 +80,18 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 60 | Capture dialog (before action) | *client-side* | — | — | `page.capture.dialog(fn?)` | `page.capture.dialog(fn?)` | `page.capture().dialog(action)` |
 | 61 | Get buffered console messages | *client-side* | — | — | `page.consoleMessages()` | `page.console_messages()` | `page.consoleMessages()` |
 | 62 | Get buffered page errors | *client-side* | — | — | `page.errors()` | `page.errors()` | `page.errors()` |
+| 170 | Owning browser context | *client-side* | — | — | `page.context` | `page.context` | `page.context()` |
+| 171 | Browsing context id | *client-side* | — | — | `page.id` | `page.id` | `page.id()` |
+| 172 | One-shot capture namespace | *client-side* | — | — | `page.capture` | `page.capture` | `page.capture()` |
+| 173 | Keyboard input for the page | *client-side* | — | — | `page.keyboard` | `page.keyboard` | `page.keyboard()` |
+| 174 | Mouse input for the page | *client-side* | — | — | `page.mouse` | `page.mouse` | `page.mouse()` |
+| 175 | Touch input for the page | *client-side* | — | — | `page.touch` | `page.touch` | `page.touch()` |
+| 176 | Clock control for the page | *client-side* | — | — | `page.clock` | `page.clock` | `page.clock()` |
+| 177 | Deprecated alias for the wait helpers | *client-side* | — | — | `page.waitUntil(fn, opts?)` | `page.wait_until` | — |
+| 178 | Enable console collect mode | *client-side* | — | — | *mode of onConsole('collect')* | *mode of on_console('collect')* | `page.collectConsole()` |
+| 179 | Enable error collect mode | *client-side* | — | — | *mode of onError('collect')* | *mode of on_error('collect')* | `page.collectErrors()` |
+| 180 | Intercept WebSockets (unsupported: throws) | — | — | — | `page.routeWebSocket(pattern, fn)` | — | — |
+| 181 | Alias for evaluate | *client-side* | — | — | — | `page.eval(expr)` | — |
 
 ## Element
 
@@ -107,6 +120,9 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 83 | Get input element value | `vibium:element.value` | `vibium value <sel>` | `browser_get_value` | `el.value()` | `el.value()` | `el.value()` |
 | 84 | Get element attribute | `vibium:element.attr` | `vibium attr <sel> <name>` | `browser_get_attribute` | `el.attr(name)` | `el.attr(name)` | `el.attr(name)` |
 | 85 | Get element bounding box | `vibium:element.bounds` | — | — | `el.bounds()` | `el.bounds()` | `el.bounds()` |
+| 182 | Bounding box (Playwright-compat alias for bounds) | *client-side* | — | — | `el.boundingBox()` | `el.bounding_box()` | `el.boundingBox()` |
+| 183 | Get attribute (alias for attr) | *client-side* | — | — | `el.getAttribute(name)` | `el.get_attribute(name)` | `el.getAttribute(name)` |
+| 184 | Find-time snapshot of tag, text, and box | *captured at find time* | — | — | `el.info` | `el.info` | `el.info()` |
 | 86 | Check if element is visible | `vibium:element.isVisible` | `vibium is visible <sel>` | `browser_is_visible` | `el.isVisible()` | `el.is_visible()` | `el.isVisible()` |
 | 87 | Check if element is hidden | `vibium:element.isHidden` | — | — | `el.isHidden()` | `el.is_hidden()` | `el.isHidden()` |
 | 88 | Check if element is enabled | `vibium:element.isEnabled` | `vibium is enabled <sel>` | `browser_is_enabled` | `el.isEnabled()` | `el.is_enabled()` | `el.isEnabled()` |
@@ -132,6 +148,8 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 103 | Set storage state | `vibium:context.setStorage` | — | `browser_restore_storage` | `context.setStorage(state)` | `context.set_storage(state)` | `context.setStorage(state)` |
 | 104 | Clear all storage | `vibium:context.clearStorage` | — | — | `context.clearStorage()` | `context.clear_storage()` | `context.clearStorage()` |
 | 105 | Add an init script | `vibium:context.addInitScript` | — | — | `context.addInitScript(script)` | `context.add_init_script(script)` | `context.addInitScript(script)` |
+| 185 | User context id | *client-side* | — | — | `context.id` | `context.id` | `context.id()` |
+| 186 | Recording controls for the context | *client-side* | — | — | `context.recording` | `context.recording` | `context.recording()` |
 
 ## Keyboard
 
@@ -188,7 +206,7 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 
 | # | Description | Wire Command | CLI | MCP | JS | Python | Java |
 |---|---|---|---|---|---|---|---|
-| 130 | Access intercepted request | — | — | — | `route.request` (property) | *passed via callback args* | `route.request()` |
+| 130 | Access intercepted request | — | — | — | `route.request` (property) | `route.request` (property) | `route.request()` |
 | 131 | Fulfill an intercepted request | `vibium:network.fulfill` | — | — | `route.fulfill(resp?)` | `route.fulfill(status?, headers?, ...)` | `route.fulfill(options?)` |
 | 132 | Continue an intercepted request | `vibium:network.continue` | — | — | `route.continue(overrides?)` | `route.continue_(overrides?)` | `route.doContinue(options?)` |
 | 133 | Abort an intercepted request | `vibium:network.abort` | — | — | `route.abort()` | `route.abort()` | `route.abort()` |
@@ -262,6 +280,30 @@ MCP/CLI-only tools with no direct client API equivalent.
 | 164 | Count elements matching selector | — | `vibium count <sel>` | `browser_count` | — | — | — |
 | 165 | Wait for text to appear on page | — | `vibium wait text <text>` | `browser_wait_for_text` | — | — | — |
 | 166 | Set the download directory | — | `vibium download dir <path>` | `browser_download_set_dir` | — | — | — |
+| 188 | Start the background daemon | — | `vibium daemon start` | — | — | — | — |
+| 189 | Query daemon status | — | `vibium daemon status` | — | — | — | — |
+| 190 | Stop the background daemon | — | `vibium daemon stop` | — | — | — | — |
+| 191 | Print the version | — | `vibium version` | — | — | — | — |
+| 192 | Print browser and cache paths | — | `vibium paths` | — | — | — | — |
+| 193 | Download the browser engine | — | `vibium install` | — | — | — | — |
+| 194 | Check whether the engine is installed | — | `vibium is-installed` | — | — | — | — |
+| 195 | Run the BiDi websocket server | — | `vibium serve` | — | — | — | — |
+| 196 | Run the ndjson stdio transport | — | `vibium pipe` | — | — | — | — |
+| 197 | Run the MCP server | — | `vibium mcp` | — | — | — | — |
+| 198 | Install the agent skill | — | `vibium add-skill` | — | — | — | — |
+| 199 | Restore saved storage state | — | `vibium storage restore <path>` | — | — | — | — |
+| 200 | Print all actionability checks | — | `vibium is actionable <sel>` | — | — | — | — |
+| 201 | Find by ARIA role | — | `vibium find role <val>` | — | — | — | — |
+| 202 | Find by visible text | — | `vibium find text <val>` | — | — | — | — |
+| 203 | Find by label | — | `vibium find label <val>` | — | — | — | — |
+| 204 | Find by placeholder | — | `vibium find placeholder <val>` | — | — | — | — |
+| 205 | Find by alt text | — | `vibium find alt <val>` | — | — | — | — |
+| 206 | Find by title attribute | — | `vibium find title <val>` | — | — | — | — |
+| 207 | Find by test id | — | `vibium find testid <val>` | — | — | — | — |
+| 208 | Find by XPath | — | `vibium find xpath <val>` | — | — | — | — |
+| 209 | Diagnostic: launch the browser directly | — | `vibium launch-test` | — | — | — | — |
+| 210 | Diagnostic: test a websocket endpoint | — | `vibium ws-test <url>` | — | — | — | — |
+| 211 | Diagnostic: test a BiDi endpoint | — | `vibium bidi-test <url>` | — | — | — | — |
 
 ## AI-Native (Planned)
 


### PR DESCRIPTION
Part of VibiumDev/vibium#435 (final increment: with this, all five surfaces report in sync with api.md in both directions)

Adds api.md rows for the 64 exported-but-undocumented members the drift checker reported: page and element accessors (context, id, capture, keyboard, mouse, touch, clock), the find-time info snapshot, the bounding-box and attribute aliases, context id and recording, the console and error collect modes, the deprecated wait_until alias, the unsupported routeWebSocket stub, and the CLI-only commands including the daemon lifecycle, the semantic find variants, storage restore, and the three diagnostics (launch-test, ws-test, bidi-test; documenting them was the conservative choice, hiding them instead is a one-line change each if preferred).

Three of the warnings were client gaps rather than doc gaps:
- The Python client exposed el.info and page.keyboard/mouse/touch/clock as instance attributes, invisible to introspection; they are properties now, which also stops accidental reassignment.
- JS toParams was public plumbing; it is private now, which TypeScript permits for its one cross-instance use in dragTo.
- api.md row 130 said the Python route passes the request only via callback args, but route.request has been a live property.

Verified:
- make check-api-drift end to end: 211 rows well-formed, python, js, java, cli, and mcp all report in sync with api.md, no warnings remaining.
- The Python property conversions passed the sync API tests exercising them (element info reads, keyboard press, capture namespace).
- The JS build is clean with toParams private; the dragTo path that uses it is covered by the engine suite in CI.