### PR TITLE
Document why the console collect buffers stay client-side

### DIFF
--- a/docs/explanation/client-implementation-guide.md
+++ b/docs/explanation/client-implementation-guide.md
@@ -386,6 +386,8 @@ The JS client provides some aliases for Playwright compatibility and discoverabi
 
 8. **Logic lives in the binary, clients stay thin.** The default implementation of any method is: send the wire command, return the result. Auto-waiting, actionability, selector semantics, dialog handling, geolocation persistence — all of it runs inside the vibium binary so that every client gets identical behavior for free and none of it is written once per language. Client-side logic is reserved for what genuinely cannot live in the binary: the transport, language-idiomatic types, and delivering events to user callbacks. If a port finds itself implementing behavior, stop and move that behavior into the binary first. This is what keeps N clients maintainable and is enforced socially in review; the API drift checker keeps the surfaces aligned, this rule keeps the semantics aligned.
 
+   One deliberate carve-out: the collect buffers behind `consoleMessages()` and `errors()` stay in the client. They only accumulate events the engine already delivers, which falls under delivering events to user callbacks, and their accessors are synchronous by design — an engine-side buffer would force both onto the wire and turn them async in every async client. A port implements them as an array a collector callback appends to, nothing more.
+
 ---
 
 ## Binary Discovery


### PR DESCRIPTION
Part of VibiumDev/vibium#446.

The client-implementation guide's rule is that feature logic lives in the vibium binary and clients stay thin. The console and error collect buffers (`onConsole('collect')` plus `consoleMessages()`, and the error twins) are the one place that rule should not apply, and until now the guide did not say so.

Moving those buffers into the binary would put `consoleMessages()` and `errors()` on the wire, and both are synchronous accessors by design, so every async client would have to break its API to comply. The buffers also only accumulate events the engine already delivers, which the rule reserves for clients anyway.

So the rule gains the carve-out instead of the buffers moving: a port implements them as an array a collector callback appends to, nothing more. The API reference already lists both accessors as client-side, so no table changes.

Verified: docs-only; the API drift checker passes unchanged.
