### PR TITLE
Launch Firefox 155 with system access and a content startup tab

### DIFF
--- a/clicker/internal/browser/launcher_firefox.go
+++ b/clicker/internal/browser/launcher_firefox.go
@@ -91,10 +91,19 @@ func launchFirefox(opts LaunchOptions) (*LaunchResult, error) {
 		fmt.Sprintf("--remote-debugging-port=%d", port),
 		"--profile", profileDir,
 		"--no-remote",
+		// Firefox 155 gates privileged BiDi commands (browsingContext.activate
+		// behind page.bringToFront, for one) on this flag; older versions
+		// accept it and change nothing.
+		"--remote-allow-system-access",
 	}
 	if opts.Headless {
 		args = append(args, "--headless")
 	}
+	// Open on about:blank instead of Firefox's chrome-privileged blanktab.
+	// The startup tab otherwise lives in the parent process until a
+	// navigation, where script-backed commands are refused and, on Firefox
+	// 155, browsingContext.activate is rejected as privileged scope.
+	args = append(args, "about:blank")
 
 	cmd := exec.Command(firefoxPath, args...)
 	if xdgConfigHome != "" {


### PR DESCRIPTION
Fixes VibiumDev/vibium#464.

Every Firefox CI job fails since Firefox 155.0 reached the release channel (the installer resolves the current release, so CI picked it up on its own): page.bringToFront dies with "System access is required. Start Firefox with -remote-allow-system-access". The failure lands on whatever PR runs CI next, whatever its diff.

Two changes in the launcher, both Firefox-only:

Firefox 155 gates privileged BiDi commands on --remote-allow-system-access, browsingContext.activate among them. The launcher now passes the flag; versions before 155 accept it and change nothing.

The flag alone is not enough. Firefox opens on its chrome-privileged blanktab, and 155 rejects activate on a privileged context outright, so bringToFront on a fresh browser still failed until something navigated. Launching with about:blank makes the startup tab an ordinary content page from the first moment. That also removes the standing hazard where script-backed commands are refused on the unnavigated startup tab, which several tests have worked around by navigating first.

Verified on Firefox 155.0 release:
- Without the change the startup tab is chrome://browser/content/blanktab.html and activate on it fails with "privileged scope"; with it the tab is about:blank and activate succeeds on both the startup tab and new pages
- The JS lifecycle and input-eval suites (31 tests) and the Python network-dialog suite (25 tests) pass on Firefox 155; the Chrome lifecycle suite is unchanged; the browser package tests pass
