### PR TITLE
Register network captures before reading the next client message

### DIFF
--- a/clicker/internal/api/capture_registry_test.go
+++ b/clicker/internal/api/capture_registry_test.go
@@ -184,3 +184,28 @@ func TestDialogCaptureClaimsPrompt(t *testing.T) {
 		t.Fatal("only dialog captures claim prompts")
 	}
 }
+
+// The registration half of a network capture runs inline on the client
+// message order: registered on the dispatch goroutine instead, the capture
+// can lose the race against the very next client command triggering its
+// traffic.
+func TestNetworkCaptureRegistersBeforeNextMessage(t *testing.T) {
+	router := &Router{}
+	client := &recordingTransport{}
+	session := &BrowserSession{
+		Client:   client,
+		stopChan: make(chan struct{}),
+		prompts:  NewPromptTracker(),
+		captures: newCaptureRegistry(),
+	}
+	router.sessions.Store(client.ID(), session)
+
+	router.OnClientMessage(client, `{"id":4,"method":"vibium:page.captureRequest","params":{"context":"ctx-1","pattern":"**","timeout":100}}`)
+
+	session.captures.mu.Lock()
+	pending := len(session.captures.pending)
+	session.captures.mu.Unlock()
+	if pending != 1 {
+		t.Fatalf("the capture must be registered when OnClientMessage returns, have %d pending", pending)
+	}
+}

--- a/clicker/internal/api/handlers_network.go
+++ b/clicker/internal/api/handlers_network.go
@@ -320,30 +320,24 @@ func convertHeadersToBidi(headers map[string]interface{}) []map[string]interface
 	return bidiHeaders
 }
 
-// handlePageCaptureRequest handles vibium:page.captureRequest — blocks until
-// the first request matching the pattern is sent, then returns its event
-// params. Matching and waiting both live here so clients need neither a glob
-// implementation nor one-shot listener machinery (#446).
-func (r *Router) handlePageCaptureRequest(session *BrowserSession, cmd bidiCommand) {
-	r.handleCapture(session, cmd, "network.beforeRequestSent", "request")
-}
-
-// handlePageCaptureResponse handles vibium:page.captureResponse — the
-// response-side twin of handlePageCaptureRequest.
-func (r *Router) handlePageCaptureResponse(session *BrowserSession, cmd bidiCommand) {
-	r.handleCapture(session, cmd, "network.responseCompleted", "response")
-}
-
-func (r *Router) handleCapture(session *BrowserSession, cmd bidiCommand, eventMethod, what string) {
+// registerNetworkCapture handles the registration half of
+// vibium:page.captureRequest / captureResponse and returns the handler that
+// waits the capture out. The router calls this inline on the client message
+// order and dispatches only the returned wait: registered on the dispatch
+// goroutine instead, the capture could lose the race against the very next
+// client command triggering its traffic, which a short trigger fuse in a
+// loaded Firefox run turned into a real timeout. A nil return means the
+// command was already answered with an error.
+func (r *Router) registerNetworkCapture(session *BrowserSession, cmd bidiCommand, eventMethod, what string) vibiumHandler {
 	context, err := r.resolveContext(session, cmd.Params)
 	if err != nil {
 		r.sendError(session, cmd.ID, err)
-		return
+		return nil
 	}
 	pattern, _ := cmd.Params["pattern"].(string)
 	if pattern == "" {
 		r.sendError(session, cmd.ID, fmt.Errorf("pattern is required"))
-		return
+		return nil
 	}
 	timeoutMs := 10000.0
 	if t, ok := cmd.Params["timeout"].(float64); ok && t > 0 {
@@ -353,21 +347,23 @@ func (r *Router) handleCapture(session *BrowserSession, cmd bidiCommand, eventMe
 	id, ch, err := session.captures.register(eventMethod, context, pattern)
 	if err != nil {
 		r.sendError(session, cmd.ID, fmt.Errorf("invalid pattern: %w", err))
-		return
+		return nil
 	}
 
-	select {
-	case params := <-ch:
-		var event interface{}
-		if err := json.Unmarshal(params, &event); err != nil {
-			r.sendError(session, cmd.ID, fmt.Errorf("capture event unparseable: %w", err))
-			return
+	return func(session *BrowserSession, cmd bidiCommand) {
+		select {
+		case params := <-ch:
+			var event interface{}
+			if err := json.Unmarshal(params, &event); err != nil {
+				r.sendError(session, cmd.ID, fmt.Errorf("capture event unparseable: %w", err))
+				return
+			}
+			r.sendSuccess(session, cmd.ID, map[string]interface{}{"event": event})
+		case <-time.After(time.Duration(timeoutMs) * time.Millisecond):
+			session.captures.cancel(id)
+			r.sendError(session, cmd.ID, fmt.Errorf("timeout waiting for %s matching %q", what, pattern))
+		case <-session.stopChan:
+			session.captures.cancel(id)
 		}
-		r.sendSuccess(session, cmd.ID, map[string]interface{}{"event": event})
-	case <-time.After(time.Duration(timeoutMs) * time.Millisecond):
-		session.captures.cancel(id)
-		r.sendError(session, cmd.ID, fmt.Errorf("timeout waiting for %s matching %q", what, pattern))
-	case <-session.stopChan:
-		session.captures.cancel(id)
 	}
 }

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -763,11 +763,18 @@ func (r *Router) OnClientMessage(client ClientTransport, msg string) {
 	case "vibium:page.unroute":
 		r.dispatch(session, cmd, r.handlePageUnroute)
 		return
+	// Network captures register inline, in client message order, so the
+	// capture exists before the client's next command can trigger its
+	// traffic; only the wait runs on the dispatch goroutine.
 	case "vibium:page.captureRequest":
-		r.dispatch(session, cmd, r.handlePageCaptureRequest)
+		if wait := r.registerNetworkCapture(session, cmd, "network.beforeRequestSent", "request"); wait != nil {
+			r.dispatch(session, cmd, wait)
+		}
 		return
 	case "vibium:page.captureResponse":
-		r.dispatch(session, cmd, r.handlePageCaptureResponse)
+		if wait := r.registerNetworkCapture(session, cmd, "network.responseCompleted", "response"); wait != nil {
+			r.dispatch(session, cmd, wait)
+		}
 		return
 	case "vibium:page.captureEvent":
 		// Inline, not dispatched: registration must land before the client's


### PR DESCRIPTION
Fixes VibiumDev/vibium#461.

captureRequest and captureResponse registered their capture on the dispatch goroutine. The command that triggers the captured traffic is usually the very next thing the client sends, so registration raced it: on a loaded runner the trigger's event can fire before the capture exists, and the one-shot then waits out its whole timeout on traffic that has already passed. The failing test schedules its fetch 100ms after registering a match-all response capture; before the captures moved into the engine, registration was a synchronous client-local listener and that fuse could not lose, so this race arrived with the wire captures.

Registration now happens inline on the client message order, the way vibium:page.captureEvent has worked since it was added, and only the wait runs on the dispatch goroutine.

Verified:
- The new test asserts the capture exists the moment OnClientMessage returns; it fails on the previous code five runs out of five and passes here, race detector clean
- The Python network-dialog suite passes on both Chrome and Firefox locally, including the capture-event tests that flaked in CI; the JS network-dialog suite and the full Go suite pass
