### PR TITLE
Move the dialog dismiss default into the engine

### DIFF
--- a/clicker/internal/api/handlers_dialog.go
+++ b/clicker/internal/api/handlers_dialog.go
@@ -1,5 +1,87 @@
 package api
 
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// handleDialogSetPolicy handles vibium:dialog.setPolicy — decides who owns a
+// user prompt when it opens in the given context. "dismiss" (the default) has
+// the router close the prompt itself; "manual" leaves it open for the client's
+// dialog handlers. Client pages flip their context to manual when their first
+// dialog handler registers and back when the last one is removed. The context
+// is required and taken as given (no resolution round trip), because this
+// handler runs inline on the client message order — that ordering is what
+// guarantees a dialog cannot open under a policy the client already left.
+func (r *Router) handleDialogSetPolicy(session *BrowserSession, cmd bidiCommand) {
+	context, _ := cmd.Params["context"].(string)
+	if context == "" {
+		r.sendError(session, cmd.ID, fmt.Errorf("vibium:dialog.setPolicy requires a context"))
+		return
+	}
+	policy, _ := cmd.Params["policy"].(string)
+	session.mu.Lock()
+	if session.dialogManual == nil {
+		session.dialogManual = make(map[string]struct{})
+	}
+	switch policy {
+	case "manual":
+		session.dialogManual[context] = struct{}{}
+	case "dismiss":
+		delete(session.dialogManual, context)
+	default:
+		session.mu.Unlock()
+		r.sendError(session, cmd.ID, fmt.Errorf("invalid dialog policy %q (want \"dismiss\" or \"manual\")", policy))
+		return
+	}
+	session.mu.Unlock()
+	r.sendSuccess(session, cmd.ID, map[string]interface{}{})
+}
+
+// autoDismissContext returns the browsing context of a userPromptOpened event
+// the router must close itself, or "" when the event is something else or the
+// client has taken that context over via vibium:dialog.setPolicy.
+func (s *BrowserSession) autoDismissContext(msg string) string {
+	var evt struct {
+		Method string `json:"method"`
+		Params struct {
+			Context string `json:"context"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(msg), &evt); err != nil {
+		return ""
+	}
+	if evt.Method != "browsingContext.userPromptOpened" {
+		return ""
+	}
+	s.mu.Lock()
+	_, manual := s.dialogManual[evt.Params.Context]
+	s.mu.Unlock()
+	if manual {
+		return ""
+	}
+	return evt.Params.Context
+}
+
+// dismissUnhandledPrompt closes a user prompt the client has not claimed. Runs
+// off the routing goroutine so a slow browser cannot stall event delivery. The
+// usual failure is benign — the prompt was already closed by a racing command —
+// but it is still logged, so a dialog that stays stuck names its cause.
+func (r *Router) dismissUnhandledPrompt(session *BrowserSession, context string) {
+	resp, err := r.sendInternalCommand(session, "browsingContext.handleUserPrompt", map[string]interface{}{
+		"context": context,
+		"accept":  false,
+	})
+	if err == nil {
+		err = checkBidiError(resp)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[router] auto-dismiss of prompt in context %s failed for client %d: %v\n",
+			context, session.Client.ID(), err)
+	}
+}
+
 // handleDialogAccept handles vibium:dialog.accept — accepts a user prompt (alert/confirm/prompt).
 func (r *Router) handleDialogAccept(session *BrowserSession, cmd bidiCommand) {
 	context, err := r.resolveContext(session, cmd.Params)

--- a/clicker/internal/api/handlers_dialog_test.go
+++ b/clicker/internal/api/handlers_dialog_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// recordingTransport captures messages sent to the client.
+type recordingTransport struct {
+	sent []string
+}
+
+func (t *recordingTransport) ID() uint64            { return 1 }
+func (t *recordingTransport) Send(msg string) error { t.sent = append(t.sent, msg); return nil }
+func (t *recordingTransport) Close() error          { return nil }
+
+const promptOpened = `{"method":"browsingContext.userPromptOpened","params":{"context":"ctx-1","type":"alert","message":"hi"}}`
+
+// The router owns the no-handler default: a prompt that opens while no client
+// dialog handler is registered is the router's to dismiss (#446).
+func TestAutoDismissContextDefaultsToDismiss(t *testing.T) {
+	session := &BrowserSession{}
+
+	if got := session.autoDismissContext(promptOpened); got != "ctx-1" {
+		t.Fatalf("expected the prompt's context %q, got %q", "ctx-1", got)
+	}
+}
+
+func TestAutoDismissContextIgnoresOtherEvents(t *testing.T) {
+	session := &BrowserSession{}
+
+	for _, msg := range []string{
+		`{"method":"browsingContext.userPromptClosed","params":{"context":"ctx-1"}}`,
+		`{"method":"log.entryAdded","params":{"context":"ctx-1"}}`,
+		`{"id":5,"type":"success","result":{}}`,
+		`not json`,
+	} {
+		if got := session.autoDismissContext(msg); got != "" {
+			t.Fatalf("message %q should not be auto-dismissed, got context %q", msg, got)
+		}
+	}
+}
+
+// A page that registered a dialog handler flips its own context to manual,
+// and the router keeps its hands off that context's prompts from then on.
+func TestSetPolicyManualStopsAutoDismiss(t *testing.T) {
+	router := &Router{}
+	client := &recordingTransport{}
+	session := &BrowserSession{Client: client}
+
+	router.handleDialogSetPolicy(session, bidiCommand{
+		ID:     7,
+		Method: "vibium:dialog.setPolicy",
+		Params: map[string]interface{}{"context": "ctx-1", "policy": "manual"},
+	})
+
+	if got := session.autoDismissContext(promptOpened); got != "" {
+		t.Fatalf("manual policy must leave the prompt open, got context %q", got)
+	}
+	assertResponseType(t, client, 7, "success")
+
+	// The policy is per context: another page's prompt is still the router's.
+	other := `{"method":"browsingContext.userPromptOpened","params":{"context":"ctx-2","type":"confirm"}}`
+	if got := session.autoDismissContext(other); got != "ctx-2" {
+		t.Fatalf("a context without handlers keeps the default, got %q", got)
+	}
+
+	// The last handler deregistering hands the default back.
+	router.handleDialogSetPolicy(session, bidiCommand{
+		ID:     8,
+		Method: "vibium:dialog.setPolicy",
+		Params: map[string]interface{}{"context": "ctx-1", "policy": "dismiss"},
+	})
+
+	if got := session.autoDismissContext(promptOpened); got != "ctx-1" {
+		t.Fatalf("dismiss policy must reclaim the prompt, got context %q", got)
+	}
+	assertResponseType(t, client, 8, "success")
+}
+
+func TestSetPolicyRequiresContext(t *testing.T) {
+	router := &Router{}
+	client := &recordingTransport{}
+	session := &BrowserSession{Client: client}
+
+	router.handleDialogSetPolicy(session, bidiCommand{
+		ID:     10,
+		Method: "vibium:dialog.setPolicy",
+		Params: map[string]interface{}{"policy": "manual"},
+	})
+
+	assertResponseType(t, client, 10, "error")
+	if got := session.autoDismissContext(promptOpened); got != "ctx-1" {
+		t.Fatalf("a rejected policy must leave the default in place, got %q", got)
+	}
+}
+
+func TestSetPolicyRejectsUnknownPolicy(t *testing.T) {
+	router := &Router{}
+	client := &recordingTransport{}
+	session := &BrowserSession{Client: client}
+
+	router.handleDialogSetPolicy(session, bidiCommand{
+		ID:     9,
+		Method: "vibium:dialog.setPolicy",
+		Params: map[string]interface{}{"context": "ctx-1", "policy": "accept"},
+	})
+
+	assertResponseType(t, client, 9, "error")
+	if !strings.Contains(client.sent[len(client.sent)-1], "invalid dialog policy") {
+		t.Fatalf("error should name the bad policy, got %s", client.sent[len(client.sent)-1])
+	}
+	// A rejected policy must not change the default.
+	if got := session.autoDismissContext(promptOpened); got != "ctx-1" {
+		t.Fatalf("rejected policy must leave the default in place, got context %q", got)
+	}
+}
+
+func assertResponseType(t *testing.T, client *recordingTransport, id int, wantType string) {
+	t.Helper()
+	if len(client.sent) == 0 {
+		t.Fatal("no response sent to client")
+	}
+	var resp struct {
+		ID   int    `json:"id"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(client.sent[len(client.sent)-1]), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if resp.ID != id || resp.Type != wantType {
+		t.Fatalf("want id=%d type=%s, got id=%d type=%s", id, wantType, resp.ID, resp.Type)
+	}
+}

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -60,10 +60,16 @@ type BrowserSession struct {
 
 	// prompts records which contexts have an open user prompt, so a command
 	// Chrome will not answer fails immediately instead of timing out.
-	prompts     *PromptTracker
-	routes      *routeRegistry
-	captures    *captureRegistry
-	navigations *NavigationTracker
+	prompts *PromptTracker
+	// dialogManual holds the contexts vibium:dialog.setPolicy has marked
+	// "manual" because a client page has its own dialog handlers. A prompt in
+	// any other context is dismissed by the router as it opens, so no client
+	// implements that default itself (#446). Entries for destroyed contexts
+	// are inert: context ids are never reused.
+	dialogManual map[string]struct{}
+	routes       *routeRegistry
+	captures     *captureRegistry
+	navigations  *NavigationTracker
 
 	// Serializes recording start/stop across their async handlers (the
 	// video screencast negotiation spans several browser commands).
@@ -213,6 +219,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		abandonedInternal: make(map[int]struct{}),
 		nextInternalID:    1000000, // Start at high number to avoid collision with client IDs
 		prompts:           NewPromptTracker(),
+		dialogManual:      make(map[string]struct{}),
 		routes:            newRouteRegistry(),
 		captures:          newCaptureRegistry(),
 		exposedPreloadIDs: make(map[string]string),
@@ -760,6 +767,14 @@ func (r *Router) OnClientMessage(client ClientTransport, msg string) {
 	case "vibium:dialog.dismiss":
 		r.dispatch(session, cmd, r.handleDialogDismiss)
 		return
+	case "vibium:dialog.setPolicy":
+		// Inline, not dispatched: ordering relative to the client's next
+		// command is the guarantee this policy exists to provide. A client
+		// registers a handler, flips the policy, then sends the command that
+		// triggers the dialog; handled in message order, the dialog can never
+		// open under the old policy.
+		r.handleDialogSetPolicy(session, cmd)
+		return
 
 	// WebSocket monitoring
 	case "vibium:page.onWebSocket":
@@ -975,6 +990,12 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 		// Track user prompts so prompt-sensitive commands can fail fast.
 		session.prompts.Observe([]byte(msg))
 		session.navigations.Observe([]byte(msg))
+
+		// A prompt no client handler has claimed is dismissed here, so every
+		// client shares one default instead of implementing it (#446).
+		if ctx := session.autoDismissContext(msg); ctx != "" {
+			go r.dismissUnhandledPrompt(session, ctx)
+		}
 
 		// Record event for recording (non-blocking)
 		session.mu.Lock()

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -40,6 +40,7 @@ public class Page {
     private final CopyOnWriteArrayList<Consumer<Request>> requestListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<Response>> responseListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<Dialog>> dialogListeners = new CopyOnWriteArrayList<>();
+    private boolean dialogPolicyManual = false;
     private final CopyOnWriteArrayList<Consumer<ConsoleMessage>> consoleListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<String>> errorListeners = new CopyOnWriteArrayList<>();
     private final CopyOnWriteArrayList<Consumer<Download>> downloadListeners = new CopyOnWriteArrayList<>();
@@ -610,7 +611,33 @@ public class Page {
 
     /** Listen for dialogs. */
     public void onDialog(Consumer<Dialog> callback) {
-        dialogListeners.add(callback);
+        addDialogListener(callback);
+    }
+
+    /**
+     * Tell the engine whether dialogs are handled here. Without a listener the
+     * engine dismisses each dialog itself (#446); listeners flip it to manual
+     * so the dialog stays open for them. client.send blocks until the policy
+     * is acknowledged, so a dialog triggered by a later command cannot open
+     * under the old policy.
+     */
+    private synchronized void syncDialogPolicy() {
+        boolean manual = !dialogListeners.isEmpty();
+        if (manual == dialogPolicyManual) return;
+        dialogPolicyManual = manual;
+        JsonObject params = new JsonObject();
+        params.addProperty("context", contextId);
+        params.addProperty("policy", manual ? "manual" : "dismiss");
+        if (manual) {
+            client.send("vibium:dialog.setPolicy", params);
+        } else {
+            try {
+                client.send("vibium:dialog.setPolicy", params);
+            } catch (Exception ignored) {
+                // The reset is best-effort; a failure here means the
+                // connection is going away with the session.
+            }
+        }
     }
 
     /** Listen for console messages. */
@@ -677,6 +704,7 @@ public class Page {
             requestListeners.clear();
             responseListeners.clear();
             dialogListeners.clear();
+            syncDialogPolicy();
             consoleListeners.clear();
             errorListeners.clear();
             downloadListeners.clear();
@@ -688,7 +716,7 @@ public class Page {
         switch (event) {
             case "request": requestListeners.clear(); break;
             case "response": responseListeners.clear(); break;
-            case "dialog": dialogListeners.clear(); break;
+            case "dialog": dialogListeners.clear(); syncDialogPolicy(); break;
             case "console": consoleListeners.clear(); break;
             case "error": errorListeners.clear(); break;
             case "download": downloadListeners.clear(); break;
@@ -958,12 +986,9 @@ public class Page {
     }
 
     private void handleDialogEvent(JsonObject params) {
+        // With no listener registered the engine dismisses the dialog itself
+        // (#446), so there is nothing to do here but deliver.
         Dialog dialog = new Dialog(client, params);
-        if (dialogListeners.isEmpty()) {
-            // Auto-dismiss if no handler
-            try { dialog.dismiss(); } catch (Exception ignored) {}
-            return;
-        }
         for (Consumer<Dialog> listener : dialogListeners) {
             try { listener.accept(dialog); } catch (Exception ignored) {}
         }
@@ -1051,8 +1076,15 @@ public class Page {
     void removeNavigationListener(Consumer<String> listener) { navigationListeners.remove(listener); }
     void addDownloadListener(Consumer<Download> listener) { downloadListeners.add(listener); }
     void removeDownloadListener(Consumer<Download> listener) { downloadListeners.remove(listener); }
-    void addDialogListener(Consumer<Dialog> listener) { dialogListeners.add(listener); }
-    void removeDialogListener(Consumer<Dialog> listener) { dialogListeners.remove(listener); }
+    void addDialogListener(Consumer<Dialog> listener) {
+        dialogListeners.add(listener);
+        syncDialogPolicy();
+    }
+
+    void removeDialogListener(Consumer<Dialog> listener) {
+        dialogListeners.remove(listener);
+        syncDialogPolicy();
+    }
     void addConsoleListener(Consumer<ConsoleMessage> listener) { consoleListeners.add(listener); }
     void removeConsoleListener(Consumer<ConsoleMessage> listener) { consoleListeners.remove(listener); }
     void addErrorListener(Consumer<String> listener) { errorListeners.add(listener); }

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -221,6 +221,7 @@ export class Page {
   private requestCallbacks: ((request: Request) => void)[] = [];
   private responseCallbacks: ((response: Response) => void)[] = [];
   private dialogCallbacks: ((dialog: Dialog) => void)[] = [];
+  private dialogPolicyManual = false;
   private consoleCallbacks: ((msg: ConsoleMessage) => void)[] = [];
   private errorCallbacks: ((error: Error) => void)[] = [];
   private downloadCallbacks: ((download: Download) => void)[] = [];
@@ -792,6 +793,7 @@ export class Page {
     }
     if (!event || event === 'dialog') {
       this.dialogCallbacks = [];
+      this.syncDialogPolicy();
     }
     if (!event || event === 'console') {
       this.consoleCallbacks = [];
@@ -876,21 +878,21 @@ export class Page {
     });
   }
 
-  /** @internal Capture a dialog event. The registered callback prevents auto-dismiss. */
+  /** @internal Capture a dialog event. The registered callback keeps the engine from auto-dismissing. */
   _captureDialog(options?: { timeout?: number }): Promise<Dialog> {
     const timeout = options?.timeout ?? 10000;
     return new Promise<Dialog>((resolve, reject) => {
       const timer = setTimeout(() => {
-        this.dialogCallbacks = this.dialogCallbacks.filter(cb => cb !== handler);
+        this.removeDialogCallback(handler);
         reject(new Error(`Timeout waiting for dialog`));
       }, timeout);
 
       const handler = (dialog: Dialog) => {
         clearTimeout(timer);
-        this.dialogCallbacks = this.dialogCallbacks.filter(cb => cb !== handler);
+        this.removeDialogCallback(handler);
         resolve(dialog);
       };
-      this.dialogCallbacks.push(handler);
+      this.addDialogCallback(handler);
     });
   }
 
@@ -922,8 +924,8 @@ export class Page {
         }
         case 'dialog': {
           const handler = (dialog: Dialog) => { clearTimeout(timer); cleanup(); resolve(dialog); };
-          this.dialogCallbacks.push(handler);
-          cleanup = () => { this.dialogCallbacks = this.dialogCallbacks.filter(cb => cb !== handler); };
+          this.addDialogCallback(handler);
+          cleanup = () => { this.removeDialogCallback(handler); };
           break;
         }
         case 'download': {
@@ -1033,7 +1035,33 @@ export class Page {
    * If no handler is registered, dialogs are automatically dismissed.
    */
   onDialog(handler: (dialog: Dialog) => void): void {
+    this.addDialogCallback(handler);
+  }
+
+  /**
+   * The engine dismisses dialogs itself while no handler is registered
+   * (#446); handlers flip it to manual so the dialog stays open for them.
+   * sendSetup, so the policy is acknowledged before any later command can
+   * trigger a dialog.
+   */
+  private syncDialogPolicy(): void {
+    const manual = this.dialogCallbacks.length > 0;
+    if (manual === this.dialogPolicyManual) return;
+    this.dialogPolicyManual = manual;
+    this.client.sendSetup('vibium:dialog.setPolicy', {
+      context: this.contextId,
+      policy: manual ? 'manual' : 'dismiss',
+    }).catch(() => {});
+  }
+
+  private addDialogCallback(handler: (dialog: Dialog) => void): void {
     this.dialogCallbacks.push(handler);
+    this.syncDialogPolicy();
+  }
+
+  private removeDialogCallback(handler: (dialog: Dialog) => void): void {
+    this.dialogCallbacks = this.dialogCallbacks.filter(cb => cb !== handler);
+    this.syncDialogPolicy();
   }
 
   /** Register a handler for console messages, or pass 'collect' to buffer them for consoleMessages(). */
@@ -1157,21 +1185,18 @@ export class Page {
   }
 
   private handleUserPromptOpened(params: Record<string, unknown>): void {
+    // With no handler registered the engine dismisses the dialog itself
+    // (#446), so there is nothing to do here but deliver.
     const dialog = new Dialog(this.client, this.contextId, params);
 
-    if (this.dialogCallbacks.length > 0) {
-      for (const cb of this.dialogCallbacks) {
-        // Catch errors from async handlers (dialog.accept/dismiss are fire-and-forget)
-        try {
-          const result = cb(dialog) as unknown;
-          if (result && typeof (result as Promise<void>).catch === 'function') {
-            (result as Promise<void>).catch(() => {});
-          }
-        } catch (_) { /* ignore sync errors from handler */ }
-      }
-    } else {
-      // Auto-dismiss if no handler registered (matches Playwright behavior)
-      dialog.dismiss().catch(() => {});
+    for (const cb of this.dialogCallbacks) {
+      // Catch errors from async handlers (dialog.accept/dismiss are fire-and-forget)
+      try {
+        const result = cb(dialog) as unknown;
+        if (result && typeof (result as Promise<void>).catch === 'function') {
+          (result as Promise<void>).catch(() => {});
+        }
+      } catch (_) { /* ignore sync errors from handler */ }
     }
   }
 

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -103,6 +103,7 @@ class Page:
         self._request_callbacks: List[Callable] = []
         self._response_callbacks: List[Callable] = []
         self._dialog_callbacks: List[Callable] = []
+        self._dialog_policy_manual = False
         self._console_callbacks: List[Callable] = []
         self._error_callbacks: List[Callable] = []
         self._download_callbacks: List[Callable] = []
@@ -406,23 +407,47 @@ class Page:
 
         return _wait()
 
+    def _sync_dialog_policy(self) -> None:
+        """Tell the engine whether dialogs are handled here.
+
+        Without a handler the engine dismisses each dialog itself (#446).
+        send_setup, so the policy is acknowledged before any later command
+        can trigger a dialog.
+        """
+        manual = bool(self._dialog_callbacks)
+        if manual == self._dialog_policy_manual:
+            return
+        self._dialog_policy_manual = manual
+        params = {"context": self._context_id, "policy": "manual" if manual else "dismiss"}
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # The sync API registers handlers from its caller thread; the
+            # policy command has to be scheduled onto the client's loop.
+            self._client.send_setup_threadsafe("vibium:dialog.setPolicy", params)
+            return
+        self._client.send_setup("vibium:dialog.setPolicy", params)
+
     async def _capture_dialog(self, timeout: Optional[int] = None) -> Dialog:
-        """Internal: wait for a dialog event. Callback presence prevents auto-dismiss."""
+        """Internal: wait for a dialog event. Callback presence keeps the engine from auto-dismissing."""
         timeout_ms = timeout or 10000
         future: asyncio.Future = asyncio.get_running_loop().create_future()
 
         def handler(dialog: Dialog) -> None:
             self._dialog_callbacks.remove(handler)
+            self._sync_dialog_policy()
             if not future.done():
                 future.set_result(dialog)
 
         self._dialog_callbacks.append(handler)
+        self._sync_dialog_policy()
 
         try:
             return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
         except asyncio.TimeoutError:
             if handler in self._dialog_callbacks:
                 self._dialog_callbacks.remove(handler)
+                self._sync_dialog_policy()
             raise errors.TimeoutError("Timeout waiting for dialog")
 
     async def _setup_capture_dialog(self, timeout: Optional[int] = None, auto_dismiss: bool = False) -> Any:
@@ -439,12 +464,14 @@ class Page:
 
         def handler(dialog: Dialog) -> None:
             self._dialog_callbacks.remove(handler)
+            self._sync_dialog_policy()
             if not future.done():
                 future.set_result(dialog)
             if auto_dismiss:
                 asyncio.ensure_future(dialog.dismiss())
 
         self._dialog_callbacks.append(handler)
+        self._sync_dialog_policy()
 
         async def _wait() -> Dialog:
             try:
@@ -452,6 +479,7 @@ class Page:
             except asyncio.TimeoutError:
                 if handler in self._dialog_callbacks:
                     self._dialog_callbacks.remove(handler)
+                    self._sync_dialog_policy()
                 raise errors.TimeoutError("Timeout waiting for dialog")
 
         return _wait()
@@ -467,18 +495,21 @@ class Page:
 
         def handler(data: Any) -> None:
             callback_list.remove(handler)
+            self._sync_dialog_policy()
             if not future.done():
                 future.set_result(data)
 
         if name in ("request", "response"):
             self._ensure_data_collector()
         callback_list.append(handler)
+        self._sync_dialog_policy()
 
         try:
             return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
         except asyncio.TimeoutError:
             if handler in callback_list:
                 callback_list.remove(handler)
+                self._sync_dialog_policy()
             raise errors.TimeoutError(f"Timeout waiting for event '{name}'")
 
     async def _setup_capture_event(self, name: str, timeout: Optional[int] = None) -> Any:
@@ -492,12 +523,14 @@ class Page:
 
         def handler(data: Any) -> None:
             callback_list.remove(handler)
+            self._sync_dialog_policy()
             if not future.done():
                 future.set_result(data)
 
         if name in ("request", "response"):
             self._ensure_data_collector()
         callback_list.append(handler)
+        self._sync_dialog_policy()
 
         async def _wait() -> Any:
             try:
@@ -505,6 +538,7 @@ class Page:
             except asyncio.TimeoutError:
                 if handler in callback_list:
                     callback_list.remove(handler)
+                    self._sync_dialog_policy()
                 raise errors.TimeoutError(f"Timeout waiting for event '{name}'")
 
         return _wait()
@@ -830,6 +864,7 @@ class Page:
 
     def on_dialog(self, handler: Callable[[Dialog], Any]) -> None:
         self._dialog_callbacks.append(handler)
+        self._sync_dialog_policy()
 
     def on_console(self, handler: Union[Callable[[ConsoleMessage], None], str]) -> None:
         """Register a handler for console messages, or pass 'collect' to buffer them."""
@@ -884,6 +919,7 @@ class Page:
             self._response_callbacks.clear()
         if not event or event == "dialog":
             self._dialog_callbacks.clear()
+            self._sync_dialog_policy()
         if not event or event == "console":
             self._console_callbacks.clear()
             self._console_buffer = None
@@ -1026,21 +1062,18 @@ class Page:
             cb(resp)
 
     def _handle_user_prompt_opened(self, params: Dict[str, Any]) -> None:
+        # With no handler registered the engine dismisses the dialog itself
+        # (#446), so there is nothing to do here but deliver.
         dialog = Dialog(self._client, self._context_id, params)
 
-        if self._dialog_callbacks:
-            for cb in self._dialog_callbacks:
-                try:
-                    result = cb(dialog)
-                    if hasattr(result, "__await__"):
-                        import asyncio
-                        asyncio.ensure_future(result)
-                except Exception:
-                    pass
-        else:
-            # Auto-dismiss if no handler registered
-            import asyncio
-            asyncio.ensure_future(dialog.dismiss())
+        for cb in list(self._dialog_callbacks):
+            try:
+                result = cb(dialog)
+                if hasattr(result, "__await__"):
+                    import asyncio
+                    asyncio.ensure_future(result)
+            except Exception:
+                pass
 
     def _handle_log_entry_added(self, params: Dict[str, Any]) -> None:
         entry_type = params.get("type", "")

--- a/clients/python/src/vibium/client.py
+++ b/clients/python/src/vibium/client.py
@@ -52,11 +52,15 @@ class BiDiClient:
         # setup is surfaced by whoever owns that registration, not injected
         # into an unrelated command.
         self._pending_setups: Set[asyncio.Future] = set()
+        # The loop the receiver runs on, so registration commands issued from
+        # another thread (the sync API's caller thread) can be scheduled here.
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
     @classmethod
     async def connect(cls, process: VibiumProcess) -> BiDiClient:
         """Create a BiDiClient from a VibiumProcess with pipe streams."""
         client = cls(process)
+        client._loop = asyncio.get_running_loop()
         client._receiver_task = asyncio.create_task(client._receive_loop())
         # Replay any events that arrived before the ready signal
         if hasattr(process, "_pre_ready_lines"):
@@ -151,6 +155,23 @@ class BiDiClient:
 
         task.add_done_callback(_done)
         return task
+
+    def send_setup_threadsafe(
+        self,
+        method: str,
+        params: Optional[Dict[str, Any]] = None,
+        timeout: float = 60,
+    ) -> None:
+        """send_setup scheduled from a thread that is not the loop's.
+
+        The sync API registers event handlers on its caller thread. The setup
+        task must be created on the client's loop, and before any command that
+        caller submits next — call_soon_threadsafe and
+        run_coroutine_threadsafe share one FIFO, so issue order holds.
+        """
+        if self._loop is None:
+            raise errors.ConnectionError("Client is not connected")
+        self._loop.call_soon_threadsafe(lambda: self.send_setup(method, params, timeout))
 
     async def _send(self, method: str, params: Optional[Dict[str, Any]] = None, timeout: float = 60) -> Any:
         """Write a command and wait for its response, bypassing the setup gate."""

--- a/docs/explanation/client-implementation-guide.md
+++ b/docs/explanation/client-implementation-guide.md
@@ -325,6 +325,10 @@ Events (`onDialog`, `onRequest`, etc.) are received as WebSocket messages with n
 2. If `type` is `"success"` or `"error"` → match to pending request by `id`
 3. If `method` is present (event) → dispatch to registered listeners
 
+### Dialog Policy
+
+The engine dismisses every dialog itself while no dialog handler is registered — clients do not implement that default. The policy is per browsing context: when a page's first dialog handler (or one-shot capture) registers, send `vibium:dialog.setPolicy` with `{"context": <the page's context>, "policy": "manual"}`; when its last one deregisters, send the same with `"policy": "dismiss"`. Issue the command through the same ordered channel as regular commands and ahead of any command that could trigger a dialog (the engine handles it in message order), so a dialog can never open under the policy the page just left.
+
 ---
 
 ## Reserved Keyword Handling


### PR DESCRIPTION
Part of #446.

With no dialog handler registered, each client dismissed dialogs itself, one implementation per language. The engine now owns that default: the router dismisses every user prompt as it opens unless the client marked the prompt's context manual with the new vibium:dialog.setPolicy command. Clients flip a context to manual when its first dialog handler registers and back when the last one is gone, and their local dismiss branches are deleted.

The policy is scoped to a browsing context because handlers are scoped to a page. A session-wide flag would let one page's handler keep another page's unhandled alert open, which shows up as a hang the moment two pages exist. The command is handled inline on the client message order rather than dispatched, so a dialog can never open under a policy the client already left.

The Python sync API registers handlers from its caller thread, where nothing can await the policy command. BiDiClient gains send_setup_threadsafe, which schedules the command onto the client loop with call_soon_threadsafe; that shares a FIFO with run_coroutine_threadsafe, so the policy is still ordered ahead of the caller's next command.

Verified:
- New engine tests cover the policy state machine, the per-context scoping, and validation (clicker/internal/api/handlers_dialog_test.go)
- JS async network-dialog and prompt-blocked suites (32 tests), JS sync suite (72 tests), Python network-dialog and sync API suites (100 tests), the Java engine suite, and the full Go suite pass against this branch; the Python sync dialog tests fail without the threadsafe path (RuntimeError: no current event loop)
