### PR TITLE
Log the first exchange per client and reap sessions a timed-out tutorial block leaks

### DIFF
--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -58,6 +58,14 @@ type BrowserSession struct {
 
 	activeContext string // last context foregrounded for pointer input; "" = unknown
 
+	// First-exchange instrumentation (#397): a session whose first command
+	// is never answered looks identical in the logs to one that never
+	// received a command at all. One line when the first command arrives and
+	// one when the first response leaves name the wedged side.
+	connectedAt   time.Time
+	firstCommand  int32 // atomic; 1 = first client command logged
+	firstResponse int32 // atomic; 1 = first response to the client logged
+
 	// prompts records which contexts have an open user prompt, so a command
 	// Chrome will not answer fails immediately instead of timing out.
 	prompts     *PromptTracker
@@ -208,6 +216,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		BidiConn:          bidiConn,
 		Client:            client,
 		ownsRemote:        ownsRemoteSession,
+		connectedAt:       time.Now(),
 		stopChan:          make(chan struct{}),
 		internalCmds:      make(map[int]chan json.RawMessage),
 		abandonedInternal: make(map[int]struct{}),
@@ -432,6 +441,14 @@ func (r *Router) OnClientMessage(client ClientTransport, msg string) {
 			fmt.Fprintf(os.Stderr, "[router] Failed to send to browser for client %d: %v\n", client.ID(), err)
 		}
 		return
+	}
+
+	// A #397 incident starts as "the client hung": this line proves the
+	// command reached the router, and its missing counterpart (the first
+	// response line) then points at the browser side.
+	if atomic.CompareAndSwapInt32(&session.firstCommand, 0, 1) {
+		fmt.Fprintf(os.Stderr, "[router] first command from client %d: %s (%.1fs after connect)\n",
+			client.ID(), cmd.Method, time.Since(session.connectedAt).Seconds())
 	}
 
 	// Handle vibium: extension commands (per WebDriver BiDi spec for extensions)
@@ -858,8 +875,18 @@ func (r *Router) getContext(session *BrowserSession) (string, error) {
 	return result.Result.Contexts[0].Context, nil
 }
 
+// noteFirstResponse logs the first response this session sends its client,
+// whoever produced it — a vibium: handler or a forwarded browser reply (#397).
+func (s *BrowserSession) noteFirstResponse() {
+	if atomic.CompareAndSwapInt32(&s.firstResponse, 0, 1) {
+		fmt.Fprintf(os.Stderr, "[router] first response to client %d (%.1fs after connect)\n",
+			s.Client.ID(), time.Since(s.connectedAt).Seconds())
+	}
+}
+
 // sendSuccess sends a successful response to the client.
 func (r *Router) sendSuccess(session *BrowserSession, id int, result interface{}) {
+	session.noteFirstResponse()
 	resp := bidiResponse{ID: id, Type: "success", Result: result}
 	data, _ := json.Marshal(resp)
 	session.Client.Send(string(data))
@@ -867,6 +894,7 @@ func (r *Router) sendSuccess(session *BrowserSession, id int, result interface{}
 
 // sendError sends an error response to the client (follows WebDriver BiDi spec).
 func (r *Router) sendError(session *BrowserSession, id int, err error) {
+	session.noteFirstResponse()
 	resp := bidiResponse{
 		ID:      id,
 		Type:    "error",
@@ -955,6 +983,9 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 			if abandoned {
 				continue
 			}
+
+			// A browser reply about to be forwarded answers a client command.
+			session.noteFirstResponse()
 		}
 
 		// Track page URL from load/navigation events (zero extra BiDi round-trips)

--- a/tests/py/helpers/tutorial_runner.py
+++ b/tests/py/helpers/tutorial_runner.py
@@ -14,7 +14,10 @@ Server blocks:
 """
 
 import asyncio
+import os
 import re
+import signal
+import subprocess
 import textwrap
 import threading
 from pathlib import Path
@@ -187,15 +190,58 @@ def run_sync_block(code, vibe, base_url=None):
 TUTORIAL_TIMEOUT = 120
 
 
+def _vibium_children():
+    """PIDs of vibium processes whose parent is this test process.
+
+    Name-anchored and parent-filtered on purpose: substring matching would
+    also hit unrelated processes (a user name containing "vibium" puts the
+    word in every process's environment path), and parallel pytest workers
+    own their own children.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-eo", "pid=,ppid=,comm="],
+            capture_output=True, text=True, timeout=10,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    me = str(os.getpid())
+    pids = set()
+    for line in out.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) == 3 and parts[1] == me and os.path.basename(parts[2]) == "vibium":
+            pids.add(int(parts[0]))
+    return pids
+
+
+def _kill_leaked_vibium(before):
+    """Terminate vibium children a timed-out block left behind.
+
+    An abandoned block's session keeps pytest's pipes open, so even a
+    correctly bounded failure blocked the run's exit until the phase
+    watchdog killed it, discarding the report (#397 incident 12). vibium
+    shuts its browser down on SIGTERM.
+    """
+    for pid in _vibium_children() - before:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+
+
 async def run_async_standalone(code, base_url=None):
     """Exec a standalone async block that manages its own browser lifecycle."""
     indented = textwrap.indent(code, "    ")
     wrapped = f"async def _run(base_url):\n{indented}\n"
     ns = {}
     exec(compile(wrapped, "<tutorial>", "exec"), ns)
+    before = _vibium_children()
     try:
         await asyncio.wait_for(ns["_run"](base_url), timeout=TUTORIAL_TIMEOUT)
     except asyncio.TimeoutError:
+        # The cancelled task's cleanup is exactly what is wedged in a #397
+        # hang, so it cannot be trusted to close its own session.
+        _kill_leaked_vibium(before)
         # asyncio.TimeoutError is not the builtin TimeoutError before 3.11
         raise TimeoutError(f"tutorial block still running after {TUTORIAL_TIMEOUT}s") from None
 
@@ -203,9 +249,8 @@ async def run_async_standalone(code, base_url=None):
 def run_sync_standalone(code, base_url=None):
     """Exec a standalone sync block that manages its own browser lifecycle."""
     # A hung sync block cannot be interrupted in place, so it runs on a
-    # scrap thread that gets abandoned on timeout; the leaked browser is
-    # cleaned by the suite's process cleanup, and the alternative was the
-    # watchdog killing the whole phase.
+    # scrap thread that gets abandoned on timeout; its session is killed
+    # here, and the alternative was the watchdog killing the whole phase.
     result = {}
 
     def _target():
@@ -214,10 +259,12 @@ def run_sync_standalone(code, base_url=None):
         except BaseException as e:
             result["error"] = e
 
+    before = _vibium_children()
     worker = threading.Thread(target=_target, daemon=True)
     worker.start()
     worker.join(TUTORIAL_TIMEOUT)
     if worker.is_alive():
+        _kill_leaked_vibium(before)
         raise TimeoutError(f"tutorial block still running after {TUTORIAL_TIMEOUT}s")
     if "error" in result:
         raise result["error"]

--- a/tests/py/test_tutorial_runner_timeout.py
+++ b/tests/py/test_tutorial_runner_timeout.py
@@ -27,6 +27,69 @@ def test_sync_hung_block_times_out(short_timeout):
         run_sync_standalone("import time\ntime.sleep(30)")
 
 
+def _leaky_block(fake_vibium, pidfile):
+    """A block that spawns a child named vibium, reports its pid, and hangs."""
+    return (
+        "import pathlib, subprocess, time\n"
+        f"p = subprocess.Popen([{str(fake_vibium)!r}, '60'])\n"
+        f"pathlib.Path({str(pidfile)!r}).write_text(str(p.pid))\n"
+        "time.sleep(30)\n"
+    )
+
+
+def _assert_terminated(pid):
+    """The reaped child is gone or a zombie awaiting its abandoned parent."""
+    import subprocess
+    import time
+
+    out = ""
+    for _ in range(50):
+        out = subprocess.run(
+            ["ps", "-o", "state=", "-p", str(pid)], capture_output=True, text=True
+        ).stdout.strip()
+        if not out or out.startswith("Z"):
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"leaked vibium child {pid} still running (state {out!r})")
+
+
+def test_sync_timeout_kills_leaked_vibium(short_timeout, tmp_path):
+    """A timed-out block's vibium child is terminated, not abandoned.
+
+    Incident 12 (#397): the bound fired, but the wedged session held the
+    pipes open and blocked the run's exit until the phase watchdog killed
+    it, discarding the pytest report.
+    """
+    import os
+
+    fake_vibium = tmp_path / "vibium"
+    # A symlink, not a copy: macOS kills copied platform binaries over
+    # their code signature, which would end this test vacuously.
+    os.symlink("/bin/sleep", fake_vibium)
+    pidfile = tmp_path / "pid"
+
+    with pytest.raises(TimeoutError):
+        run_sync_standalone(_leaky_block(fake_vibium, pidfile))
+
+    _assert_terminated(int(pidfile.read_text()))
+
+
+async def test_async_timeout_kills_leaked_vibium(short_timeout, tmp_path):
+    import os
+
+    fake_vibium = tmp_path / "vibium"
+    os.symlink("/bin/sleep", fake_vibium)
+    pidfile = tmp_path / "pid"
+
+    code = _leaky_block(fake_vibium, pidfile).replace(
+        "time.sleep(30)", "import asyncio\nawait asyncio.sleep(30)"
+    )
+    with pytest.raises(TimeoutError):
+        await run_async_standalone(code)
+
+    _assert_terminated(int(pidfile.read_text()))
+
+
 async def test_async_block_still_runs_and_returns():
     await run_async_standalone("assert base_url == 'x'", base_url="x")
 


### PR DESCRIPTION
Part of #397.

Two diagnosis gaps in the event-delivery hangs, both observed in CI runs on that issue:

A freshly launched session sometimes never answers its first command. The log today cannot say whether the command never reached the router or the browser never replied, because nothing marks either point. The router now logs one line when a client's first command arrives and one when its first response goes out. In the next such run, a missing first-command line points at the client or transport, and a first-command line with no first-response line points at the browser connection.

The standalone tutorial runners bound a hung block (#439) so it fails its own test instead of dying to the 600s phase watchdog. But the timed-out block's vibium session survives abandonment, holds the output pipes open, and blocks pytest's exit, so the watchdog still kills the run and discards the report the bound existed to produce. On timeout the runners now SIGTERM vibium children spawned during the block. Matching is by exact process name plus parent pid: substring matching is unsafe (any path containing "vibium" would match), and the parent filter keeps parallel pytest workers out of each other's children.

Verified:
- New runner tests spawn a child named vibium from a hung block and assert it is terminated after the timeout; they fail on main (child still running) and pass with the reaper. The fake vibium is a symlink to /bin/sleep rather than a copy, because macOS refuses to run copied platform binaries, which would end the test before it tested anything
- Both log lines observed on a live pipe session, 0.0s and 0.1s after connect
- The existing tutorial-timeout tests and the full Go suite pass
