### PR TITLE
Honor --json in is actionable, storage -o, and start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ test-cli: build-go
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/help-flags.test.js tests/cli/is-installed.test.js tests/cli/packaging.test.js tests/cli/release-versioning.test.js tests/cli/wrapper.test.js
 	@"$(MAKE)" test-cli-shared ENGINE=$(ENGINE)
 	@echo "--- CLI Process Tests (sequential) ---"
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js tests/cli/dead-browser.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js tests/cli/dead-browser.test.js tests/cli/start-json.test.js
 
 test-cli-shared: build-go
 	@echo "--- CLI Shared Tests ($(ENGINE)) ---"

--- a/clicker/cmd/clicker/is.go
+++ b/clicker/cmd/clicker/is.go
@@ -111,7 +111,9 @@ func newIsCmd() *cobra.Command {
 				selector = args[1]
 			}
 
-			fmt.Printf("\nChecking actionability for selector: %s\n", selector)
+			if !jsonOutput {
+				fmt.Printf("\nChecking actionability for selector: %s\n", selector)
+			}
 
 			// Evaluate actionability script
 			script := `(() => {
@@ -173,7 +175,7 @@ func newIsCmd() *cobra.Command {
 				ReceivesEvents bool   `json:"receivesEvents"`
 				Enabled        bool   `json:"enabled"`
 				Editable       bool   `json:"editable"`
-				Error          string `json:"error"`
+				Error          string `json:"error,omitempty"`
 			}
 			if err := json.Unmarshal([]byte(resultText), &actionResult); err != nil {
 				printError(fmt.Errorf("failed to parse actionability result: %w", err))
@@ -181,6 +183,13 @@ func newIsCmd() *cobra.Command {
 			}
 			if actionResult.Error != "" {
 				printError(fmt.Errorf("%s", actionResult.Error))
+				return
+			}
+
+			// The five booleans are the result; a string would lose them.
+			// Struct-valued like paths --json (#392).
+			if jsonOutput {
+				printJSON(jsonEnvelope{OK: true, Result: actionResult})
 				return
 			}
 

--- a/clicker/cmd/clicker/start.go
+++ b/clicker/cmd/clicker/start.go
@@ -72,18 +72,20 @@ Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.`,
 				return
 			}
 
-			// Remote connect — stop existing daemon and start fresh with --connect
+			// Remote connect — stop existing daemon and start fresh with --connect.
+			// Failures go through printError: these paths wrote straight to
+			// stderr, which is why --json never reached them (#451).
 			if err := shutdownDaemonAndWait(); err != nil {
-				fmt.Fprintf(os.Stderr, "Error stopping existing daemon: %v\n", err)
-				os.Exit(1)
+				printError(fmt.Errorf("stopping existing daemon: %w", err))
+				return
 			}
 
 			daemon.CleanStale()
 
 			exe, err := os.Executable()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error finding executable: %v\n", err)
-				os.Exit(1)
+				printError(fmt.Errorf("finding executable: %w", err))
+				return
 			}
 
 			daemonArgs := []string{"daemon", "start", "--_internal", "--idle-timeout=30m",
@@ -109,14 +111,14 @@ Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.`,
 			setSysProcAttr(child)
 
 			if err := child.Start(); err != nil {
-				fmt.Fprintf(os.Stderr, "Error starting daemon: %v\n", err)
-				os.Exit(1)
+				printError(fmt.Errorf("starting daemon: %w", err))
+				return
 			}
 
 			socketPath, _ := paths.GetSocketPath()
 			if err := waitForSocket(socketPath, 5*time.Second); err != nil {
-				fmt.Fprintf(os.Stderr, "Daemon failed to start: %v\n", err)
-				os.Exit(1)
+				printError(fmt.Errorf("daemon failed to start: %w", err))
+				return
 			}
 
 			// Connect now instead of leaving it to the first command that
@@ -125,12 +127,19 @@ Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.`,
 			// endpoint is no use to the next command either — take it down
 			// rather than leave it to auto-start the same failure.
 			if _, err := daemonCall("browser_start", map[string]interface{}{}); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to connect to %s: %v\n", connectURL, err)
+				// Take the daemon down before reporting: it cannot reach the
+				// endpoint either, so leaving it up only defers the failure.
 				shutdownDaemonAndWait()
-				os.Exit(1)
+				printError(fmt.Errorf("failed to connect to %s: %w", connectURL, err))
+				return
 			}
 
-			fmt.Printf("Connected to %s (daemon pid %d)\n", connectURL, child.Process.Pid)
+			msg := fmt.Sprintf("Connected to %s (daemon pid %d)", connectURL, child.Process.Pid)
+			if jsonOutput {
+				printJSON(jsonEnvelope{OK: true, Result: msg})
+				return
+			}
+			fmt.Println(msg)
 		},
 	}
 }

--- a/clicker/cmd/clicker/storage.go
+++ b/clicker/cmd/clicker/storage.go
@@ -36,7 +36,12 @@ func newStorageCmd() *cobra.Command {
 					printError(fmt.Errorf("failed to write file: %w", err))
 					return
 				}
-				fmt.Printf("State saved to %s\n", output)
+				msg := fmt.Sprintf("State saved to %s", output)
+				if jsonOutput {
+					printJSON(jsonEnvelope{OK: true, Result: msg})
+					return
+				}
+				fmt.Println(msg)
 				return
 			}
 			printResult(result)
@@ -53,8 +58,8 @@ func newStorageCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			path, err := filepath.Abs(args[0])
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: invalid path: %v\n", err)
-				os.Exit(1)
+				printError(fmt.Errorf("invalid path: %w", err))
+				return
 			}
 
 			result, err := daemonCall("browser_restore_storage", map[string]interface{}{"path": path})

--- a/tests/cli/engine/actionability.test.js
+++ b/tests/cli/engine/actionability.test.js
@@ -53,6 +53,21 @@ describe('CLI: Actionability', () => {
       'Should timeout or report not found'
     );
   });
+
+  test('is actionable honors --json', () => {
+    // The five booleans are the whole result, so under --json they must
+    // come back machine-readable, like the is visible/enabled/checked
+    // siblings (#451).
+    const out = execSync(`${VIBIUM} is actionable ${baseURL}/example "a" --json`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const env = JSON.parse(out.trim()); // throws on the unfixed binary
+    assert.strictEqual(env.ok, true, 'envelope should report ok');
+    for (const key of ['visible', 'stable', 'receivesEvents', 'enabled', 'editable']) {
+      assert.strictEqual(typeof env.result[key], 'boolean', `result.${key} should be a boolean`);
+    }
+  });
 });
 
 describe('CLI: --timeout flag formats', () => {

--- a/tests/cli/engine/storage.test.js
+++ b/tests/cli/engine/storage.test.js
@@ -112,4 +112,18 @@ describe('CLI: storage export/restore', () => {
     }).trim();
     assert.strictEqual(legacy, 'legacy_value', 'legacy state file should still restore');
   });
+
+  test('storage -o honors --json', () => {
+    // Without -o this command already emits the envelope; the -o branch
+    // returned early with plain text instead (#451).
+    const outPath = path.join(tmpDir, 'state-json.json');
+    const out = execSync(`${VIBIUM} storage -o ${outPath} --json`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    const env = JSON.parse(out.trim()); // throws on the unfixed binary
+    assert.strictEqual(env.ok, true, 'envelope should report ok');
+    assert.match(env.result, /^State saved to /, 'result should carry the human message');
+    assert.ok(fs.existsSync(outPath), 'the state file should still be written');
+  });
 });

--- a/tests/cli/start-json.test.js
+++ b/tests/cli/start-json.test.js
@@ -1,0 +1,96 @@
+/**
+ * CLI Tests: `start <ws-url>` honors --json on both outcomes (#451)
+ *
+ * The remote-connect branch printed straight to stdout/stderr instead of
+ * going through printResult/printError, so under --json a script got
+ * neither a parsable object on success nor an error envelope on failure.
+ * The local branch (`start` with no URL) already emits the envelope.
+ *
+ * Runs its own daemon under an isolated VIBIUM_SESSION so stopping it in
+ * teardown cannot pull the shared daemon out from under other suites.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawn, spawnSync } = require('node:child_process');
+const net = require('node:net');
+const { VIBIUM } = require('../helpers');
+
+const ENV = { ...process.env, VIBIUM_SESSION: `start-json-${process.pid}` };
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// Poll instead of sleeping: serve's bind time varies with machine load.
+async function waitForPort(port, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const open = await new Promise((resolve) => {
+      const sock = net.connect(port, '127.0.0.1');
+      sock.once('connect', () => { sock.destroy(); resolve(true); });
+      sock.once('error', () => { sock.destroy(); resolve(false); });
+    });
+    if (open) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`serve did not bind port ${port} within ${timeoutMs}ms`);
+}
+
+// stdout and stderr stay separate on purpose: the envelope belongs on
+// stdout so `--json | jq` works, and a merged capture would keep passing
+// if a change moved it to stderr.
+function run(args) {
+  const r = spawnSync(VIBIUM, args, { encoding: 'utf-8', timeout: 90000, env: ENV });
+  assert.strictEqual(r.error, undefined, `spawn failed: ${r.error}`);
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+let serveProcess, port;
+
+describe('CLI: start <ws-url> honors --json', () => {
+  before(async () => {
+    port = await freePort();
+    serveProcess = spawn(VIBIUM, ['serve', '--port', String(port), '--headless'], {
+      stdio: 'ignore',
+      env: ENV,
+    });
+    await waitForPort(port);
+  });
+
+  after(() => {
+    spawnSync(VIBIUM, ['daemon', 'stop'], { encoding: 'utf-8', timeout: 30000, env: ENV });
+    if (serveProcess) serveProcess.kill();
+  });
+
+  test('a successful connect emits the ok envelope', () => {
+    const { stdout, status } = run(['start', `ws://localhost:${port}`, '--json']);
+    const env = JSON.parse(stdout.trim()); // throws on the unfixed binary
+    assert.strictEqual(env.ok, true, 'envelope should report ok');
+    assert.match(env.result, /^Connected to /, 'result should carry the human message');
+    assert.strictEqual(status, 0, 'a successful connect should exit 0');
+  });
+
+  test('a failed connect emits an error envelope on stdout and exits non-zero', () => {
+    // Port 1 is never listening, so this fails without needing a browser.
+    const { stdout, stderr, status } = run(['start', 'ws://127.0.0.1:1/nope', '--json']);
+    const env = JSON.parse(stdout.trim()); // throws on the unfixed binary
+    assert.strictEqual(env.ok, false, 'envelope should report failure');
+    assert.match(env.error, /failed to connect to ws:\/\/127\.0\.0\.1:1/, 'error should name the endpoint');
+    assert.notStrictEqual(status, 0, 'a failed connect must not exit 0');
+    assert.strictEqual(stderr.trim(), '', 'nothing should go to stderr under --json');
+  });
+
+  test('without --json the failure stays human-readable on stderr', () => {
+    const { stdout, stderr } = run(['start', 'ws://127.0.0.1:1/nope']);
+    assert.match(stderr, /^Error: failed to connect to /, 'human mode reports on stderr');
+    assert.strictEqual(stdout.trim(), '', 'nothing should go to stdout without --json');
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#451.

Three CLI commands printed human text under --json and exited 0, so a script got neither a parsable object nor an error to catch: `is actionable`, `storage -o`, and `start <ws-url>`. Each has a sibling invocation that already emits the standard `{"ok":..,"result":..}` envelope (`is visible`, `storage` without `-o`, `start` with no URL), which settles the intended shape.

`is actionable` now returns its five booleans as a struct-valued result, since they do not collapse into a string without loss. `storage -o` emits the envelope instead of returning early with plain text. `start`'s remote-connect branch reports through the shared printError helper instead of writing to stderr with a bare exit; bypassing that helper is why --json never reached its failure paths. Its errors gain the standard `Error:` prefix in human mode, keep exit status 1, and put the envelope on stdout so `--json | jq` works on failures too. `storage restore`'s unreachable invalid-path error moves onto printError as well, so the file has no bypass left for the next reader to copy.

The new start-json suite is named in the Makefile's sequential CLI group: files under tests/cli/ are listed one by one there, so an unlisted file is silently never run, and this one stops a daemon in teardown so it cannot run beside the concurrent group.

The diagnosis, including the sweep that scoped the change to exactly these three commands, was contributed in the issue.

Verified:
- The three new envelope tests fail on the unfixed binary (JSON.parse throws on the human text) and pass with the fix; probed directly, the unfixed binary prints the human checklist under --json with exit 0, the fixed one emits {"ok":true,"result":{"visible":true,...}}
- The actionability, storage, and start-json suites pass locally (26 tests); go vet and gofmt are clean
