### PR TITLE
Wait out one-shot event captures in the engine

### DIFF
--- a/clicker/internal/api/capture_registry.go
+++ b/clicker/internal/api/capture_registry.go
@@ -2,16 +2,17 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/vibium/clicker/internal/urlmatch"
 )
 
-// captureRegistry holds the one-shot request/response captures for a
-// session. The engine owns both halves that used to live in every client:
-// matching the URL pattern (urlmatch, one dialect) and waiting for the first
-// matching event (vibium:page.captureRequest/captureResponse block until it
+// captureRegistry holds the one-shot event captures for a session. The engine
+// owns both halves that used to live in every client: deciding whether an
+// event satisfies a capture and waiting for the first one that does
+// (vibium:page.captureRequest/captureResponse/captureEvent block until it
 // arrives or the timeout passes). Clients just await the command (#446).
 type captureRegistry struct {
 	mu      sync.Mutex
@@ -20,30 +21,127 @@ type captureRegistry struct {
 }
 
 type pendingCapture struct {
-	method  string // the BiDi event method this capture waits for
-	context string
-	matcher *urlmatch.Matcher
-	ch      chan json.RawMessage
+	match func(method string, params json.RawMessage) bool
+	// promptContext is set on dialog captures: a prompt opening in this
+	// context belongs to the capturer, so the router's auto-dismiss default
+	// must leave it alone.
+	promptContext string
+	ch            chan json.RawMessage
 }
 
 func newCaptureRegistry() *captureRegistry {
 	return &captureRegistry{pending: map[int]*pendingCapture{}}
 }
 
-// register adds a one-shot capture and returns its id and delivery channel.
-func (cr *captureRegistry) register(eventMethod, context, pattern string) (int, chan json.RawMessage, error) {
-	matcher, err := urlmatch.Compile(pattern)
-	if err != nil {
-		return 0, nil, err
-	}
+// add registers a one-shot capture and returns its id and delivery channel.
+func (cr *captureRegistry) add(p *pendingCapture) (int, chan json.RawMessage) {
 	cr.mu.Lock()
 	defer cr.mu.Unlock()
 	cr.nextID++
 	id := cr.nextID
 	// Buffered: offer must never block the event-forwarding loop.
-	ch := make(chan json.RawMessage, 1)
-	cr.pending[id] = &pendingCapture{method: eventMethod, context: context, matcher: matcher, ch: ch}
+	p.ch = make(chan json.RawMessage, 1)
+	cr.pending[id] = p
+	return id, p.ch
+}
+
+// register adds a one-shot network capture and returns its id and delivery
+// channel.
+func (cr *captureRegistry) register(eventMethod, context, pattern string) (int, chan json.RawMessage, error) {
+	matcher, err := urlmatch.Compile(pattern)
+	if err != nil {
+		return 0, nil, err
+	}
+	id, ch := cr.add(&pendingCapture{match: networkMatch(eventMethod, context, matcher)})
 	return id, ch, nil
+}
+
+// networkMatch matches one network event method for a context, with the URL
+// run through the session's one glob dialect. Blocked requests belong to
+// route interception; captures see the same traffic the request listeners do.
+func networkMatch(eventMethod, context string, matcher *urlmatch.Matcher) func(string, json.RawMessage) bool {
+	return func(method string, raw json.RawMessage) bool {
+		if method != eventMethod {
+			return false
+		}
+		var params struct {
+			Context   string `json:"context"`
+			IsBlocked bool   `json:"isBlocked"`
+			Request   struct {
+				URL string `json:"url"`
+			} `json:"request"`
+		}
+		if json.Unmarshal(raw, &params) != nil || params.Request.URL == "" {
+			return false
+		}
+		if method == "network.beforeRequestSent" && params.IsBlocked {
+			return false
+		}
+		return params.Context == context && matcher.Match(params.Request.URL)
+	}
+}
+
+// captureEventKind builds the pending capture for a vibium:page.captureEvent
+// kind. Kinds mirror the client capture surface: capture.navigation,
+// capture.download, capture.dialog, and capture.event(name).
+func captureEventKind(kind, context string) (*pendingCapture, error) {
+	methodIn := func(method string, methods ...string) bool {
+		for _, m := range methods {
+			if method == m {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch kind {
+	case "navigation":
+		return &pendingCapture{match: func(method string, raw json.RawMessage) bool {
+			if !methodIn(method, "browsingContext.load", "browsingContext.fragmentNavigated", "browsingContext.historyUpdated") {
+				return false
+			}
+			var params struct {
+				Context string `json:"context"`
+				URL     string `json:"url"`
+			}
+			return json.Unmarshal(raw, &params) == nil && params.Context == context && params.URL != ""
+		}}, nil
+	case "dialog":
+		return &pendingCapture{
+			promptContext: context,
+			match: func(method string, raw json.RawMessage) bool {
+				if method != "browsingContext.userPromptOpened" {
+					return false
+				}
+				var params struct {
+					Context string `json:"context"`
+				}
+				return json.Unmarshal(raw, &params) == nil && params.Context == context
+			},
+		}, nil
+	case "console", "error":
+		wantType := "console"
+		if kind == "error" {
+			wantType = "javascript"
+		}
+		return &pendingCapture{match: func(method string, raw json.RawMessage) bool {
+			if method != "log.entryAdded" {
+				return false
+			}
+			var params struct {
+				Type   string `json:"type"`
+				Source struct {
+					Context string `json:"context"`
+				} `json:"source"`
+			}
+			return json.Unmarshal(raw, &params) == nil && params.Type == wantType && params.Source.Context == context
+		}}, nil
+	default:
+		// Downloads are absent deliberately: a captured download must be the
+		// same object the client completes on downloadEnd, so download capture
+		// moves into the engine together with that bookkeeping.
+		return nil, fmt.Errorf("unknown capture kind %q (want navigation, dialog, console, or error)", kind)
+	}
 }
 
 // cancel removes a capture that timed out or whose session is closing.
@@ -53,41 +151,49 @@ func (cr *captureRegistry) cancel(id int) {
 	delete(cr.pending, id)
 }
 
+// wantsPrompt reports whether a pending dialog capture claims prompts opening
+// in the given context. The router's auto-dismiss default defers to it.
+func (cr *captureRegistry) wantsPrompt(context string) bool {
+	if cr == nil {
+		return false
+	}
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	for _, p := range cr.pending {
+		if p.promptContext == context {
+			return true
+		}
+	}
+	return false
+}
+
 // offer inspects one browser event and delivers its params to every pending
 // capture it satisfies. The event always continues to the client afterwards:
 // captures observe traffic, they do not consume it.
 func (cr *captureRegistry) offer(msg string) {
-	// Cheap gate before JSON work.
-	if !strings.Contains(msg, `"network.beforeRequestSent"`) && !strings.Contains(msg, `"network.responseCompleted"`) {
+	// Cheap gate before JSON work: events have a method, responses do not.
+	if !strings.Contains(msg, `"method"`) {
 		return
 	}
+	cr.mu.Lock()
+	idle := len(cr.pending) == 0
+	cr.mu.Unlock()
+	if idle {
+		return
+	}
+
 	var evt struct {
 		Method string          `json:"method"`
 		Params json.RawMessage `json:"params"`
 	}
-	if json.Unmarshal([]byte(msg), &evt) != nil || evt.Params == nil {
-		return
-	}
-	var params struct {
-		Context   string `json:"context"`
-		IsBlocked bool   `json:"isBlocked"`
-		Request   struct {
-			URL string `json:"url"`
-		} `json:"request"`
-	}
-	if json.Unmarshal(evt.Params, &params) != nil || params.Request.URL == "" {
-		return
-	}
-	// Blocked requests belong to route interception; captures see the same
-	// traffic the request listeners do.
-	if evt.Method == "network.beforeRequestSent" && params.IsBlocked {
+	if json.Unmarshal([]byte(msg), &evt) != nil || evt.Method == "" || evt.Params == nil {
 		return
 	}
 
 	cr.mu.Lock()
 	defer cr.mu.Unlock()
 	for id, p := range cr.pending {
-		if p.method != evt.Method || p.context != params.Context || !p.matcher.Match(params.Request.URL) {
+		if !p.match(evt.Method, evt.Params) {
 			continue
 		}
 		select {

--- a/clicker/internal/api/capture_registry_test.go
+++ b/clicker/internal/api/capture_registry_test.go
@@ -65,3 +65,112 @@ func TestCaptureRegistry(t *testing.T) {
 
 	_ = id
 }
+
+// vibium:page.captureEvent kinds: each waits for its own event shape, scoped
+// to one browsing context (#446).
+func TestCaptureEventKinds(t *testing.T) {
+	deliver := func(t *testing.T, kind, context string, miss, hit []string) string {
+		t.Helper()
+		cr := newCaptureRegistry()
+		capture, err := captureEventKind(kind, context)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, ch := cr.add(capture)
+		for _, msg := range miss {
+			cr.offer(msg)
+		}
+		select {
+		case params := <-ch:
+			t.Fatalf("non-matching event delivered: %s", params)
+		default:
+		}
+		for _, msg := range hit {
+			cr.offer(msg)
+		}
+		select {
+		case params := <-ch:
+			return string(params)
+		default:
+			t.Fatal("matching event was not delivered")
+			return ""
+		}
+	}
+
+	t.Run("navigation matches load, fragment, and history for its context", func(t *testing.T) {
+		got := deliver(t, "navigation", "ctx1",
+			[]string{
+				`{"method":"browsingContext.load","params":{"context":"ctx2","url":"https://x.test/other"}}`,
+				`{"method":"browsingContext.navigationStarted","params":{"context":"ctx1","url":"https://x.test/a"}}`,
+				`{"method":"browsingContext.load","params":{"context":"ctx1"}}`,
+			},
+			[]string{`{"method":"browsingContext.fragmentNavigated","params":{"context":"ctx1","url":"https://x.test/a#frag"}}`},
+		)
+		if !strings.Contains(got, "#frag") {
+			t.Fatalf("params = %s", got)
+		}
+	})
+
+	t.Run("dialog matches userPromptOpened for its context", func(t *testing.T) {
+		got := deliver(t, "dialog", "ctx1",
+			[]string{`{"method":"browsingContext.userPromptOpened","params":{"context":"ctx2","type":"alert"}}`},
+			[]string{`{"method":"browsingContext.userPromptOpened","params":{"context":"ctx1","type":"confirm","message":"go?"}}`},
+		)
+		if !strings.Contains(got, "go?") {
+			t.Fatalf("params = %s", got)
+		}
+	})
+
+	t.Run("console and error split log.entryAdded by type", func(t *testing.T) {
+		consoleEntry := `{"method":"log.entryAdded","params":{"type":"console","method":"warn","text":"careful","source":{"context":"ctx1"}}}`
+		errorEntry := `{"method":"log.entryAdded","params":{"type":"javascript","text":"boom","source":{"context":"ctx1"}}}`
+		got := deliver(t, "console", "ctx1", []string{errorEntry}, []string{consoleEntry})
+		if !strings.Contains(got, "careful") {
+			t.Fatalf("params = %s", got)
+		}
+		got = deliver(t, "error", "ctx1", []string{consoleEntry}, []string{errorEntry})
+		if !strings.Contains(got, "boom") {
+			t.Fatalf("params = %s", got)
+		}
+	})
+
+	t.Run("unknown kind errors", func(t *testing.T) {
+		if _, err := captureEventKind("websocket", "ctx1"); err == nil {
+			t.Fatal("unknown kind must error")
+		}
+	})
+}
+
+// A pending dialog capture claims its context's prompts, so the router's
+// auto-dismiss default leaves the captured dialog open.
+func TestDialogCaptureClaimsPrompt(t *testing.T) {
+	cr := newCaptureRegistry()
+	if cr.wantsPrompt("ctx1") {
+		t.Fatal("no capture, no claim")
+	}
+
+	capture, err := captureEventKind("dialog", "ctx1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, _ := cr.add(capture)
+
+	if !cr.wantsPrompt("ctx1") {
+		t.Fatal("a pending dialog capture must claim its context's prompts")
+	}
+	if cr.wantsPrompt("ctx2") {
+		t.Fatal("the claim is scoped to the capture's context")
+	}
+
+	cr.cancel(id)
+	if cr.wantsPrompt("ctx1") {
+		t.Fatal("a cancelled capture must release its claim")
+	}
+
+	// Non-dialog captures never claim prompts.
+	nav, _ := captureEventKind("navigation", "ctx1")
+	cr.add(nav)
+	if cr.wantsPrompt("ctx1") {
+		t.Fatal("only dialog captures claim prompts")
+	}
+}

--- a/clicker/internal/api/handlers_capture.go
+++ b/clicker/internal/api/handlers_capture.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // handlePageScreenshot handles vibium:page.screenshot — captures a page screenshot.
@@ -139,6 +140,49 @@ func (r *Router) handlePagePDF(session *BrowserSession, cmd bidiCommand) {
 	}
 
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"data": printResult.Result.Data})
+}
+
+// handlePageCaptureEvent handles vibium:page.captureEvent — a one-shot wait
+// for the next matching event (kind: navigation, dialog, console, error)
+// that returns the event's params. The router runs this inline on the
+// client message order, so the capture is registered before any later command
+// can trigger its event; only the wait itself runs on a goroutine. For dialog
+// captures the inline registration is also what parks the auto-dismiss
+// default before the dialog can open.
+func (r *Router) handlePageCaptureEvent(session *BrowserSession, cmd bidiCommand) {
+	context, err := r.resolveContext(session, cmd.Params)
+	if err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+	kind, _ := cmd.Params["kind"].(string)
+	capture, err := captureEventKind(kind, context)
+	if err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+	timeoutMs := 10000.0
+	if t, ok := cmd.Params["timeout"].(float64); ok && t > 0 {
+		timeoutMs = t
+	}
+	id, ch := session.captures.add(capture)
+
+	go func() {
+		select {
+		case params := <-ch:
+			var event interface{}
+			if err := json.Unmarshal(params, &event); err != nil {
+				r.sendError(session, cmd.ID, fmt.Errorf("capture event unparseable: %w", err))
+				return
+			}
+			r.sendSuccess(session, cmd.ID, map[string]interface{}{"event": event})
+		case <-time.After(time.Duration(timeoutMs) * time.Millisecond):
+			session.captures.cancel(id)
+			r.sendError(session, cmd.ID, fmt.Errorf("timeout waiting for %s", kind))
+		case <-session.stopChan:
+			session.captures.cancel(id)
+		}
+	}()
 }
 
 // ---------------------------------------------------------------------------

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -747,6 +747,11 @@ func (r *Router) OnClientMessage(client ClientTransport, msg string) {
 	case "vibium:page.captureResponse":
 		r.dispatch(session, cmd, r.handlePageCaptureResponse)
 		return
+	case "vibium:page.captureEvent":
+		// Inline, not dispatched: registration must land before the client's
+		// next command, which may be the trigger for the captured event.
+		r.handlePageCaptureEvent(session, cmd)
+		return
 	case "vibium:network.continue":
 		go r.handleNetworkContinue(session, cmd)
 		return
@@ -992,8 +997,10 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 		session.navigations.Observe([]byte(msg))
 
 		// A prompt no client handler has claimed is dismissed here, so every
-		// client shares one default instead of implementing it (#446).
-		if ctx := session.autoDismissContext(msg); ctx != "" {
+		// client shares one default instead of implementing it (#446). A
+		// pending dialog capture claims the prompt the same way a handler
+		// does: the capturer decides how it closes.
+		if ctx := session.autoDismissContext(msg); ctx != "" && !session.captures.wantsPrompt(ctx) {
 			go r.dismissUnhandledPrompt(session, ctx)
 		}
 

--- a/clients/java/src/main/java/com/vibium/Capture.java
+++ b/clients/java/src/main/java/com/vibium/Capture.java
@@ -12,10 +12,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
- * One-shot event capture helpers. Each method registers its listener before
- * starting the action, then removes that listener on every exit path.
+ * One-shot event capture helpers. The binary owns the matching and the wait
+ * (vibium:page.captureRequest/captureResponse/captureEvent); each method
+ * starts that command, runs the action while it is in flight, and awaits the
+ * result. Downloads still capture through a local listener, because the
+ * captured Download must be the same object the downloadEnd event completes.
  */
 public final class Capture {
 
@@ -36,13 +40,10 @@ public final class Capture {
         return request(pattern, action, null);
     }
 
-    /**
-     * The binary matches the pattern and waits for the event
-     * (vibium:page.captureRequest); this starts that command, runs the
-     * action while it is in flight, and awaits the result.
-     */
     public Request request(String pattern, Runnable action, WaitOptions options) {
-        return awaitWire("vibium:page.captureRequest", pattern, action, options,
+        long timeoutMs = timeout(options);
+        return awaitWire(() -> page.sendCapture("vibium:page.captureRequest", pattern, timeoutMs),
+            timeoutMs, action,
             event -> page.requestFromEvent(event),
             "request matching '" + pattern + "'");
     }
@@ -52,33 +53,11 @@ public final class Capture {
     }
 
     public Response response(String pattern, Runnable action, WaitOptions options) {
-        return awaitWire("vibium:page.captureResponse", pattern, action, options,
+        long timeoutMs = timeout(options);
+        return awaitWire(() -> page.sendCapture("vibium:page.captureResponse", pattern, timeoutMs),
+            timeoutMs, action,
             event -> page.responseFromEvent(event),
             "response matching '" + pattern + "'");
-    }
-
-    private <T> T awaitWire(String method, String pattern, Runnable action, WaitOptions options,
-                            java.util.function.Function<com.google.gson.JsonObject, T> build, String what) {
-        long timeoutMs = options != null && options.timeout() != null ? options.timeout() : DEFAULT_TIMEOUT_MS;
-        CompletableFuture<com.google.gson.JsonObject> pending = CompletableFuture.supplyAsync(
-            () -> page.sendCapture(method, pattern, timeoutMs), ACTIONS);
-        action.run();
-        try {
-            // The binary enforces timeoutMs; the slack only covers transport.
-            com.google.gson.JsonObject result = pending.get(timeoutMs + 5_000, TimeUnit.MILLISECONDS);
-            return build.apply(result.getAsJsonObject("event"));
-        } catch (TimeoutException e) {
-            pending.cancel(true);
-            throw new VibiumTimeoutException("Timeout waiting for " + what);
-        } catch (ExecutionException e) {
-            if (e.getCause() instanceof VibiumException) {
-                throw (VibiumException) e.getCause();
-            }
-            throw new VibiumTimeoutException("Timeout waiting for " + what);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new VibiumTimeoutException("Interrupted waiting for " + what);
-        }
     }
 
     public String navigation(Runnable action) {
@@ -86,28 +65,10 @@ public final class Capture {
     }
 
     public String navigation(Runnable action, WaitOptions options) {
-        // page.go() returns once navigation completes, but its event is
-        // delivered asynchronously and can land after this capture registers
-        // its handler and actionStarted flips -- that guard only rejects
-        // events seen before the action begins. Matching any navigation then
-        // completes on the stale event and returns the previous URL. Wait for
-        // a move away from where the page is now instead.
-        //
-        // The trade-off: a navigation to the URL the page is already on is not
-        // captured. Returning the wrong URL is the worse failure.
-        String from;
-        try {
-            from = page.url();
-        } catch (RuntimeException ignored) {
-            from = null;
-        }
-        String previous = from;
-        return await(
-            handler -> page.addNavigationListener(handler),
-            handler -> page.removeNavigationListener(handler),
-            value -> previous == null || !previous.equals(value),
-            action,
-            options,
+        long timeoutMs = timeout(options);
+        return awaitWire(() -> page.sendCaptureEvent("navigation", timeoutMs),
+            timeoutMs, action,
+            event -> event.has("url") ? event.get("url").getAsString() : "",
             "navigation");
     }
 
@@ -119,7 +80,6 @@ public final class Capture {
         return await(
             handler -> page.addDownloadListener(handler),
             handler -> page.removeDownloadListener(handler),
-            value -> true,
             action,
             options,
             "download");
@@ -130,12 +90,10 @@ public final class Capture {
     }
 
     public Dialog dialog(Runnable action, WaitOptions options) {
-        return await(
-            handler -> page.addDialogListener(handler),
-            handler -> page.removeDialogListener(handler),
-            value -> true,
-            action,
-            options,
+        long timeoutMs = timeout(options);
+        return awaitWire(() -> page.sendCaptureEvent("dialog", timeoutMs),
+            timeoutMs, action,
+            event -> page.dialogFromEvent(event),
             "dialog");
     }
 
@@ -146,41 +104,72 @@ public final class Capture {
     public Object event(String name, Runnable action, WaitOptions options) {
         switch (name) {
             case "request":
-                return awaitAny(page::addRequestListener, page::removeRequestListener,
-                    action, options, name);
+                return request("**", action, options);
             case "response":
-                return awaitAny(page::addResponseListener, page::removeResponseListener,
-                    action, options, name);
+                return response("**", action, options);
             case "navigation":
-                return awaitAny(page::addNavigationListener, page::removeNavigationListener,
-                    action, options, name);
+                return navigation(action, options);
             case "download":
-                return awaitAny(page::addDownloadListener, page::removeDownloadListener,
-                    action, options, name);
+                return download(action, options);
             case "dialog":
-                return awaitAny(page::addDialogListener, page::removeDialogListener,
-                    action, options, name);
-            case "console":
-                return awaitAny(page::addConsoleListener, page::removeConsoleListener,
-                    action, options, name);
-            case "error":
-                return awaitAny(page::addErrorListener, page::removeErrorListener,
-                    action, options, name);
+                return dialog(action, options);
+            case "console": {
+                long timeoutMs = timeout(options);
+                return awaitWire(() -> page.sendCaptureEvent("console", timeoutMs),
+                    timeoutMs, action,
+                    event -> page.consoleFromEvent(event),
+                    "event 'console'");
+            }
+            case "error": {
+                long timeoutMs = timeout(options);
+                return awaitWire(() -> page.sendCaptureEvent("error", timeoutMs),
+                    timeoutMs, action,
+                    event -> event.has("text") ? event.get("text").getAsString() : "",
+                    "event 'error'");
+            }
             default:
                 throw new IllegalArgumentException("Unknown event name: '" + name + "'");
         }
     }
 
-    private <T> T awaitAny(Consumer<Consumer<T>> register,
-                           Consumer<Consumer<T>> unregister,
-                           Runnable action, WaitOptions options, String name) {
-        return await(register, unregister, value -> true, action, options,
-            "event '" + name + "'");
+    private <T> T awaitWire(Supplier<CompletableFuture<com.google.gson.JsonObject>> start, long timeoutMs,
+                            Runnable action,
+                            java.util.function.Function<com.google.gson.JsonObject, T> build, String what) {
+        if (action == null) {
+            throw new IllegalArgumentException("capture action must not be null");
+        }
+        // The capture command is written on this thread before the action can
+        // send anything, so the engine registers the capture first, in
+        // message order.
+        CompletableFuture<com.google.gson.JsonObject> pending = start.get();
+        // The action runs on the executor: a trigger that blocks until the
+        // captured thing is handled — an eval stuck inside the alert it
+        // opened (#146) — must not block the capture's return.
+        CompletableFuture<Void> actionFuture = CompletableFuture.runAsync(action::run, ACTIONS);
+        actionFuture.whenComplete((ignored, error) -> {
+            if (error != null) pending.completeExceptionally(unwrap(error));
+        });
+        try {
+            // The binary enforces timeoutMs; the slack only covers transport.
+            com.google.gson.JsonObject result = pending.get(timeoutMs + 5_000, TimeUnit.MILLISECONDS);
+            return build.apply(result.getAsJsonObject("event"));
+        } catch (TimeoutException e) {
+            pending.cancel(true);
+            throw new VibiumTimeoutException("Timeout waiting for " + what);
+        } catch (ExecutionException e) {
+            Throwable cause = unwrap(e.getCause());
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new VibiumException("Capture action failed: " + cause.getMessage(), cause);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new VibiumTimeoutException("Interrupted waiting for " + what);
+        }
     }
 
     private <T> T await(Consumer<Consumer<T>> register,
                         Consumer<Consumer<T>> unregister,
-                        java.util.function.Predicate<T> matches,
                         Runnable action, WaitOptions options, String description) {
         if (action == null) {
             throw new IllegalArgumentException("capture action must not be null");
@@ -189,7 +178,7 @@ public final class Capture {
         CompletableFuture<T> captured = new CompletableFuture<>();
         AtomicBoolean actionStarted = new AtomicBoolean();
         Consumer<T> handler = value -> {
-            if (actionStarted.get() && matches.test(value)) {
+            if (actionStarted.get()) {
                 captured.complete(value);
             }
         };

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -924,15 +924,30 @@ public class Page {
     }
 
     /** Send a one-shot capture command; the binary matches and waits. */
-    JsonObject sendCapture(String method, String pattern, long timeoutMs) {
+    java.util.concurrent.CompletableFuture<JsonObject> sendCapture(String method, String pattern, long timeoutMs) {
         JsonObject params = contextParams();
         params.addProperty("pattern", pattern);
         params.addProperty("timeout", timeoutMs);
-        return client.send(method, params);
+        return client.sendAsync(method, params);
+    }
+
+    java.util.concurrent.CompletableFuture<JsonObject> sendCaptureEvent(String kind, long timeoutMs) {
+        JsonObject params = contextParams();
+        params.addProperty("kind", kind);
+        params.addProperty("timeout", timeoutMs);
+        return client.sendAsync("vibium:page.captureEvent", params);
     }
 
     Request requestFromEvent(JsonObject event) {
         return new Request(client, event);
+    }
+
+    Dialog dialogFromEvent(JsonObject event) {
+        return new Dialog(client, event);
+    }
+
+    ConsoleMessage consoleFromEvent(JsonObject event) {
+        return new ConsoleMessage(event);
     }
 
     Response responseFromEvent(JsonObject event) {

--- a/clients/java/src/main/java/com/vibium/internal/BiDiClient.java
+++ b/clients/java/src/main/java/com/vibium/internal/BiDiClient.java
@@ -75,36 +75,10 @@ public class BiDiClient {
      * Send a command and wait for the response with a custom timeout.
      */
     public JsonObject send(String method, JsonObject params, long timeoutMs) {
-        if (closed) {
-            throw new VibiumConnectionException("BiDi client is closed");
-        }
         StackTraceElement[] callerStack = captureCallerStack();
 
         int id = nextId.getAndIncrement();
-        CompletableFuture<JsonObject> future = new CompletableFuture<>();
-        pendingRequests.put(id, future);
-
-        // Build command
-        JsonObject command = new JsonObject();
-        command.addProperty("id", id);
-        command.addProperty("method", method);
-        if (params != null) {
-            command.add("params", params);
-        } else {
-            command.add("params", new JsonObject());
-        }
-
-        // Write to stdin
-        try {
-            synchronized (stdin) {
-                stdin.write(GSON.toJson(command));
-                stdin.newLine();
-                stdin.flush();
-            }
-        } catch (IOException e) {
-            pendingRequests.remove(id);
-            throw new VibiumConnectionException("Failed to send command: " + e.getMessage(), e);
-        }
+        CompletableFuture<JsonObject> future = writeCommand(id, method, params);
 
         // Wait for response
         try {
@@ -125,6 +99,49 @@ public class BiDiClient {
             Thread.currentThread().interrupt();
             throw new VibiumException("Interrupted while waiting for response to " + method);
         }
+    }
+
+    /**
+     * Write a command now and return the pending response as a future.
+     *
+     * The write happens on the caller's thread, so any command sent after
+     * this returns is ordered behind it on the wire. Captures depend on that:
+     * the engine must register the capture before the action that triggers
+     * its event can be processed (#446). No client-side timeout is armed; the
+     * engine answers every capture, with an error once its own timeout
+     * passes.
+     */
+    public CompletableFuture<JsonObject> sendAsync(String method, JsonObject params) {
+        return writeCommand(nextId.getAndIncrement(), method, params);
+    }
+
+    private CompletableFuture<JsonObject> writeCommand(int id, String method, JsonObject params) {
+        if (closed) {
+            throw new VibiumConnectionException("BiDi client is closed");
+        }
+        CompletableFuture<JsonObject> future = new CompletableFuture<>();
+        pendingRequests.put(id, future);
+
+        JsonObject command = new JsonObject();
+        command.addProperty("id", id);
+        command.addProperty("method", method);
+        if (params != null) {
+            command.add("params", params);
+        } else {
+            command.add("params", new JsonObject());
+        }
+
+        try {
+            synchronized (stdin) {
+                stdin.write(GSON.toJson(command));
+                stdin.newLine();
+                stdin.flush();
+            }
+        } catch (IOException e) {
+            pendingRequests.remove(id);
+            throw new VibiumConnectionException("Failed to send command: " + e.getMessage(), e);
+        }
+        return future;
     }
 
     static StackTraceElement[] captureCallerStack() {

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -842,22 +842,24 @@ export class Page {
     return new Response(result.event, this.client);
   }
 
-  /** @internal Capture a navigation event. Resolves with the URL. */
-  _captureNavigation(options?: { timeout?: number }): Promise<string> {
-    const timeout = options?.timeout ?? 10000;
-    return new Promise<string>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.navigationCallbacks = this.navigationCallbacks.filter(cb => cb !== handler);
-        reject(new Error(`Timeout waiting for navigation`));
-      }, timeout);
-
-      const handler = (url: string) => {
-        clearTimeout(timer);
-        this.navigationCallbacks = this.navigationCallbacks.filter(cb => cb !== handler);
-        resolve(url);
-      };
-      this.navigationCallbacks.push(handler);
+  /**
+   * @internal One-shot capture, waited out in the engine
+   * (vibium:page.captureEvent), so no client keeps its own listener and
+   * timeout machinery (#446). Returns the raw event params.
+   */
+  private async captureEventParams(kind: string, options?: { timeout?: number }): Promise<Record<string, unknown>> {
+    const result = await this.client.send<{ event: Record<string, unknown> }>('vibium:page.captureEvent', {
+      context: this.contextId,
+      kind,
+      timeout: options?.timeout ?? 10000,
     });
+    return result.event;
+  }
+
+  /** @internal Capture a navigation event. Resolves with the URL. */
+  async _captureNavigation(options?: { timeout?: number }): Promise<string> {
+    const params = await this.captureEventParams('navigation', options);
+    return (params.url as string) ?? '';
   }
 
   /** @internal Capture a download event. */
@@ -878,85 +880,34 @@ export class Page {
     });
   }
 
-  /** @internal Capture a dialog event. The registered callback keeps the engine from auto-dismissing. */
-  _captureDialog(options?: { timeout?: number }): Promise<Dialog> {
-    const timeout = options?.timeout ?? 10000;
-    return new Promise<Dialog>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.removeDialogCallback(handler);
-        reject(new Error(`Timeout waiting for dialog`));
-      }, timeout);
-
-      const handler = (dialog: Dialog) => {
-        clearTimeout(timer);
-        this.removeDialogCallback(handler);
-        resolve(dialog);
-      };
-      this.addDialogCallback(handler);
-    });
+  /** @internal Capture a dialog event. The pending engine capture keeps the dialog from being auto-dismissed. */
+  async _captureDialog(options?: { timeout?: number }): Promise<Dialog> {
+    const params = await this.captureEventParams('dialog', options);
+    return new Dialog(this.client, this.contextId, params);
   }
 
-  /** @internal Capture a named event. Maps event name to the appropriate callback array. */
-  _captureEvent(name: string, options?: { timeout?: number }): Promise<unknown> {
-    const timeout = options?.timeout ?? 10000;
-    return new Promise<unknown>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        cleanup();
-        reject(new Error(`Timeout waiting for event '${name}'`));
-      }, timeout);
-
-      let cleanup: () => void;
-
-      switch (name) {
-        case 'request': {
-          const handler = (req: Request) => { clearTimeout(timer); cleanup(); resolve(req); };
-          this.requestCallbacks.push(handler);
-          cleanup = () => { this.requestCallbacks = this.requestCallbacks.filter(cb => cb !== handler); };
-          this.ensureDataCollector();
-          break;
-        }
-        case 'response': {
-          const handler = (resp: Response) => { clearTimeout(timer); cleanup(); resolve(resp); };
-          this.responseCallbacks.push(handler);
-          cleanup = () => { this.responseCallbacks = this.responseCallbacks.filter(cb => cb !== handler); };
-          this.ensureDataCollector();
-          break;
-        }
-        case 'dialog': {
-          const handler = (dialog: Dialog) => { clearTimeout(timer); cleanup(); resolve(dialog); };
-          this.addDialogCallback(handler);
-          cleanup = () => { this.removeDialogCallback(handler); };
-          break;
-        }
-        case 'download': {
-          const handler = (download: Download) => { clearTimeout(timer); cleanup(); resolve(download); };
-          this.downloadCallbacks.push(handler);
-          cleanup = () => { this.downloadCallbacks = this.downloadCallbacks.filter(cb => cb !== handler); };
-          break;
-        }
-        case 'navigation': {
-          const handler = (url: string) => { clearTimeout(timer); cleanup(); resolve(url); };
-          this.navigationCallbacks.push(handler);
-          cleanup = () => { this.navigationCallbacks = this.navigationCallbacks.filter(cb => cb !== handler); };
-          break;
-        }
-        case 'console': {
-          const handler = (msg: ConsoleMessage) => { clearTimeout(timer); cleanup(); resolve(msg); };
-          this.consoleCallbacks.push(handler);
-          cleanup = () => { this.consoleCallbacks = this.consoleCallbacks.filter(cb => cb !== handler); };
-          break;
-        }
-        case 'error': {
-          const handler = (err: Error) => { clearTimeout(timer); cleanup(); resolve(err); };
-          this.errorCallbacks.push(handler);
-          cleanup = () => { this.errorCallbacks = this.errorCallbacks.filter(cb => cb !== handler); };
-          break;
-        }
-        default:
-          clearTimeout(timer);
-          reject(new Error(`Unknown event name: '${name}'`));
+  /** @internal Capture a named event. */
+  async _captureEvent(name: string, options?: { timeout?: number }): Promise<unknown> {
+    switch (name) {
+      case 'request':
+        return this._captureRequest('**', options);
+      case 'response':
+        return this._captureResponse('**', options);
+      case 'download':
+        return this._captureDownload(options);
+      case 'navigation':
+        return this._captureNavigation(options);
+      case 'dialog':
+        return this._captureDialog(options);
+      case 'console':
+        return new ConsoleMessage(await this.captureEventParams('console', options));
+      case 'error': {
+        const params = await this.captureEventParams('error', options);
+        return new Error((params.text as string) ?? 'Unknown error');
       }
-    });
+      default:
+        throw new Error(`Unknown event name: '${name}'`);
+    }
   }
 
   /** Set extra HTTP headers for all requests in this page. */

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -325,46 +325,23 @@ class Page:
     async def _setup_capture_request(self, pattern: str, timeout: Optional[int] = None) -> Any:
         """Internal: start a request capture now, return a task to await later."""
         return asyncio.get_running_loop().create_task(self._capture_request(pattern, timeout))
+    async def _capture_event_params(self, kind: str, timeout: Optional[int] = None) -> Dict[str, Any]:
+        """Internal: one-shot capture, waited out in the engine
+        (vibium:page.captureEvent), so no client keeps its own listener and
+        timeout machinery (#446). Returns the raw event params."""
+        result = await self._client.send("vibium:page.captureEvent", {
+            "context": self._context_id, "kind": kind, "timeout": timeout or 10000,
+        })
+        return result["event"]
+
     async def _capture_navigation(self, timeout: Optional[int] = None) -> str:
         """Internal: wait for a navigation event. Resolves with URL."""
-        timeout_ms = timeout or 10000
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
-
-        def handler(url: str) -> None:
-            self._navigation_callbacks.remove(handler)
-            if not future.done():
-                future.set_result(url)
-
-        self._navigation_callbacks.append(handler)
-
-        try:
-            return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
-        except asyncio.TimeoutError:
-            if handler in self._navigation_callbacks:
-                self._navigation_callbacks.remove(handler)
-            raise errors.TimeoutError("Timeout waiting for navigation")
+        params = await self._capture_event_params("navigation", timeout)
+        return params.get("url", "")
 
     async def _setup_capture_navigation(self, timeout: Optional[int] = None) -> Any:
-        """Internal: set up navigation listener and return a coroutine to await later."""
-        timeout_ms = timeout or 10000
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
-
-        def handler(url: str) -> None:
-            self._navigation_callbacks.remove(handler)
-            if not future.done():
-                future.set_result(url)
-
-        self._navigation_callbacks.append(handler)
-
-        async def _wait() -> str:
-            try:
-                return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
-            except asyncio.TimeoutError:
-                if handler in self._navigation_callbacks:
-                    self._navigation_callbacks.remove(handler)
-                raise errors.TimeoutError("Timeout waiting for navigation")
-
-        return _wait()
+        """Internal: start a navigation capture now, return a task to await later."""
+        return asyncio.get_running_loop().create_task(self._capture_navigation(timeout))
 
     async def _capture_download(self, timeout: Optional[int] = None) -> Download:
         """Internal: wait for a download event."""
@@ -429,132 +406,55 @@ class Page:
         self._client.send_setup("vibium:dialog.setPolicy", params)
 
     async def _capture_dialog(self, timeout: Optional[int] = None) -> Dialog:
-        """Internal: wait for a dialog event. Callback presence keeps the engine from auto-dismissing."""
-        timeout_ms = timeout or 10000
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
-
-        def handler(dialog: Dialog) -> None:
-            self._dialog_callbacks.remove(handler)
-            self._sync_dialog_policy()
-            if not future.done():
-                future.set_result(dialog)
-
-        self._dialog_callbacks.append(handler)
-        self._sync_dialog_policy()
-
-        try:
-            return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
-        except asyncio.TimeoutError:
-            if handler in self._dialog_callbacks:
-                self._dialog_callbacks.remove(handler)
-                self._sync_dialog_policy()
-            raise errors.TimeoutError("Timeout waiting for dialog")
+        """Internal: wait for a dialog event. The pending engine capture keeps
+        the dialog from being auto-dismissed."""
+        params = await self._capture_event_params("dialog", timeout)
+        return Dialog(self._client, self._context_id, params)
 
     async def _setup_capture_dialog(self, timeout: Optional[int] = None, auto_dismiss: bool = False) -> Any:
-        """Internal: set up dialog listener and return a coroutine to await later.
+        """Internal: start a dialog capture now, return a task to await later.
 
-        auto_dismiss dismisses the dialog the moment it is captured. The sync
-        wrappers use it: they return only the dialog's data, so the caller has
-        no handle to close the dialog with, and a dialog left open blocks the
-        page, including a trigger fn stuck inside evaluate("alert(...)"),
-        which otherwise deadlocks the capture (#146).
+        auto_dismiss dismisses the dialog the moment it is captured, not when
+        the task is awaited. The sync wrappers use it: they return only the
+        dialog's data, so the caller has no handle to close the dialog with,
+        and a dialog left open blocks the page, including a trigger fn stuck
+        inside evaluate("alert(...)"), which otherwise deadlocks the capture
+        (#146).
         """
-        timeout_ms = timeout or 10000
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        task = asyncio.get_running_loop().create_task(self._capture_dialog(timeout))
+        if auto_dismiss:
+            def _dismiss(finished: Any) -> None:
+                if not finished.cancelled() and finished.exception() is None:
+                    asyncio.ensure_future(finished.result().dismiss())
+            task.add_done_callback(_dismiss)
+        return task
 
-        def handler(dialog: Dialog) -> None:
-            self._dialog_callbacks.remove(handler)
-            self._sync_dialog_policy()
-            if not future.done():
-                future.set_result(dialog)
-            if auto_dismiss:
-                asyncio.ensure_future(dialog.dismiss())
-
-        self._dialog_callbacks.append(handler)
-        self._sync_dialog_policy()
-
-        async def _wait() -> Dialog:
-            try:
-                return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
-            except asyncio.TimeoutError:
-                if handler in self._dialog_callbacks:
-                    self._dialog_callbacks.remove(handler)
-                    self._sync_dialog_policy()
-                raise errors.TimeoutError("Timeout waiting for dialog")
-
-        return _wait()
+    _CAPTURE_EVENT_NAMES = ("request", "response", "download", "navigation", "dialog", "console", "error")
 
     async def _capture_event(self, name: str, timeout: Optional[int] = None) -> Any:
         """Internal: wait for a named event."""
-        timeout_ms = timeout or 10000
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
-
-        callback_list = self._get_callback_list(name)
-        if callback_list is None:
-            raise ValueError(f"Unknown event name: '{name}'")
-
-        def handler(data: Any) -> None:
-            callback_list.remove(handler)
-            self._sync_dialog_policy()
-            if not future.done():
-                future.set_result(data)
-
-        if name in ("request", "response"):
-            self._ensure_data_collector()
-        callback_list.append(handler)
-        self._sync_dialog_policy()
-
-        try:
-            return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
-        except asyncio.TimeoutError:
-            if handler in callback_list:
-                callback_list.remove(handler)
-                self._sync_dialog_policy()
-            raise errors.TimeoutError(f"Timeout waiting for event '{name}'")
+        if name == "request":
+            return await self._capture_request("**", timeout)
+        if name == "response":
+            return await self._capture_response("**", timeout)
+        if name == "download":
+            return await self._capture_download(timeout)
+        if name == "navigation":
+            return await self._capture_navigation(timeout)
+        if name == "dialog":
+            return await self._capture_dialog(timeout)
+        if name == "console":
+            return ConsoleMessage(await self._capture_event_params("console", timeout))
+        if name == "error":
+            params = await self._capture_event_params("error", timeout)
+            return Exception(params.get("text", "Unknown error"))
+        raise ValueError(f"Unknown event name: '{name}'")
 
     async def _setup_capture_event(self, name: str, timeout: Optional[int] = None) -> Any:
-        """Internal: set up event listener and return a coroutine to await later."""
-        timeout_ms = timeout or 10000
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
-
-        callback_list = self._get_callback_list(name)
-        if callback_list is None:
+        """Internal: start an event capture now, return a task to await later."""
+        if name not in self._CAPTURE_EVENT_NAMES:
             raise ValueError(f"Unknown event name: '{name}'")
-
-        def handler(data: Any) -> None:
-            callback_list.remove(handler)
-            self._sync_dialog_policy()
-            if not future.done():
-                future.set_result(data)
-
-        if name in ("request", "response"):
-            self._ensure_data_collector()
-        callback_list.append(handler)
-        self._sync_dialog_policy()
-
-        async def _wait() -> Any:
-            try:
-                return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
-            except asyncio.TimeoutError:
-                if handler in callback_list:
-                    callback_list.remove(handler)
-                    self._sync_dialog_policy()
-                raise errors.TimeoutError(f"Timeout waiting for event '{name}'")
-
-        return _wait()
-
-    def _get_callback_list(self, name: str) -> Optional[List[Callable]]:
-        """Map event name to callback list."""
-        mapping = {
-            "request": self._request_callbacks,
-            "response": self._response_callbacks,
-            "dialog": self._dialog_callbacks,
-            "download": self._download_callbacks,
-            "navigation": self._navigation_callbacks,
-            "console": self._console_callbacks,
-            "error": self._error_callbacks,
-        }
-        return mapping.get(name)
+        return asyncio.get_running_loop().create_task(self._capture_event(name, timeout))
 
     # --- Screenshots & PDF ---
 

--- a/docs/explanation/client-implementation-guide.md
+++ b/docs/explanation/client-implementation-guide.md
@@ -327,7 +327,11 @@ Events (`onDialog`, `onRequest`, etc.) are received as WebSocket messages with n
 
 ### Dialog Policy
 
-The engine dismisses every dialog itself while no dialog handler is registered — clients do not implement that default. The policy is per browsing context: when a page's first dialog handler (or one-shot capture) registers, send `vibium:dialog.setPolicy` with `{"context": <the page's context>, "policy": "manual"}`; when its last one deregisters, send the same with `"policy": "dismiss"`. Issue the command through the same ordered channel as regular commands and ahead of any command that could trigger a dialog (the engine handles it in message order), so a dialog can never open under the policy the page just left.
+The engine dismisses every dialog itself while no dialog handler is registered — clients do not implement that default. The policy is per browsing context: when a page's first dialog handler registers, send `vibium:dialog.setPolicy` with `{"context": <the page's context>, "policy": "manual"}`; when its last one deregisters, send the same with `"policy": "dismiss"`. Issue the command through the same ordered channel as regular commands and ahead of any command that could trigger a dialog (the engine handles it in message order), so a dialog can never open under the policy the page just left. One-shot captures need no policy flip: a pending `vibium:page.captureEvent` with kind `dialog` holds off the auto-dismiss default by itself.
+
+### One-Shot Captures
+
+`capture.request` / `capture.response` send `vibium:page.captureRequest` / `vibium:page.captureResponse` with `{context, pattern, timeout}`; `capture.navigation`, `capture.dialog`, and `capture.event("console" | "error")` send `vibium:page.captureEvent` with `{context, kind, timeout}`. The engine registers the capture in client message order, waits for the first matching event, and answers with its raw params (`{"event": {...}}`) — clients keep no listener or timeout machinery, they build the language object from the returned params. Start the capture command on the wire before running the trigger action, and run the action so that its blocking cannot block the capture's return (a trigger stuck inside `evaluate("alert(...)")` resolves only after the captured dialog is handled). `capture.download` stays a local listener for now: the captured Download must be the same object the `downloadEnd` event completes.
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -74,10 +74,10 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 54 | Remove all event listeners | *client-side* | — | — | `page.removeAllListeners(ev?)` | `page.remove_all_listeners(ev?)` | `page.removeAllListeners(ev?)` |
 | 55 | Capture response (before action) | `vibium:page.captureResponse` | — | — | `page.capture.response(pat, fn?)` | `page.capture.response(pat, fn?)` | `page.capture().response(pat, action)` |
 | 56 | Capture request (before action) | `vibium:page.captureRequest` | — | — | `page.capture.request(pat, fn?)` | `page.capture.request(pat, fn?)` | `page.capture().request(pat, action)` |
-| 57 | Capture navigation (before action) | *client-side* | — | — | `page.capture.navigation(fn?)` | `page.capture.navigation(fn?)` | `page.capture().navigation(action)` |
-| 58 | Capture event (before action) | *client-side* | — | — | `page.capture.event(name, fn?)` | `page.capture.event(name, fn?)` | `page.capture().event(name, action)` |
+| 57 | Capture navigation (before action) | `vibium:page.captureEvent` | — | — | `page.capture.navigation(fn?)` | `page.capture.navigation(fn?)` | `page.capture().navigation(action)` |
+| 58 | Capture event (before action) | `vibium:page.captureEvent` | — | — | `page.capture.event(name, fn?)` | `page.capture.event(name, fn?)` | `page.capture().event(name, action)` |
 | 59 | Capture download (before action) | *client-side* | — | — | `page.capture.download(fn?)` | `page.capture.download(fn?)` | `page.capture().download(action)` |
-| 60 | Capture dialog (before action) | *client-side* | — | — | `page.capture.dialog(fn?)` | `page.capture.dialog(fn?)` | `page.capture().dialog(action)` |
+| 60 | Capture dialog (before action) | `vibium:page.captureEvent` | — | — | `page.capture.dialog(fn?)` | `page.capture.dialog(fn?)` | `page.capture().dialog(action)` |
 | 61 | Get buffered console messages | *client-side* | — | — | `page.consoleMessages()` | `page.console_messages()` | `page.consoleMessages()` |
 | 62 | Get buffered page errors | *client-side* | — | — | `page.errors()` | `page.errors()` | `page.errors()` |
 | 170 | Owning browser context | *client-side* | — | — | `page.context` | `page.context` | `page.context()` |


### PR DESCRIPTION
Part of #446. Builds on the dialog policy change (vibium:dialog.setPolicy), which merges first.

capture.navigation, capture.dialog, and capture.event kept a private future-and-timeout machine in every client. They now send vibium:page.captureEvent {context, kind, timeout}; the engine registers the capture inline on the client message order, waits for the first matching event, and answers with its raw params, which the client turns into its language object. capture.event maps request and response onto the existing captureRequest/captureResponse commands with a match-all pattern.

A pending dialog capture claims its context's prompts, so the engine's auto-dismiss default leaves the captured dialog open without any policy traffic from the client.

The Java client gains BiDiClient.sendAsync, which writes the command on the caller's thread and returns the pending response as a future. Capture uses it to guarantee the capture command is on the wire before the action runs, and to run the action off the waiting thread. Both matter: the awaitWire helper on main starts the capture command on an executor, so it can lose the write race against the action's first command, and it runs the action on the waiting thread, so a trigger that blocks until the captured dialog is handled (an evaluate stuck inside the alert it opened) deadlocks against its own capture. CaptureTest.dialogCaptureDoesNotDeadlockWhenActionBlocks exercises exactly that shape once dialog capture goes over the wire.

capture.download stays a local listener on purpose: the captured Download must be the same object the downloadEnd event completes, so it moves into the engine together with the download bookkeeping in a follow-up.

Verified:
- New engine tests cover every capture kind and the dialog-capture prompt claim (capture_registry_test.go)
- JS async capture suites, JS sync suite, Python engine dialog and sync API suites, the Java engine suite including CaptureTest, the full Go suite, and the API drift checker pass against this branch
