### PR TITLE
Let the page call back into the client through exposed functions

### DIFF
--- a/clicker/internal/api/handlers_expose.go
+++ b/clicker/internal/api/handlers_expose.go
@@ -1,0 +1,307 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/vibium/clicker/internal/log"
+)
+
+// Exposed functions (feature B of page.expose, #298): the page calls
+// window[name](args), the client's host function runs, and the return value
+// comes back to the page. Three wire pieces:
+//
+//   - vibium:page.exposeFunction {context, name} installs the binding
+//   - vibium:expose.call {name, seq, args, context, realm} — event to the
+//     client when the page calls the function
+//   - vibium:expose.result {context, realm, seq, result | error} — command
+//     from the client delivering the host function's outcome into the page
+//
+// The engine keeps no per-call state: the page parks each call's promise
+// under a sequence number, and the client echoes that seq back with the
+// result. The same channel machinery runs WebSocket monitoring
+// (handlers_websocket.go).
+
+// exposeChannelName is the BiDi channel every exposed-function binding posts
+// through; one channel serves all names, multiplexed by the payload.
+const exposeChannelName = "vibium-expose"
+
+// exposeBindingDeclaration builds the preload source for one name. The name
+// is embedded as a literal because addPreloadScript accepts only channel
+// arguments. The stash is per document and dies with it, which is right: a
+// pending page promise cannot survive navigation anyway.
+func exposeBindingDeclaration(nameLit string) string {
+	return fmt.Sprintf(`(channel) => {
+	const store = window.__vibiumExpose = window.__vibiumExpose || { seq: 0, pending: {} };
+	window[%s] = (...args) => new Promise((resolve, reject) => {
+		const seq = ++store.seq;
+		store.pending[seq] = { resolve: resolve, reject: reject };
+		channel(JSON.stringify({ name: %s, seq: seq, args: args }));
+	});
+}`, nameLit, nameLit)
+}
+
+// exposeDeliverScript settles the parked promise for one call. The result
+// travels as a JSON string so only primitives cross the argument boundary;
+// a null errorMsg means success.
+const exposeDeliverScript = `(seq, resultJson, errorMsg) => {
+	const store = window.__vibiumExpose;
+	const pending = store && store.pending[seq];
+	if (!pending) return;
+	delete store.pending[seq];
+	if (errorMsg !== null) pending.reject(new Error(errorMsg));
+	else pending.resolve(resultJson === null ? undefined : JSON.parse(resultJson));
+}`
+
+// handlePageExposeFunction handles vibium:page.exposeFunction — installs the
+// promise-returning stub for one name, session-wide and into the already-open
+// document, exactly like feature A's source injection (handlePageExpose).
+// Repeated exposure of a name replaces its previous binding either way, so
+// the two forms of page.expose stay interchangeable per name.
+func (r *Router) handlePageExposeFunction(session *BrowserSession, cmd bidiCommand) {
+	name, _ := cmd.Params["name"].(string)
+	if name == "" {
+		r.sendError(session, cmd.ID, fmt.Errorf("name is required"))
+		return
+	}
+
+	context, err := r.resolveContext(session, cmd.Params)
+	if err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+
+	if err := r.ensureScriptMessageSubscription(session); err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+
+	nameLit, err := json.Marshal(name)
+	if err != nil {
+		r.sendError(session, cmd.ID, fmt.Errorf("invalid name: %w", err))
+		return
+	}
+	declaration := exposeBindingDeclaration(string(nameLit))
+	channelArg := []map[string]interface{}{
+		{
+			"type": "channel",
+			"value": map[string]interface{}{
+				"channel": exposeChannelName,
+			},
+		},
+	}
+
+	// Replace any previous script for this name rather than stacking another.
+	session.mu.Lock()
+	previous := session.exposedPreloadIDs[name]
+	session.mu.Unlock()
+	if previous != "" {
+		if _, err := r.sendInternalCommand(session, "script.removePreloadScript", map[string]interface{}{
+			"script": previous,
+		}); err != nil {
+			log.Debug("failed to remove previous exposed function", "name", name, "error", err)
+		}
+	}
+
+	resp, err := r.sendInternalCommand(session, "script.addPreloadScript", map[string]interface{}{
+		"functionDeclaration": declaration,
+		"arguments":           channelArg,
+	})
+	if err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+	if bidiErr := checkBidiError(resp); bidiErr != nil {
+		r.sendError(session, cmd.ID, bidiErr)
+		return
+	}
+
+	var added struct {
+		Result struct {
+			Script string `json:"script"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &added); err != nil {
+		r.sendError(session, cmd.ID, fmt.Errorf("failed to parse addPreloadScript response: %w", err))
+		return
+	}
+	session.mu.Lock()
+	session.exposedPreloadIDs[name] = added.Result.Script
+	session.mu.Unlock()
+
+	// The preload only runs for documents loaded from now on, so bind in the
+	// document that is already open too.
+	if _, err := r.sendInternalCommand(session, "script.callFunction", map[string]interface{}{
+		"functionDeclaration": declaration,
+		"target":              map[string]interface{}{"context": context},
+		"arguments":           channelArg,
+		"awaitPromise":        false,
+	}); err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+
+	r.sendSuccess(session, cmd.ID, map[string]interface{}{"exposed": true})
+}
+
+// ensureScriptMessageSubscription subscribes the session to script.message
+// once; WebSocket monitoring and exposed functions share the subscription.
+func (r *Router) ensureScriptMessageSubscription(session *BrowserSession) error {
+	session.mu.Lock()
+	subscribed := session.wsSubscribed
+	session.mu.Unlock()
+	if subscribed {
+		return nil
+	}
+
+	resp, err := r.sendInternalCommand(session, "session.subscribe", map[string]interface{}{
+		"events": []string{"script.message"},
+	})
+	if err != nil {
+		return err
+	}
+	if bidiErr := checkBidiError(resp); bidiErr != nil {
+		return bidiErr
+	}
+	session.mu.Lock()
+	session.wsSubscribed = true
+	session.mu.Unlock()
+	return nil
+}
+
+// parseExposeCall extracts a vibium:expose.call event's params from a raw
+// browser message, or nil when the message is not an expose channel message.
+func parseExposeCall(msg string) map[string]interface{} {
+	var event struct {
+		Method string `json:"method"`
+		Params struct {
+			Channel string          `json:"channel"`
+			Data    json.RawMessage `json:"data"`
+			Source  struct {
+				Context string `json:"context"`
+				Realm   string `json:"realm"`
+			} `json:"source"`
+		} `json:"params"`
+	}
+	if json.Unmarshal([]byte(msg), &event) != nil {
+		return nil
+	}
+	if event.Method != "script.message" || event.Params.Channel != exposeChannelName {
+		return nil
+	}
+
+	// The channel payload is a BiDi remote value wrapping our JSON string.
+	var dataValue struct {
+		Type  string `json:"type"`
+		Value string `json:"value"`
+	}
+	if json.Unmarshal(event.Params.Data, &dataValue) != nil || dataValue.Type != "string" {
+		return nil
+	}
+
+	var call struct {
+		Name string        `json:"name"`
+		Seq  float64       `json:"seq"`
+		Args []interface{} `json:"args"`
+	}
+	if json.Unmarshal([]byte(dataValue.Value), &call) != nil || call.Name == "" {
+		return nil
+	}
+
+	args := call.Args
+	if args == nil {
+		args = []interface{}{}
+	}
+	return map[string]interface{}{
+		"name":    call.Name,
+		"seq":     call.Seq,
+		"args":    args,
+		"context": event.Params.Source.Context,
+		"realm":   event.Params.Source.Realm,
+	}
+}
+
+// isExposeChannelEvent intercepts a script.message on the expose channel and
+// forwards it to the client as a vibium:expose.call event, returning true.
+func (r *Router) isExposeChannelEvent(session *BrowserSession, msg string) bool {
+	params := parseExposeCall(msg)
+	if params == nil {
+		return false
+	}
+	eventMsg := map[string]interface{}{
+		"method": "vibium:expose.call",
+		"params": params,
+	}
+	data, _ := json.Marshal(eventMsg)
+	session.Client.Send(string(data))
+	return true
+}
+
+// exposeDeliverArgs translates a vibium:expose.result command's params into
+// the primitive arguments exposeDeliverScript takes: the seq, the result as a
+// JSON string or null, and the error message or null.
+func exposeDeliverArgs(params map[string]interface{}) ([]map[string]interface{}, error) {
+	seq, ok := params["seq"].(float64)
+	if !ok {
+		return nil, fmt.Errorf("expose.result requires a numeric seq")
+	}
+
+	resultArg := map[string]interface{}{"type": "null"}
+	errorArg := map[string]interface{}{"type": "null"}
+	if errMsg, ok := params["error"].(string); ok && errMsg != "" {
+		errorArg = map[string]interface{}{"type": "string", "value": errMsg}
+	} else if result, ok := params["result"]; ok && result != nil {
+		data, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("result is not serializable: %w", err)
+		}
+		resultArg = map[string]interface{}{"type": "string", "value": string(data)}
+	}
+
+	return []map[string]interface{}{
+		{"type": "number", "value": seq},
+		resultArg,
+		errorArg,
+	}, nil
+}
+
+// handleExposeResult handles vibium:expose.result — delivers a host
+// function's outcome into the page, settling the promise parked under seq.
+// The calling realm from the expose.call event is the preferred target: with
+// only a context, a navigation between call and result could deliver into
+// the wrong document (the deliver script then finds no pending seq and does
+// nothing, which is the correct outcome for a dead call).
+func (r *Router) handleExposeResult(session *BrowserSession, cmd bidiCommand) {
+	args, err := exposeDeliverArgs(cmd.Params)
+	if err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+
+	target := map[string]interface{}{}
+	if realm, _ := cmd.Params["realm"].(string); realm != "" {
+		target["realm"] = realm
+	} else if context, _ := cmd.Params["context"].(string); context != "" {
+		target["context"] = context
+	} else {
+		r.sendError(session, cmd.ID, fmt.Errorf("expose.result requires a realm or context"))
+		return
+	}
+
+	resp, err := r.sendInternalCommand(session, "script.callFunction", map[string]interface{}{
+		"functionDeclaration": exposeDeliverScript,
+		"target":              target,
+		"arguments":           args,
+		"awaitPromise":        false,
+	})
+	if err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+	if bidiErr := checkBidiError(resp); bidiErr != nil {
+		r.sendError(session, cmd.ID, bidiErr)
+		return
+	}
+
+	r.sendSuccess(session, cmd.ID, map[string]interface{}{})
+}

--- a/clicker/internal/api/handlers_expose_test.go
+++ b/clicker/internal/api/handlers_expose_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The page posts {name, seq, args} through the expose channel; the router
+// turns that into a vibium:expose.call event with the calling realm attached
+// (#298).
+func TestParseExposeCall(t *testing.T) {
+	msg := `{"method":"script.message","params":{"channel":"vibium-expose",` +
+		`"data":{"type":"string","value":"{\"name\":\"save\",\"seq\":3,\"args\":[\"x\",2]}"},` +
+		`"source":{"context":"ctx-1","realm":"realm-1"}}}`
+
+	params := parseExposeCall(msg)
+	if params == nil {
+		t.Fatal("a well-formed expose channel message must parse")
+	}
+	if params["name"] != "save" || params["seq"] != 3.0 {
+		t.Fatalf("params = %v", params)
+	}
+	if !reflect.DeepEqual(params["args"], []interface{}{"x", 2.0}) {
+		t.Fatalf("args = %v", params["args"])
+	}
+	if params["context"] != "ctx-1" || params["realm"] != "realm-1" {
+		t.Fatalf("source not carried: %v", params)
+	}
+}
+
+func TestParseExposeCallIgnoresOtherMessages(t *testing.T) {
+	for _, msg := range []string{
+		// The WebSocket monitor shares the script.message subscription.
+		`{"method":"script.message","params":{"channel":"vibium-ws","data":{"type":"string","value":"{}"},"source":{"context":"c"}}}`,
+		`{"method":"log.entryAdded","params":{"type":"console"}}`,
+		`{"method":"script.message","params":{"channel":"vibium-expose","data":{"type":"number","value":5},"source":{"context":"c"}}}`,
+		`{"method":"script.message","params":{"channel":"vibium-expose","data":{"type":"string","value":"not json"},"source":{"context":"c"}}}`,
+		`not json`,
+	} {
+		if params := parseExposeCall(msg); params != nil {
+			t.Fatalf("message %q must not parse as an expose call, got %v", msg, params)
+		}
+	}
+}
+
+// A call with no arguments still carries an empty args array, so clients can
+// spread it without a nil check.
+func TestParseExposeCallDefaultsArgs(t *testing.T) {
+	msg := `{"method":"script.message","params":{"channel":"vibium-expose",` +
+		`"data":{"type":"string","value":"{\"name\":\"ping\",\"seq\":1}"},` +
+		`"source":{"context":"ctx-1","realm":"realm-1"}}}`
+	params := parseExposeCall(msg)
+	if params == nil {
+		t.Fatal("must parse")
+	}
+	if !reflect.DeepEqual(params["args"], []interface{}{}) {
+		t.Fatalf("args = %v", params["args"])
+	}
+}
+
+// expose.result params become the three primitive deliver arguments: seq,
+// result JSON or null, error message or null.
+func TestExposeDeliverArgs(t *testing.T) {
+	t.Run("result value", func(t *testing.T) {
+		args, err := exposeDeliverArgs(map[string]interface{}{
+			"seq": 3.0, "result": map[string]interface{}{"ok": true},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []map[string]interface{}{
+			{"type": "number", "value": 3.0},
+			{"type": "string", "value": `{"ok":true}`},
+			{"type": "null"},
+		}
+		if !reflect.DeepEqual(args, want) {
+			t.Fatalf("args = %v", args)
+		}
+	})
+
+	t.Run("error takes precedence", func(t *testing.T) {
+		args, err := exposeDeliverArgs(map[string]interface{}{
+			"seq": 1.0, "error": "boom", "result": "ignored",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if args[1]["type"] != "null" || args[2]["value"] != "boom" {
+			t.Fatalf("args = %v", args)
+		}
+	})
+
+	t.Run("no result means undefined in the page", func(t *testing.T) {
+		args, err := exposeDeliverArgs(map[string]interface{}{"seq": 2.0})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if args[1]["type"] != "null" || args[2]["type"] != "null" {
+			t.Fatalf("args = %v", args)
+		}
+	})
+
+	t.Run("seq is required", func(t *testing.T) {
+		if _, err := exposeDeliverArgs(map[string]interface{}{"result": 1}); err == nil {
+			t.Fatal("a missing seq must error")
+		}
+	})
+}

--- a/clicker/internal/api/handlers_websocket.go
+++ b/clicker/internal/api/handlers_websocket.go
@@ -66,26 +66,9 @@ func (r *Router) handlePageOnWebSocket(session *BrowserSession, cmd bidiCommand)
 		return
 	}
 
-	// Subscribe to script.message events (once per session)
-	session.mu.Lock()
-	needSubscribe := !session.wsSubscribed
-	session.mu.Unlock()
-
-	if needSubscribe {
-		resp, err := r.sendInternalCommand(session, "session.subscribe", map[string]interface{}{
-			"events": []string{"script.message"},
-		})
-		if err != nil {
-			r.sendError(session, cmd.ID, err)
-			return
-		}
-		if bidiErr := checkBidiError(resp); bidiErr != nil {
-			r.sendError(session, cmd.ID, bidiErr)
-			return
-		}
-		session.mu.Lock()
-		session.wsSubscribed = true
-		session.mu.Unlock()
+	if err := r.ensureScriptMessageSubscription(session); err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
 	}
 
 	// Install preload script (once per session) — applies to all future navigations

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -330,6 +330,10 @@ func unblocksAnotherCommand(method string) bool {
 	// A download await blocks until the browser finishes writing the file.
 	case "vibium:download.await":
 		return true
+	// The command it unblocks is an evaluate stuck awaiting the exposed
+	// function this result settles.
+	case "vibium:expose.result":
+		return true
 	}
 	return false
 }
@@ -619,6 +623,12 @@ func (r *Router) OnClientMessage(client ClientTransport, msg string) {
 		return
 	case "vibium:page.expose":
 		r.dispatch(session, cmd, r.handlePageExpose)
+		return
+	case "vibium:page.exposeFunction":
+		r.dispatch(session, cmd, r.handlePageExposeFunction)
+		return
+	case "vibium:expose.result":
+		r.dispatch(session, cmd, r.handleExposeResult)
 		return
 
 	// Page-level waiting commands
@@ -1057,6 +1067,11 @@ func (r *Router) routeBrowserToClient(session *BrowserSession) {
 
 		// Check for WebSocket channel events (intercept, don't forward raw script.message)
 		if r.isWsChannelEvent(session, msg) {
+			continue
+		}
+
+		// Expose channel messages become vibium:expose.call events (#298).
+		if r.isExposeChannelEvent(session, msg) {
 			continue
 		}
 

--- a/clients/javascript/src/page.ts
+++ b/clients/javascript/src/page.ts
@@ -66,6 +66,62 @@ interface VibiumFindAllResult {
 
 const customInspect = Symbol.for('nodejs.util.inspect.custom');
 
+// Exposed host functions are connection-scoped, not Page-instance-scoped:
+// browser.page() hands out a fresh Page object for the same context, and
+// every instance sees every event. One registry and one dispatcher per
+// client means one execution and one reply per call, whichever instance
+// registered the function.
+const exposeRegistries = new WeakMap<BiDiClient, Map<string, (...args: unknown[]) => unknown>>();
+
+function exposeRegistry(client: BiDiClient): Map<string, (...args: unknown[]) => unknown> {
+  let registry = exposeRegistries.get(client);
+  if (!registry) {
+    const fns = new Map<string, (...args: unknown[]) => unknown>();
+    registry = fns;
+    exposeRegistries.set(client, fns);
+    client.onEvent((event) => {
+      if (event.method !== 'vibium:expose.call') return;
+      handleExposeCall(client, fns, event.params as Record<string, unknown>);
+    });
+  }
+  return registry;
+}
+
+async function handleExposeCall(
+  client: BiDiClient,
+  fns: Map<string, (...args: unknown[]) => unknown>,
+  params: Record<string, unknown>,
+): Promise<void> {
+  const name = params.name as string;
+  const seq = params.seq as number;
+  const context = params.context as string;
+  const realm = params.realm as string | undefined;
+
+  // Every outcome answers: an unanswered call leaves the page's promise
+  // parked forever. The reply carries the calling realm back, so the engine
+  // delivers into the document that made the call, not whatever the context
+  // shows after a navigation.
+  const reply = (body: { result?: unknown; error?: string }) => {
+    client.send('vibium:expose.result', { context, realm, seq, ...body }).catch(() => {});
+  };
+
+  const fn = fns.get(name);
+  if (!fn) {
+    reply({ error: `${name} is not exposed` });
+    return;
+  }
+
+  try {
+    const result = await fn(...((params.args as unknown[]) ?? []));
+    // Results cross as JSON; catching the serialization failure here turns
+    // it into a page-side rejection instead of a forever-pending promise.
+    JSON.stringify(result);
+    reply({ result: result === undefined ? null : result });
+  } catch (e) {
+    reply({ error: e instanceof Error ? e.message : String(e) });
+  }
+}
+
 /** Page-level keyboard input. */
 export class Keyboard {
   private client: BiDiClient;
@@ -593,8 +649,27 @@ export class Page {
     });
   }
 
-  /** Expose a function on window. The function body is injected as a string. */
-  async expose(name: string, fn: string): Promise<void> {
+  /**
+   * Expose a function on window.
+   *
+   * Pass a function to expose a host callback: the page calls
+   * window[name](...args), this function runs here, and its return value
+   * resolves the page's promise. Arguments and results cross as JSON.
+   * Pass a string to inject it as JS source instead, defining window[name]
+   * inside the page.
+   *
+   * Either form survives navigation, and re-exposing a name replaces it.
+   */
+  async expose(name: string, fn: string | ((...args: unknown[]) => unknown)): Promise<void> {
+    if (typeof fn === 'function') {
+      exposeRegistry(this.client).set(name, fn);
+      await this.client.send('vibium:page.exposeFunction', {
+        context: this.contextId,
+        name,
+      });
+      return;
+    }
+    exposeRegistries.get(this.client)?.delete(name);
     await this.client.send('vibium:page.expose', {
       context: this.contextId,
       name,

--- a/docs/explanation/client-implementation-guide.md
+++ b/docs/explanation/client-implementation-guide.md
@@ -333,6 +333,12 @@ The engine dismisses every dialog itself while no dialog handler is registered �
 
 `capture.request` / `capture.response` send `vibium:page.captureRequest` / `vibium:page.captureResponse` with `{context, pattern, timeout}`; `capture.navigation`, `capture.download`, `capture.dialog`, and `capture.event("console" | "error")` send `vibium:page.captureEvent` with `{context, kind, timeout}`. The engine registers the capture in client message order, waits for the first matching event, and answers with its raw params (`{"event": {...}}`) — clients keep no listener or timeout machinery, they build the language object from the returned params. Start the capture command on the wire before running the trigger action, and run the action so that its blocking cannot block the capture's return (a trigger stuck inside `evaluate("alert(...)")` resolves only after the captured dialog is handled).
 
+### Exposed Functions
+
+`page.expose(name, fn)` with a host function sends `vibium:page.exposeFunction {context, name}`. The engine installs a preload that defines `window[name]` as a promise-returning stub: each call parks its promise under a sequence number and posts `{name, seq, args}` through a script channel. The engine forwards that as a `vibium:expose.call {name, seq, args, context, realm}` event. The client looks the name up in its per-page function map, runs the host function, and sends `vibium:expose.result {context, realm, seq, result | error}`; the engine then settles the parked promise inside the calling realm. Always reply, whatever the outcome — an unanswered call leaves the page's promise pending forever — and reply with an error for a name the page calls that this page never exposed. Arguments and results cross as JSON.
+
+The string form (`vibium:page.expose`) keeps its old meaning: the string is JS source that defines `window[name]` inside the page, with no host round trip.
+
 ### Downloads
 
 The engine tracks every download by its navigation id and saves the file to a session temp dir. A Download object holds the `downloadWillBegin` params (url, suggested filename, navigation id) and nothing else; `path()` and `saveAs()` send `vibium:download.await` with `{navigation, timeout}` and get `{status, filepath}` back once the download ends. The engine answers already-finished downloads immediately, so the accessors can be called repeatedly and in any order. No client watches `downloadEnd` or keeps a pending-downloads map.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -41,7 +41,7 @@ For what goes *in* the `<sel>` argument — CSS, shadow-DOM pierce combinators, 
 | 21 | Evaluate JavaScript | `vibium:page.eval` | `vibium eval <expr>` | `browser_evaluate` | `page.evaluate(expr)` | `page.evaluate(expr)` | `page.evaluate(expr)` |
 | 22 | Add a script tag | `vibium:page.addScript` | ⬜ | ⬜ | `page.addScript(src)` | `page.add_script(src)` | `page.addScript(src)` |
 | 23 | Add a style tag | `vibium:page.addStyle` | ⬜ | ⬜ | `page.addStyle(src)` | `page.add_style(src)` | `page.addStyle(src)` |
-| 24 | Expose a function to the page | `vibium:page.expose` | — | — | `page.expose(name, fn)` | `page.expose(name, fn)` | `page.expose(name, fn)` |
+| 24 | Expose a function to the page | `vibium:page.expose` / `vibium:page.exposeFunction` | — | — | `page.expose(name, fn)` | `page.expose(name, fn)` | `page.expose(name, fn)` |
 | 25 | Wait for a duration | `vibium:page.wait` | `vibium sleep <ms>` | `browser_sleep` | `page.wait(ms)` | `page.wait(ms)` | `page.sleep(ms)` |
 | 26 | Wait for a selector | `vibium:page.waitFor` | `vibium wait <sel>` | `browser_wait` | — | — | `page.waitFor(sel, options?)` |
 | 27 | Wait for JS function to return truthy | `vibium:page.waitForFunction` | `vibium wait fn <expr>` | `browser_wait_for_fn` | `page.waitForFunction(fn, opts?)` | `page.wait_for_function(fn, **opts)` | `page.waitForFunction(fn, options?)` |

--- a/tests/js/async/engine/expose.test.js
+++ b/tests/js/async/engine/expose.test.js
@@ -1,0 +1,153 @@
+/**
+ * JS Library Tests: page.expose
+ *
+ * Both forms of expose: injecting JS source (a string) and exposing a host
+ * function whose return value comes back to the page (#298). The host form
+ * round-trips through the engine: the page posts {name, seq, args} over a
+ * script channel, the client runs the function, and vibium:expose.result
+ * settles the page's promise.
+ *
+ * Uses a local HTTP server — no external network dependencies.
+ */
+
+const { test, describe, before, after } = require("../../../helpers/capabilities").suite("core");
+const assert = require('node:assert');
+const http = require('http');
+
+const { browser } = require('../../../../clients/javascript/dist');
+
+let server;
+let baseURL;
+let bro;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    if (req.url === '/other') {
+      res.end('<html><head><title>Other</title></head><body>other</body></html>');
+    } else {
+      res.end('<html><head><title>Expose</title></head><body>page</body></html>');
+    }
+  });
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      baseURL = `http://127.0.0.1:${server.address().port}`;
+      resolve();
+    });
+  });
+  bro = await browser.start({ headless: true });
+});
+
+after(async () => {
+  await bro.stop();
+  if (server) server.close();
+});
+
+describe('Expose: JS source (string form)', () => {
+  test('defines window[name] from injected source', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    await vibe.expose('double', '(x) => x * 2');
+    const result = await vibe.evaluate('window.double(21)');
+    assert.strictEqual(result, 42);
+
+    await vibe.close();
+  });
+});
+
+describe('Expose: host functions', () => {
+  test('the page call runs the host function and gets its return value', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    await vibe.expose('add', (a, b) => a + b);
+    const result = await vibe.evaluate('window.add(2, 3)');
+    assert.strictEqual(result, 5);
+
+    await vibe.close();
+  });
+
+  test('async host functions and object results work', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    await vibe.expose('lookup', async (key) => {
+      await new Promise((r) => setTimeout(r, 20));
+      return { key, found: true };
+    });
+    const result = await vibe.evaluate('window.lookup("user")');
+    assert.deepStrictEqual(result, { key: 'user', found: true });
+
+    await vibe.close();
+  });
+
+  test('a throwing host function rejects the page promise with its message', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    await vibe.expose('explode', () => {
+      throw new Error('no fuel');
+    });
+    const message = await vibe.evaluate('window.explode().catch((e) => e.message)');
+    assert.strictEqual(message, 'no fuel');
+
+    await vibe.close();
+  });
+
+  test('the binding survives navigation', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    let calls = 0;
+    await vibe.expose('count', () => { calls += 1; return calls; });
+    assert.strictEqual(await vibe.evaluate('window.count()'), 1);
+
+    await vibe.go(`${baseURL}/other`);
+    assert.strictEqual(await vibe.evaluate('window.count()'), 2, 'the preload must rebind after navigation');
+
+    await vibe.close();
+  });
+
+  test('concurrent calls resolve independently by sequence number', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    await vibe.expose('echoLater', async (value, delayMs) => {
+      await new Promise((r) => setTimeout(r, delayMs));
+      return value;
+    });
+    // The slower call was made first; per-call sequencing must keep the
+    // results from crossing.
+    const result = await vibe.evaluate(
+      'Promise.all([window.echoLater("slow", 80), window.echoLater("fast", 5)])'
+    );
+    assert.deepStrictEqual(result, ['slow', 'fast']);
+
+    await vibe.close();
+  });
+
+  test('another Page instance for the same context does not shadow the function', async () => {
+    // browser.page() constructs a fresh Page object per call, and every
+    // instance sees every event. The registry is connection-scoped, so an
+    // instance that never registered the function must not answer for it.
+    const first = await bro.page();
+    const second = await bro.page();
+    await second.go(baseURL);
+
+    await second.expose('whoami', () => 'owner');
+    assert.strictEqual(await second.evaluate('window.whoami()'), 'owner');
+    assert.ok(first, 'the earlier instance keeps listening without interfering');
+  });
+
+  test('re-exposing a name replaces the previous function', async () => {
+    const vibe = await bro.newPage();
+    await vibe.go(baseURL);
+
+    await vibe.expose('answer', () => 'first');
+    await vibe.expose('answer', () => 'second');
+    assert.strictEqual(await vibe.evaluate('window.answer()'), 'second');
+
+    await vibe.close();
+  });
+});


### PR DESCRIPTION
Part of VibiumDev/vibium#298. Engine and JS client; Python and Java follow in a second PR.

page.expose has meant two things: with a string it injects JS source into the page (built), and with a function it should expose a host callback the page can invoke (never built, though Java's signature has promised it all along). This adds the callback form to the engine and the JS client: the page calls window[name](args), the client's function runs, and its return value resolves the page's promise. The string form is unchanged.

Three wire pieces carry the round trip. vibium:page.exposeFunction {context, name} installs a preload that defines window[name] as a promise-returning stub, which parks each call under a sequence number and posts {name, seq, args} through a script channel — the same channel machinery WebSocket monitoring already uses, and the two now share one script.message subscription. The engine forwards the channel message to the client as a vibium:expose.call {name, seq, args, context, realm} event. The client runs the host function and answers with vibium:expose.result {context, realm, seq, result | error}; the engine delivers that into the calling realm, settling the parked promise. The engine keeps no per-call state, and arguments and results cross as JSON.

Two deliberate choices. Results target the realm from the call event rather than the context: if the page navigates between call and result, delivery lands in the dead document's realm, where the deliver script finds no pending entry and does nothing, the correct outcome for a call whose document is gone. And the client always replies, including with an error for a name it never exposed, because an unanswered call would leave the page's promise pending forever. The function registry is scoped to the connection, not the Page object: browser.page() hands out a fresh Page instance for the same context on every call, and an instance-scoped registry would let an empty instance answer "not exposed" for a sibling's function.

The bindings survive navigation through the preload, and re-exposing a name replaces its previous binding in either form.

Verified:
- New engine tests cover the channel-message parsing and the result-to-deliver-arguments translation, including the error and no-result forms
- A new browser suite covers both expose forms end to end: return values, async host functions and object results, thrown errors rejecting the page promise with their message, navigation survival, concurrent calls staying correlated by sequence number, and re-exposure replacing the function (7 tests)
- The injected-source regression tests, the WebSocket suite that shares the subscription (31 tests together), the full Go suite, and the API drift checker pass
