### PR TITLE
Await download completion in the engine

### DIFF
--- a/clicker/internal/api/capture_registry.go
+++ b/clicker/internal/api/capture_registry.go
@@ -106,6 +106,16 @@ func captureEventKind(kind, context string) (*pendingCapture, error) {
 			}
 			return json.Unmarshal(raw, &params) == nil && params.Context == context && params.URL != ""
 		}}, nil
+	case "download":
+		return &pendingCapture{match: func(method string, raw json.RawMessage) bool {
+			if method != "browsingContext.downloadWillBegin" {
+				return false
+			}
+			var params struct {
+				Context string `json:"context"`
+			}
+			return json.Unmarshal(raw, &params) == nil && params.Context == context
+		}}, nil
 	case "dialog":
 		return &pendingCapture{
 			promptContext: context,
@@ -137,10 +147,7 @@ func captureEventKind(kind, context string) (*pendingCapture, error) {
 			return json.Unmarshal(raw, &params) == nil && params.Type == wantType && params.Source.Context == context
 		}}, nil
 	default:
-		// Downloads are absent deliberately: a captured download must be the
-		// same object the client completes on downloadEnd, so download capture
-		// moves into the engine together with that bookkeeping.
-		return nil, fmt.Errorf("unknown capture kind %q (want navigation, dialog, console, or error)", kind)
+		return nil, fmt.Errorf("unknown capture kind %q (want navigation, download, dialog, console, or error)", kind)
 	}
 }
 

--- a/clicker/internal/api/capture_registry_test.go
+++ b/clicker/internal/api/capture_registry_test.go
@@ -111,6 +111,16 @@ func TestCaptureEventKinds(t *testing.T) {
 		}
 	})
 
+	t.Run("download matches downloadWillBegin for its context", func(t *testing.T) {
+		got := deliver(t, "download", "ctx1",
+			[]string{`{"method":"browsingContext.downloadWillBegin","params":{"context":"ctx2","url":"https://x.test/f.zip"}}`},
+			[]string{`{"method":"browsingContext.downloadWillBegin","params":{"context":"ctx1","url":"https://x.test/f.zip","suggestedFilename":"f.zip","navigation":"nav-9"}}`},
+		)
+		if !strings.Contains(got, "nav-9") {
+			t.Fatalf("params = %s", got)
+		}
+	})
+
 	t.Run("dialog matches userPromptOpened for its context", func(t *testing.T) {
 		got := deliver(t, "dialog", "ctx1",
 			[]string{`{"method":"browsingContext.userPromptOpened","params":{"context":"ctx2","type":"alert"}}`},

--- a/clicker/internal/api/download_registry.go
+++ b/clicker/internal/api/download_registry.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// downloadRegistry tracks each download's completion by its navigation id,
+// so clients await it over the wire (vibium:download.await) instead of each
+// keeping a pending-downloads map per language (#446). Completed entries are
+// kept for the session's lifetime: path() can be asked again after delivery,
+// and one browser session's download count stays small.
+type downloadRegistry struct {
+	mu     sync.Mutex
+	states map[string]*downloadState
+}
+
+type downloadResult struct {
+	Status   string
+	Filepath string
+}
+
+type downloadState struct {
+	done    bool
+	result  downloadResult
+	waiters []chan downloadResult
+}
+
+func newDownloadRegistry() *downloadRegistry {
+	return &downloadRegistry{states: map[string]*downloadState{}}
+}
+
+// Observe records download progress from one raw browser event; anything
+// that is not a download event is ignored.
+func (dr *downloadRegistry) Observe(msg string) {
+	var evt struct {
+		Method string `json:"method"`
+		Params struct {
+			Navigation string `json:"navigation"`
+			Status     string `json:"status"`
+			Filepath   string `json:"filepath"`
+		} `json:"params"`
+	}
+	if json.Unmarshal([]byte(msg), &evt) != nil || evt.Params.Navigation == "" {
+		return
+	}
+
+	switch evt.Method {
+	case "browsingContext.downloadWillBegin":
+		dr.mu.Lock()
+		if _, ok := dr.states[evt.Params.Navigation]; !ok {
+			dr.states[evt.Params.Navigation] = &downloadState{}
+		}
+		dr.mu.Unlock()
+
+	case "browsingContext.downloadEnd":
+		status := evt.Params.Status
+		if status == "" {
+			status = "complete"
+		}
+		result := downloadResult{Status: status, Filepath: evt.Params.Filepath}
+
+		dr.mu.Lock()
+		st, ok := dr.states[evt.Params.Navigation]
+		if !ok {
+			st = &downloadState{}
+			dr.states[evt.Params.Navigation] = st
+		}
+		st.done = true
+		st.result = result
+		waiters := st.waiters
+		st.waiters = nil
+		dr.mu.Unlock()
+
+		// Buffered channels: delivery cannot block the event loop.
+		for _, ch := range waiters {
+			ch <- result
+		}
+	}
+}
+
+// Await returns the finished result immediately, or a channel that delivers
+// it when downloadEnd arrives. known is false when this navigation id was
+// never seen; the id can only be wrong then, because the client learned it
+// from the willBegin event this registry observed before it was forwarded.
+func (dr *downloadRegistry) Await(navigation string) (result downloadResult, ch chan downloadResult, known bool) {
+	dr.mu.Lock()
+	defer dr.mu.Unlock()
+	st, ok := dr.states[navigation]
+	if !ok {
+		return downloadResult{}, nil, false
+	}
+	if st.done {
+		return st.result, nil, true
+	}
+	ch = make(chan downloadResult, 1)
+	st.waiters = append(st.waiters, ch)
+	return downloadResult{}, ch, true
+}

--- a/clicker/internal/api/download_registry_test.go
+++ b/clicker/internal/api/download_registry_test.go
@@ -1,0 +1,76 @@
+package api
+
+import "testing"
+
+const (
+	willBegin = `{"method":"browsingContext.downloadWillBegin","params":{"context":"ctx1","navigation":"nav-1","url":"https://x.test/f.zip","suggestedFilename":"f.zip"}}`
+	ended     = `{"method":"browsingContext.downloadEnd","params":{"context":"ctx1","navigation":"nav-1","status":"complete","filepath":"/tmp/dl/f.zip"}}`
+)
+
+// Download completion is awaited in the binary (#446): the registry answers
+// immediately once the download ended, however often it is asked.
+func TestDownloadRegistryAnswersAfterEnd(t *testing.T) {
+	dr := newDownloadRegistry()
+	dr.Observe(willBegin)
+	dr.Observe(ended)
+
+	for i := 0; i < 2; i++ {
+		result, ch, known := dr.Await("nav-1")
+		if !known || ch != nil {
+			t.Fatalf("a finished download must answer immediately (known=%v ch=%v)", known, ch)
+		}
+		if result.Status != "complete" || result.Filepath != "/tmp/dl/f.zip" {
+			t.Fatalf("result = %+v", result)
+		}
+	}
+}
+
+// A waiter that arrives while the download is in flight is delivered to when
+// downloadEnd comes in.
+func TestDownloadRegistryDeliversToWaiters(t *testing.T) {
+	dr := newDownloadRegistry()
+	dr.Observe(willBegin)
+
+	_, ch, known := dr.Await("nav-1")
+	if !known || ch == nil {
+		t.Fatalf("an in-flight download must hand out a wait channel (known=%v)", known)
+	}
+
+	dr.Observe(ended)
+	select {
+	case result := <-ch:
+		if result.Status != "complete" || result.Filepath != "/tmp/dl/f.zip" {
+			t.Fatalf("result = %+v", result)
+		}
+	default:
+		t.Fatal("downloadEnd must deliver to the pending waiter")
+	}
+}
+
+// The client can only learn a navigation id from the willBegin event the
+// registry observed first, so an unseen id is a caller error, not a race.
+func TestDownloadRegistryRejectsUnknownNavigation(t *testing.T) {
+	dr := newDownloadRegistry()
+	if _, _, known := dr.Await("nav-nope"); known {
+		t.Fatal("an unseen navigation id must not be awaitable")
+	}
+	dr.Observe(`{"method":"browsingContext.downloadWillBegin","params":{"navigation":""}}`)
+	if _, _, known := dr.Await(""); known {
+		t.Fatal("an empty navigation id must not create state")
+	}
+}
+
+// A failed download reports its status instead of hanging or inventing a path.
+func TestDownloadRegistryReportsFailure(t *testing.T) {
+	dr := newDownloadRegistry()
+	dr.Observe(willBegin)
+	dr.Observe(`{"method":"browsingContext.downloadEnd","params":{"navigation":"nav-1","status":"canceled"}}`)
+
+	result, ch, known := dr.Await("nav-1")
+	if !known || ch != nil {
+		t.Fatal("a finished download must answer immediately")
+	}
+	if result.Status != "canceled" || result.Filepath != "" {
+		t.Fatalf("result = %+v", result)
+	}
+}

--- a/clicker/internal/api/handlers_download.go
+++ b/clicker/internal/api/handlers_download.go
@@ -32,6 +32,39 @@ func (r *Router) setupDownloads(session *BrowserSession) {
 	}
 }
 
+// handleDownloadAwait handles vibium:download.await — waits until the
+// download named by its navigation id ends, then returns its status and
+// temp-file path. Already-finished downloads answer immediately, so repeated
+// calls (path() then saveAs()) keep working.
+func (r *Router) handleDownloadAwait(session *BrowserSession, cmd bidiCommand) {
+	navigation, _ := cmd.Params["navigation"].(string)
+	if navigation == "" {
+		r.sendError(session, cmd.ID, fmt.Errorf("download.await requires a navigation id"))
+		return
+	}
+	timeoutMs := 300000.0
+	if t, ok := cmd.Params["timeout"].(float64); ok && t > 0 {
+		timeoutMs = t
+	}
+
+	result, ch, known := session.downloads.Await(navigation)
+	if !known {
+		r.sendError(session, cmd.ID, fmt.Errorf("unknown download %q", navigation))
+		return
+	}
+	if ch == nil {
+		r.sendSuccess(session, cmd.ID, map[string]interface{}{"status": result.Status, "filepath": result.Filepath})
+		return
+	}
+	select {
+	case result := <-ch:
+		r.sendSuccess(session, cmd.ID, map[string]interface{}{"status": result.Status, "filepath": result.Filepath})
+	case <-time.After(time.Duration(timeoutMs) * time.Millisecond):
+		r.sendError(session, cmd.ID, fmt.Errorf("timeout waiting for download to finish"))
+	case <-session.stopChan:
+	}
+}
+
 // handleDownloadSaveAs copies a downloaded file from the temp dir to a user-specified path.
 func (r *Router) handleDownloadSaveAs(session *BrowserSession, cmd bidiCommand) {
 	sourcePath, _ := cmd.Params["sourcePath"].(string)

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -78,6 +78,7 @@ type BrowserSession struct {
 	routes       *routeRegistry
 	captures     *captureRegistry
 	navigations  *NavigationTracker
+	downloads    *downloadRegistry
 
 	// Serializes recording start/stop across their async handlers (the
 	// video screencast negotiation spans several browser commands).
@@ -233,6 +234,7 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 		captures:          newCaptureRegistry(),
 		exposedPreloadIDs: make(map[string]string),
 		navigations:       NewNavigationTracker(),
+		downloads:         newDownloadRegistry(),
 	}
 
 	r.sessions.Store(client.ID(), session)
@@ -324,6 +326,9 @@ func unblocksAnotherCommand(method string) bool {
 		return true
 	// Captures block until traffic another command produces arrives.
 	case "vibium:page.captureRequest", "vibium:page.captureResponse":
+		return true
+	// A download await blocks until the browser finishes writing the file.
+	case "vibium:download.await":
 		return true
 	}
 	return false
@@ -804,6 +809,9 @@ func (r *Router) OnClientMessage(client ClientTransport, msg string) {
 		return
 
 	// Download & file commands
+	case "vibium:download.await":
+		r.dispatch(session, cmd, r.handleDownloadAwait)
+		return
 	case "vibium:download.saveAs":
 		r.dispatch(session, cmd, r.handleDownloadSaveAs)
 		return
@@ -1026,6 +1034,10 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 		// Track user prompts so prompt-sensitive commands can fail fast.
 		session.prompts.Observe([]byte(msg))
 		session.navigations.Observe([]byte(msg))
+		// Track downloads before the forward: a client can only learn a
+		// navigation id from the willBegin event, so by the time it can send
+		// download.await the registry has the entry.
+		session.downloads.Observe(msg)
 
 		// A prompt no client handler has claimed is dismissed here, so every
 		// client shares one default instead of implementing it (#446). A

--- a/clients/java/src/main/java/com/vibium/Capture.java
+++ b/clients/java/src/main/java/com/vibium/Capture.java
@@ -10,16 +10,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
  * One-shot event capture helpers. The binary owns the matching and the wait
  * (vibium:page.captureRequest/captureResponse/captureEvent); each method
  * starts that command, runs the action while it is in flight, and awaits the
- * result. Downloads still capture through a local listener, because the
- * captured Download must be the same object the downloadEnd event completes.
+ * result.
  */
 public final class Capture {
 
@@ -77,11 +74,10 @@ public final class Capture {
     }
 
     public Download download(Runnable action, WaitOptions options) {
-        return await(
-            handler -> page.addDownloadListener(handler),
-            handler -> page.removeDownloadListener(handler),
-            action,
-            options,
+        long timeoutMs = timeout(options);
+        return awaitWire(() -> page.sendCaptureEvent("download", timeoutMs),
+            timeoutMs, action,
+            event -> page.downloadFromEvent(event),
             "download");
     }
 
@@ -165,57 +161,6 @@ public final class Capture {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new VibiumTimeoutException("Interrupted waiting for " + what);
-        }
-    }
-
-    private <T> T await(Consumer<Consumer<T>> register,
-                        Consumer<Consumer<T>> unregister,
-                        Runnable action, WaitOptions options, String description) {
-        if (action == null) {
-            throw new IllegalArgumentException("capture action must not be null");
-        }
-
-        CompletableFuture<T> captured = new CompletableFuture<>();
-        AtomicBoolean actionStarted = new AtomicBoolean();
-        Consumer<T> handler = value -> {
-            if (actionStarted.get()) {
-                captured.complete(value);
-            }
-        };
-
-        register.accept(handler);
-        CompletableFuture<Void> actionFuture;
-        try {
-            actionFuture = CompletableFuture.runAsync(() -> {
-                actionStarted.set(true);
-                action.run();
-            }, ACTIONS);
-        } catch (RuntimeException error) {
-            unregister.accept(handler);
-            throw error;
-        }
-
-        // A normal action completion does not end capture: the event can arrive
-        // after the action returns. A failure before the event does end it.
-        actionFuture.whenComplete((ignored, error) -> {
-            if (error != null) captured.completeExceptionally(unwrap(error));
-        });
-
-        try {
-            return captured.get(timeout(options), TimeUnit.MILLISECONDS);
-        } catch (TimeoutException error) {
-            actionFuture.cancel(true);
-            throw new VibiumTimeoutException("Timeout waiting for " + description);
-        } catch (ExecutionException error) {
-            Throwable cause = unwrap(error.getCause());
-            if (cause instanceof RuntimeException) throw (RuntimeException) cause;
-            throw new VibiumException("Capture action failed: " + cause.getMessage(), cause);
-        } catch (InterruptedException error) {
-            actionFuture.cancel(true);
-            Thread.currentThread().interrupt();
-            throw new VibiumException("Interrupted while waiting for " + description, error);
-        } finally {
-            unregister.accept(handler);
         }
     }
 

--- a/clients/java/src/main/java/com/vibium/Download.java
+++ b/clients/java/src/main/java/com/vibium/Download.java
@@ -4,9 +4,6 @@ import com.google.gson.JsonObject;
 import com.vibium.errors.VibiumException;
 import com.vibium.internal.BiDiClient;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-
 /**
  * File download handle.
  */
@@ -17,7 +14,7 @@ public class Download {
     private final BiDiClient client;
     private final String url;
     private final String suggestedFilename;
-    private final CompletableFuture<String> pathFuture = new CompletableFuture<>();
+    private final String navigation;
 
     Download(BiDiClient client, JsonObject params) {
         this.client = client;
@@ -25,6 +22,7 @@ public class Download {
         this.suggestedFilename = params.has("suggestedFilename")
             ? params.get("suggestedFilename").getAsString()
             : (params.has("filename") ? params.get("filename").getAsString() : "");
+        this.navigation = params.has("navigation") ? params.get("navigation").getAsString() : "";
     }
 
     /** Get the download URL. */
@@ -45,23 +43,27 @@ public class Download {
         client.send("vibium:download.saveAs", params);
     }
 
-    /** Get the temp file path (waits for download to complete). */
+    /**
+     * Get the temp file path (waits for download to complete).
+     *
+     * Completion is awaited in the engine (vibium:download.await), which
+     * tracks every download by its navigation id, so this client keeps no
+     * pending-downloads map. Finished downloads answer immediately, so
+     * asking repeatedly is fine.
+     */
     public String path() {
+        JsonObject params = new JsonObject();
+        params.addProperty("navigation", navigation);
+        params.addProperty("timeout", DOWNLOAD_TIMEOUT_MS);
         try {
-            return pathFuture.get(DOWNLOAD_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            JsonObject result = client.send("vibium:download.await", params, DOWNLOAD_TIMEOUT_MS + 10_000);
+            if (!result.has("status") || !"complete".equals(result.get("status").getAsString())) {
+                return null;
+            }
+            String filepath = result.has("filepath") ? result.get("filepath").getAsString() : "";
+            return filepath.isEmpty() ? null : filepath;
         } catch (Exception e) {
             return null;
-        }
-    }
-
-    /**
-     * Called internally when the download completes.
-     */
-    void complete(String status, String filePath) {
-        if (filePath != null) {
-            pathFuture.complete(filePath);
-        } else {
-            pathFuture.complete(null);
         }
     }
 

--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -59,8 +59,6 @@ public class Page {
     private final Object dataCollectorLock = new Object();
     private String dataCollectorId;
 
-    // Active downloads keyed by navigation ID
-    private final Map<String, Download> activeDownloads = Collections.synchronizedMap(new HashMap<>());
 
     // Event handler reference for cleanup
     private final Consumer<JsonObject> eventHandler;
@@ -888,9 +886,6 @@ public class Page {
             case "browsingContext.downloadWillBegin":
                 handleDownloadStarted(params);
                 break;
-            case "browsingContext.downloadEnd":
-                handleDownloadCompleted(params);
-                break;
             case "vibium:ws.created":
                 handleWebSocketCreated(params);
                 break;
@@ -944,6 +939,10 @@ public class Page {
 
     Dialog dialogFromEvent(JsonObject event) {
         return new Dialog(client, event);
+    }
+
+    Download downloadFromEvent(JsonObject event) {
+        return new Download(client, event);
     }
 
     ConsoleMessage consoleFromEvent(JsonObject event) {
@@ -1026,24 +1025,12 @@ public class Page {
     }
 
     private void handleDownloadStarted(JsonObject params) {
+        // Completion is awaited in the engine by navigation id (#446), so
+        // there is no client-side pending map to feed on downloadEnd.
         if (downloadListeners.isEmpty()) return;
         Download download = new Download(client, params);
-        String navId = params.has("navigation") ? params.get("navigation").getAsString() : "";
-        if (!navId.isEmpty()) {
-            activeDownloads.put(navId, download);
-        }
         for (Consumer<Download> listener : downloadListeners) {
             try { listener.accept(download); } catch (Exception ignored) {}
-        }
-    }
-
-    private void handleDownloadCompleted(JsonObject params) {
-        String navId = params.has("navigation") ? params.get("navigation").getAsString() : "";
-        Download download = activeDownloads.remove(navId);
-        if (download != null) {
-            String status = params.has("status") ? params.get("status").getAsString() : "complete";
-            String path = params.has("filepath") ? params.get("filepath").getAsString() : null;
-            download.complete(status, path);
         }
     }
 

--- a/clients/javascript/src/download.ts
+++ b/clients/javascript/src/download.ts
@@ -1,5 +1,4 @@
 import { BiDiClient } from './bidi';
-import * as fs from 'fs/promises';
 
 /** Default timeout for download completion (5 minutes). */
 const DOWNLOAD_TIMEOUT_MS = 300_000;
@@ -9,16 +8,13 @@ export class Download {
   private client: BiDiClient;
   private _url: string;
   private _suggestedFilename: string;
-  private _resolve!: (value: { status: string; filepath: string | null }) => void;
-  private _completionPromise: Promise<{ status: string; filepath: string | null }>;
+  private _navigation: string;
 
-  constructor(client: BiDiClient, url: string, suggestedFilename: string) {
+  constructor(client: BiDiClient, params: Record<string, unknown>) {
     this.client = client;
-    this._url = url;
-    this._suggestedFilename = suggestedFilename;
-    this._completionPromise = new Promise((resolve) => {
-      this._resolve = resolve;
-    });
+    this._url = (params.url as string) ?? '';
+    this._suggestedFilename = (params.suggestedFilename as string) ?? '';
+    this._navigation = (params.navigation as string) ?? '';
   }
 
   /** The URL of the download. */
@@ -31,18 +27,18 @@ export class Download {
     return this._suggestedFilename;
   }
 
-  /** Wait for the download completion promise with a timeout. */
+  /**
+   * Completion is awaited in the engine (vibium:download.await), which
+   * tracks every download by its navigation id, so no client keeps a
+   * pending-downloads map. The engine answers finished downloads
+   * immediately, so asking repeatedly is fine.
+   */
   private _waitForCompletion(): Promise<{ status: string; filepath: string | null }> {
-    let timer: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timer = setTimeout(
-        () => reject(new Error(`Download timed out after ${DOWNLOAD_TIMEOUT_MS / 1000}s`)),
-        DOWNLOAD_TIMEOUT_MS,
-      );
-    });
-    return Promise.race([this._completionPromise, timeoutPromise]).finally(() => {
-      clearTimeout(timer);
-    });
+    return this.client.send<{ status: string; filepath?: string }>(
+      'vibium:download.await',
+      { navigation: this._navigation, timeout: DOWNLOAD_TIMEOUT_MS },
+      DOWNLOAD_TIMEOUT_MS + 10_000,
+    ).then((result) => ({ status: result.status, filepath: result.filepath || null }));
   }
 
   /** Wait for the download to complete, then save to the specified path. */
@@ -62,10 +58,5 @@ export class Download {
   async path(): Promise<string | null> {
     const result = await this._waitForCompletion();
     return result.filepath;
-  }
-
-  /** Internal: called by Page when downloadCompleted fires. */
-  _complete(status: string, filepath: string | null): void {
-    this._resolve({ status, filepath });
   }
 }

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -226,7 +226,6 @@ export class Page {
   private errorCallbacks: ((error: Error) => void)[] = [];
   private downloadCallbacks: ((download: Download) => void)[] = [];
   private navigationCallbacks: ((url: string) => void)[] = [];
-  private pendingDownloads: Map<string, Download> = new Map();
   private wsCallbacks: ((ws: WebSocketInfo) => void)[] = [];
   private wsConnections: Map<number, WebSocketInfo> = new Map();
   private wsSetup: Promise<unknown> | null = null;
@@ -307,8 +306,6 @@ export class Page {
         this.handleUserPromptOpened(params);
       } else if (event.method === 'browsingContext.downloadWillBegin') {
         this.handleDownloadWillBegin(params);
-      } else if (event.method === 'browsingContext.downloadEnd') {
-        this.handleDownloadCompleted(params);
       } else if (event.method === 'log.entryAdded') {
         // log.entryAdded uses source.context, not params.context
         const source = params.source as { context?: string } | undefined;
@@ -863,21 +860,9 @@ export class Page {
   }
 
   /** @internal Capture a download event. */
-  _captureDownload(options?: { timeout?: number }): Promise<Download> {
-    const timeout = options?.timeout ?? 10000;
-    return new Promise<Download>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.downloadCallbacks = this.downloadCallbacks.filter(cb => cb !== handler);
-        reject(new Error(`Timeout waiting for download`));
-      }, timeout);
-
-      const handler = (download: Download) => {
-        clearTimeout(timer);
-        this.downloadCallbacks = this.downloadCallbacks.filter(cb => cb !== handler);
-        resolve(download);
-      };
-      this.downloadCallbacks.push(handler);
-    });
+  async _captureDownload(options?: { timeout?: number }): Promise<Download> {
+    const params = await this.captureEventParams('download', options);
+    return new Download(this.client, params);
   }
 
   /** @internal Capture a dialog event. The pending engine capture keeps the dialog from being auto-dismissed. */
@@ -1169,29 +1154,11 @@ export class Page {
   }
 
   private handleDownloadWillBegin(params: Record<string, unknown>): void {
-    const url = (params.url as string) ?? '';
-    const suggestedFilename = (params.suggestedFilename as string) ?? '';
-    const navigation = (params.navigation as string) ?? '';
-
-    const download = new Download(this.client, url, suggestedFilename);
-    if (navigation) {
-      this.pendingDownloads.set(navigation, download);
-    }
-
+    // Completion is awaited in the engine by navigation id (#446), so
+    // there is no client-side pending map to feed on downloadEnd.
+    const download = new Download(this.client, params);
     for (const cb of this.downloadCallbacks) {
       cb(download);
-    }
-  }
-
-  private handleDownloadCompleted(params: Record<string, unknown>): void {
-    const navigation = (params.navigation as string) ?? '';
-    const status = (params.status as string) ?? 'complete';
-    const filepath = (params.filepath as string) ?? null;
-
-    const download = this.pendingDownloads.get(navigation);
-    if (download) {
-      download._complete(status, filepath);
-      this.pendingDownloads.delete(navigation);
     }
   }
 

--- a/clients/python/src/vibium/async_api/download.py
+++ b/clients/python/src/vibium/async_api/download.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..client import BiDiClient
@@ -15,11 +14,11 @@ _DOWNLOAD_TIMEOUT = 300
 class Download:
     """Represents a file download triggered by the page."""
 
-    def __init__(self, client: BiDiClient, url: str, suggested_filename: str) -> None:
+    def __init__(self, client: BiDiClient, params: Dict[str, Any]) -> None:
         self._client = client
-        self._url = url
-        self._suggested_filename = suggested_filename
-        self._future: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._url = params.get("url", "")
+        self._suggested_filename = params.get("suggestedFilename", "")
+        self._navigation = params.get("navigation", "")
 
     def url(self) -> str:
         return self._url
@@ -28,15 +27,19 @@ class Download:
         return self._suggested_filename
 
     async def _wait_for_completion(self) -> dict:
-        """Wait for the download future with a timeout."""
-        return await asyncio.wait_for(self._future, timeout=_DOWNLOAD_TIMEOUT)
+        """Completion is awaited in the engine (vibium:download.await), which
+        tracks every download by its navigation id, so no client keeps a
+        pending-downloads map. Finished downloads answer immediately, so
+        asking repeatedly is fine."""
+        return await self._client.send(
+            "vibium:download.await",
+            {"navigation": self._navigation, "timeout": _DOWNLOAD_TIMEOUT * 1000},
+            timeout=_DOWNLOAD_TIMEOUT + 10,
+        )
 
     async def save_as(self, path: str) -> None:
         """Wait for the download to complete, then save to the specified path."""
-        try:
-            result = await self._wait_for_completion()
-        except asyncio.TimeoutError:
-            raise TimeoutError(f"Download timed out after {_DOWNLOAD_TIMEOUT}s")
+        result = await self._wait_for_completion()
         if result["status"] != "complete" or not result.get("filepath"):
             raise RuntimeError(f"Download failed with status: {result['status']}")
         await self._client.send("vibium:download.saveAs", {
@@ -46,13 +49,5 @@ class Download:
 
     async def path(self) -> Optional[str]:
         """Wait for the download to complete and return the temp file path."""
-        try:
-            result = await self._wait_for_completion()
-        except asyncio.TimeoutError:
-            raise TimeoutError(f"Download timed out after {_DOWNLOAD_TIMEOUT}s")
-        return result.get("filepath")
-
-    def _complete(self, status: str, filepath: Optional[str]) -> None:
-        """Internal: called by Page when downloadCompleted fires."""
-        if not self._future.done():
-            self._future.set_result({"status": status, "filepath": filepath})
+        result = await self._wait_for_completion()
+        return result.get("filepath") or None

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -108,7 +108,6 @@ class Page:
         self._error_callbacks: List[Callable] = []
         self._download_callbacks: List[Callable] = []
         self._navigation_callbacks: List[Callable] = []
-        self._pending_downloads: Dict[str, Download] = {}
         self._ws_callbacks: List[Callable] = []
         self._ws_connections: Dict[int, WebSocketInfo] = {}
         self._ws_setup: Optional[asyncio.Future] = None
@@ -345,44 +344,12 @@ class Page:
 
     async def _capture_download(self, timeout: Optional[int] = None) -> Download:
         """Internal: wait for a download event."""
-        timeout_ms = timeout or 10000
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
-
-        def handler(download: Download) -> None:
-            self._download_callbacks.remove(handler)
-            if not future.done():
-                future.set_result(download)
-
-        self._download_callbacks.append(handler)
-
-        try:
-            return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
-        except asyncio.TimeoutError:
-            if handler in self._download_callbacks:
-                self._download_callbacks.remove(handler)
-            raise errors.TimeoutError("Timeout waiting for download")
+        params = await self._capture_event_params("download", timeout)
+        return Download(self._client, params)
 
     async def _setup_capture_download(self, timeout: Optional[int] = None) -> Any:
-        """Internal: set up download listener and return a coroutine to await later."""
-        timeout_ms = timeout or 10000
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
-
-        def handler(download: Download) -> None:
-            self._download_callbacks.remove(handler)
-            if not future.done():
-                future.set_result(download)
-
-        self._download_callbacks.append(handler)
-
-        async def _wait() -> Download:
-            try:
-                return await asyncio.wait_for(future, timeout=timeout_ms / 1000)
-            except asyncio.TimeoutError:
-                if handler in self._download_callbacks:
-                    self._download_callbacks.remove(handler)
-                raise errors.TimeoutError("Timeout waiting for download")
-
-        return _wait()
+        """Internal: start a download capture now, return a task to await later."""
+        return asyncio.get_running_loop().create_task(self._capture_download(timeout))
 
     def _sync_dialog_policy(self) -> None:
         """Tell the engine whether dialogs are handled here.
@@ -901,8 +868,6 @@ class Page:
             self._handle_user_prompt_opened(params)
         elif method == "browsingContext.downloadWillBegin":
             self._handle_download_will_begin(params)
-        elif method == "browsingContext.downloadEnd":
-            self._handle_download_completed(params)
         elif method == "log.entryAdded":
             self._handle_log_entry_added(params)
         elif method == "browsingContext.load":
@@ -988,25 +953,11 @@ class Page:
                 cb(error)
 
     def _handle_download_will_begin(self, params: Dict[str, Any]) -> None:
-        url = params.get("url", "")
-        filename = params.get("suggestedFilename", "")
-        navigation = params.get("navigation", "")
-
-        download = Download(self._client, url, filename)
-        if navigation:
-            self._pending_downloads[navigation] = download
-
+        # Completion is awaited in the engine by navigation id (#446), so
+        # there is no client-side pending map to feed on downloadEnd.
+        download = Download(self._client, params)
         for cb in self._download_callbacks:
             cb(download)
-
-    def _handle_download_completed(self, params: Dict[str, Any]) -> None:
-        navigation = params.get("navigation", "")
-        status = params.get("status", "complete")
-        filepath = params.get("filepath")
-
-        download = self._pending_downloads.pop(navigation, None)
-        if download:
-            download._complete(status, filepath)
 
     def _handle_ws_created(self, params: Dict[str, Any]) -> None:
         ws_id = params.get("id", 0)

--- a/docs/explanation/client-implementation-guide.md
+++ b/docs/explanation/client-implementation-guide.md
@@ -331,7 +331,11 @@ The engine dismisses every dialog itself while no dialog handler is registered �
 
 ### One-Shot Captures
 
-`capture.request` / `capture.response` send `vibium:page.captureRequest` / `vibium:page.captureResponse` with `{context, pattern, timeout}`; `capture.navigation`, `capture.dialog`, and `capture.event("console" | "error")` send `vibium:page.captureEvent` with `{context, kind, timeout}`. The engine registers the capture in client message order, waits for the first matching event, and answers with its raw params (`{"event": {...}}`) — clients keep no listener or timeout machinery, they build the language object from the returned params. Start the capture command on the wire before running the trigger action, and run the action so that its blocking cannot block the capture's return (a trigger stuck inside `evaluate("alert(...)")` resolves only after the captured dialog is handled). `capture.download` stays a local listener for now: the captured Download must be the same object the `downloadEnd` event completes.
+`capture.request` / `capture.response` send `vibium:page.captureRequest` / `vibium:page.captureResponse` with `{context, pattern, timeout}`; `capture.navigation`, `capture.download`, `capture.dialog`, and `capture.event("console" | "error")` send `vibium:page.captureEvent` with `{context, kind, timeout}`. The engine registers the capture in client message order, waits for the first matching event, and answers with its raw params (`{"event": {...}}`) — clients keep no listener or timeout machinery, they build the language object from the returned params. Start the capture command on the wire before running the trigger action, and run the action so that its blocking cannot block the capture's return (a trigger stuck inside `evaluate("alert(...)")` resolves only after the captured dialog is handled).
+
+### Downloads
+
+The engine tracks every download by its navigation id and saves the file to a session temp dir. A Download object holds the `downloadWillBegin` params (url, suggested filename, navigation id) and nothing else; `path()` and `saveAs()` send `vibium:download.await` with `{navigation, timeout}` and get `{status, filepath}` back once the download ends. The engine answers already-finished downloads immediately, so the accessors can be called repeatedly and in any order. No client watches `downloadEnd` or keeps a pending-downloads map.
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -76,7 +76,7 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 56 | Capture request (before action) | `vibium:page.captureRequest` | — | — | `page.capture.request(pat, fn?)` | `page.capture.request(pat, fn?)` | `page.capture().request(pat, action)` |
 | 57 | Capture navigation (before action) | `vibium:page.captureEvent` | — | — | `page.capture.navigation(fn?)` | `page.capture.navigation(fn?)` | `page.capture().navigation(action)` |
 | 58 | Capture event (before action) | `vibium:page.captureEvent` | — | — | `page.capture.event(name, fn?)` | `page.capture.event(name, fn?)` | `page.capture().event(name, action)` |
-| 59 | Capture download (before action) | *client-side* | — | — | `page.capture.download(fn?)` | `page.capture.download(fn?)` | `page.capture().download(action)` |
+| 59 | Capture download (before action) | `vibium:page.captureEvent` | — | — | `page.capture.download(fn?)` | `page.capture.download(fn?)` | `page.capture().download(action)` |
 | 60 | Capture dialog (before action) | `vibium:page.captureEvent` | — | — | `page.capture.dialog(fn?)` | `page.capture.dialog(fn?)` | `page.capture().dialog(action)` |
 | 61 | Get buffered console messages | *client-side* | — | — | `page.consoleMessages()` | `page.console_messages()` | `page.consoleMessages()` |
 | 62 | Get buffered page errors | *client-side* | — | — | `page.errors()` | `page.errors()` | `page.errors()` |
@@ -228,7 +228,7 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 139 | Save a download to path | `vibium:download.saveAs` | ⬜ | ⬜ | `download.saveAs(path)` | `download.save_as(path)` | `download.saveAs(path)` |
 | 140 | Get download URL | *from event data* | — | — | `download.url()` | `download.url()` | `download.url()` |
 | 141 | Get download filename | *from event data* | — | — | `download.suggestedFilename()` | `download.suggested_filename()` | `download.suggestedFilename()` |
-| 142 | Get download path | *from event data* | — | — | `download.path()` | `download.path()` | `download.path()` |
+| 142 | Get download path | `vibium:download.await` | — | — | `download.path()` | `download.path()` | `download.path()` |
 
 ## Request
 


### PR DESCRIPTION
Closes VibiumDev/vibium#446. This is the last of the moves that issue lists: URL pattern matching, the dialog dismiss default, the one-shot captures, and the collect-buffer decision have all landed, and downloads were the remaining duplication.

Every client kept a pending-downloads map: on downloadWillBegin it created a Download, filed it by navigation id, and on downloadEnd looked it up to resolve the path, each with its own five-minute timeout machinery. The engine now owns that bookkeeping. A download registry tracks each download by its navigation id, and the new vibium:download.await command returns {status, filepath} once the download ends. Already-finished downloads answer immediately, so path() and saveAs() can be called repeatedly and in any order.

With completion identity no longer living in a client-side map, capture.download joins the other one-shot captures on vibium:page.captureEvent, which removes the last capture listener any client keeps. A Download object now holds only the willBegin params: url, suggested filename, and the navigation id it awaits by.

The registry observes events before they are forwarded to the client, so a client can never hold a navigation id the engine does not know; an unknown id in download.await is a caller error and fails fast instead of waiting out the timeout.

Verified:
- New engine tests cover immediate answers after downloadEnd, delivery to in-flight waiters, failure statuses, and unknown-id rejection (download_registry_test.go); the download capture kind is covered in the capture registry tests
- The JS download and capture suites (36 tests), the Python download tutorials plus dialog and sync API suites (104 tests), the JS sync suite (72 tests), the Java engine suite, the full Go suite, and the API drift checker all pass against this branch