### PR TITLE
Remove the duplicate --headless flag on vibium mcp

### DIFF
--- a/clicker/cmd/clicker/mcp_cmd.go
+++ b/clicker/cmd/clicker/mcp_cmd.go
@@ -95,7 +95,6 @@ with LLM agents like Claude Code.
 				}
 
 				connectURL, connectHeaders := connectFromEnv()
-				headless, _ := cmd.Flags().GetBool("headless")
 
 				server := agent.NewServer(version, agent.ServerOptions{
 					ScreenshotDir:  screenshotDir,
@@ -123,6 +122,7 @@ with LLM agents like Claude Code.
 		},
 	}
 	cmd.Flags().String("screenshot-dir", "", "Directory for saving screenshots (default: ~/Pictures/Vibium, use \"\" to disable)")
-	cmd.Flags().Bool("headless", false, "Launch browsers in headless mode (no visible window)")
+	// --headless is the root's persistent flag; a local declaration here
+	// shadowed it out of Global Flags with a divergent description (#452).
 	return cmd
 }

--- a/tests/cli/help-flags.test.js
+++ b/tests/cli/help-flags.test.js
@@ -87,6 +87,52 @@ describe('CLI: help flags on DisableFlagParsing commands', () => {
   });
 });
 
+describe('CLI: mcp inherits the root --headless flag (#452)', () => {
+  // A section is everything from its header to the next blank line, so the
+  // assertions cannot pass on a flag rendered in the other section.
+  function flagSection(helpText, flag) {
+    for (const header of ['Flags:', 'Global Flags:']) {
+      const start = helpText.indexOf(header);
+      if (start === -1) continue;
+      const body = helpText.slice(start + header.length).split('\n\n')[0];
+      if (body.includes(flag)) return header;
+    }
+    return null;
+  }
+
+  test('--headless renders under Global Flags with the shared description', () => {
+    const result = spawnSync(VIBIUM, ['mcp', '--help'], { encoding: 'utf-8', timeout: 30000 });
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(
+      flagSection(result.stdout, '--headless'),
+      'Global Flags:',
+      'mcp used to redeclare --headless locally, shadowing the root flag'
+    );
+    assert.match(result.stdout, /Hide browser window \(visible by default\)/, 'the root description should render');
+    assert.doesNotMatch(result.stdout, /Launch browsers in headless mode/, 'the divergent local description must be gone');
+  });
+
+  test('--headless renders where every other command puts it', () => {
+    const click = spawnSync(VIBIUM, ['click', '--help'], { encoding: 'utf-8', timeout: 30000 });
+    const mcp = spawnSync(VIBIUM, ['mcp', '--help'], { encoding: 'utf-8', timeout: 30000 });
+    assert.strictEqual(flagSection(click.stdout, '--headless'), 'Global Flags:');
+    assert.strictEqual(flagSection(mcp.stdout, '--headless'), flagSection(click.stdout, '--headless'));
+  });
+
+  test('mcp --headless still parses', () => {
+    // Guards the opposite regression: deleting the local flag must not drop
+    // the option. Bad flags fail fast with a usage error before any server
+    // starts; a flag cobra accepts leaves the server waiting on stdin, so
+    // closed stdin plus a parse check keeps this browser-free.
+    const result = spawnSync(VIBIUM, ['mcp', '--headless'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      input: '',
+    });
+    assert.doesNotMatch(result.stderr || '', /unknown flag/, '--headless must still be accepted');
+  });
+});
+
 describe('CLI: scroll help names its full surface (#445)', () => {
   test('all four directions and the real --selector meaning are in the help', () => {
     const result = spawnSync(VIBIUM, ['scroll', '--help'], { encoding: 'utf-8', timeout: 30000 });


### PR DESCRIPTION
Fixes VibiumDev/vibium#452.

`vibium mcp` was the only command in the CLI whose help listed --headless under `Flags:` instead of `Global Flags:`, with a second, divergent description. It declared its own --headless even though the root command has a persistent one; cobra drops a parent flag from `Global Flags` when a command redeclares it, so the local wording rendered instead.

The local declaration came in alongside the change that first made mcp's headless option take effect, whose notes said the option did not exist. It did exist; only its effect was missing. The wiring that change added was right, the extra flag declaration next to it was not. mcp now reads the same variable the root flag binds, the way `vibium start` does. This is help-surface only: `vibium mcp --headless` worked before and still works.

The diagnosis was contributed in the issue.

Verified:
- The two new help-placement tests fail on the unfixed binary and pass with the fix; the parse guard passes on both by design
- The MCP server suite, which launches with `mcp --headless`, passes (47 tests)
