### PR TITLE
Expose host functions from the Python, Java, and sync JS surfaces

### DIFF
--- a/clients/java/src/main/java/com/vibium/Page.java
+++ b/clients/java/src/main/java/com/vibium/Page.java
@@ -8,10 +8,12 @@ import com.vibium.internal.BiDiClient;
 import com.vibium.types.*;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Represents a browser tab. The primary interface for page automation.
@@ -24,6 +26,70 @@ public class Page {
         thread.setDaemon(true);
         return thread;
     });
+    private static final ExecutorService HOST_FUNCTIONS = Executors.newCachedThreadPool(r -> {
+        Thread thread = new Thread(r, "vibium-exposed-function");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    // Exposed host functions are connection-scoped, not Page-instance-scoped:
+    // browser.page() hands out a fresh Page for the same context, and every
+    // instance sees every event. One registry and one dispatcher per client
+    // means one execution and one reply per call, whichever instance
+    // registered the function. Weak keys: a registry dies with its client.
+    private static final Map<BiDiClient, Map<String, Function<Object[], Object>>> EXPOSE_REGISTRIES =
+        Collections.synchronizedMap(new WeakHashMap<>());
+
+    private static Map<String, Function<Object[], Object>> exposeRegistry(BiDiClient client) {
+        synchronized (EXPOSE_REGISTRIES) {
+            Map<String, Function<Object[], Object>> registry = EXPOSE_REGISTRIES.get(client);
+            if (registry == null) {
+                Map<String, Function<Object[], Object>> fns = new ConcurrentHashMap<>();
+                EXPOSE_REGISTRIES.put(client, fns);
+                client.onEvent(event -> {
+                    if (event.has("method") && "vibium:expose.call".equals(event.get("method").getAsString())) {
+                        handleExposeCall(client, fns, event.getAsJsonObject("params"));
+                    }
+                });
+                registry = fns;
+            }
+            return registry;
+        }
+    }
+
+    private static void handleExposeCall(BiDiClient client, Map<String, Function<Object[], Object>> fns, JsonObject params) {
+        String name = params.has("name") ? params.get("name").getAsString() : "";
+        JsonElement seq = params.get("seq");
+        String context = params.has("context") ? params.get("context").getAsString() : "";
+        String realm = params.has("realm") ? params.get("realm").getAsString() : "";
+
+        // Off the event thread: that executor is single-threaded, so a slow
+        // host function would stall every later event. Every outcome answers,
+        // because an unanswered call leaves the page's promise parked
+        // forever; the reply carries the calling realm back so the engine
+        // delivers into the document that made the call.
+        HOST_FUNCTIONS.execute(() -> {
+            JsonObject reply = new JsonObject();
+            reply.addProperty("context", context);
+            reply.addProperty("realm", realm);
+            reply.add("seq", seq);
+
+            Function<Object[], Object> fn = fns.get(name);
+            if (fn == null) {
+                reply.addProperty("error", name + " is not exposed");
+            } else {
+                try {
+                    JsonElement rawArgs = params.has("args") ? params.get("args") : new JsonArray();
+                    Object[] args = GSON.fromJson(rawArgs, Object[].class);
+                    Object result = fn.apply(args != null ? args : new Object[0]);
+                    reply.add("result", GSON.toJsonTree(result));
+                } catch (Exception e) {
+                    reply.addProperty("error", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+                }
+            }
+            client.sendAsync("vibium:expose.result", reply);
+        });
+    }
 
     private final BiDiClient client;
     private final String contextId;
@@ -316,16 +382,30 @@ public class Page {
     /**
      * Define window[name] in the page from JS function source, in the current
      * document and every later one, matching the JS and Python clients:
-     * page.expose("double", "(n) => n * 2"). This replaces a callback-taking
-     * overload that sent no fn, which the server rejected on every call, and
-     * subscribed to an event the server never emits. Host-side callbacks,
-     * where the page calls back into the Java program, are tracked in #298.
+     * page.expose("double", "(n) => n * 2").
      */
     public void expose(String name, String fn) {
+        Map<String, Function<Object[], Object>> registry = EXPOSE_REGISTRIES.get(client);
+        if (registry != null) {
+            registry.remove(name);
+        }
         JsonObject params = contextParams();
         params.addProperty("name", name);
         params.addProperty("fn", fn);
         client.send("vibium:page.expose", params);
+    }
+
+    /**
+     * Expose a host function on window. The page calls window[name](args),
+     * the callback runs in this program, and its return value resolves the
+     * page's promise. Arguments and results cross as JSON. Either form of
+     * expose survives navigation, and re-exposing a name replaces it.
+     */
+    public void expose(String name, Function<Object[], Object> callback) {
+        exposeRegistry(client).put(name, callback);
+        JsonObject params = contextParams();
+        params.addProperty("name", name);
+        client.send("vibium:page.exposeFunction", params);
     }
 
     // ── Waiting ─────────────────────────────────────────────────

--- a/clients/java/src/test/java/com/vibium/engine/ExposeTest.java
+++ b/clients/java/src/test/java/com/vibium/engine/ExposeTest.java
@@ -9,8 +9,9 @@ import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * page.expose defines a named JS function in the page, matching the JS and
- * Python clients. The previous Java signature was non-functional (#298).
+ * page.expose in both forms (#298): a string defines window[name] from JS
+ * source inside the page; a callback exposes a host function whose return
+ * value comes back to the page through vibium:expose.call/result.
  */
 @RequiresCapability("core")
 class ExposeTest {
@@ -52,5 +53,36 @@ class ExposeTest {
         page.reload();
 
         assertEquals("marked", page.evaluate("window.vibiumMark()"));
+    }
+
+    @Test
+    void hostFunctionRunsAndReturnsItsValue() {
+        page.setContent("<p>x</p>");
+        page.expose("vibiumAdd", (args) ->
+            ((Number) args[0]).doubleValue() + ((Number) args[1]).doubleValue());
+
+        Object result = page.evaluate("window.vibiumAdd(2, 3)");
+        assertEquals(5.0, ((Number) result).doubleValue());
+    }
+
+    @Test
+    void hostFunctionErrorRejectsThePagePromise() {
+        page.setContent("<p>x</p>");
+        page.expose("vibiumExplode", (args) -> {
+            throw new IllegalStateException("no fuel");
+        });
+
+        Object message = page.evaluate("window.vibiumExplode().catch((e) => e.message)");
+        assertEquals("no fuel", message);
+    }
+
+    @Test
+    void hostFunctionSurvivesNavigationAndReExposureReplaces() {
+        page.setContent("<p>x</p>");
+        page.expose("vibiumAnswer", (args) -> "first");
+        page.expose("vibiumAnswer", (args) -> "second");
+        page.reload();
+
+        assertEquals("second", page.evaluate("window.vibiumAnswer()"));
     }
 }

--- a/clients/javascript/src/sync/page.ts
+++ b/clients/javascript/src/sync/page.ts
@@ -312,7 +312,22 @@ export class PageSync {
     this._bridge.call('page.addStyle', [this._pageId, source]);
   }
 
-  expose(name: string, fn: string): void {
+  expose(name: string, fn: string | ((...args: unknown[]) => unknown)): void {
+    if (typeof fn === 'function') {
+      const handlerId = `expose_${this._pageId}_${name}`;
+      // The bridge swallows handler exceptions, so the outcome travels in an
+      // envelope the worker unwraps: a thrown host error must reject the
+      // page's promise, not resolve it with null.
+      this._bridge.registerHandler(handlerId, (args: unknown) => {
+        try {
+          return { ok: true, value: fn(...(args as unknown[])) };
+        } catch (e) {
+          return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        }
+      });
+      this._bridge.call('page.exposeWithCallback', [this._pageId, name, handlerId]);
+      return;
+    }
     this._bridge.call('page.expose', [this._pageId, name, fn]);
   }
 

--- a/clients/javascript/src/sync/worker.ts
+++ b/clients/javascript/src/sync/worker.ts
@@ -741,6 +741,20 @@ const handlers: Record<string, Handler> = {
 
   // --- Page events (simplified for sync) ---
 
+  'page.exposeWithCallback': async (args) => {
+    const [pageId, name, handlerId] = args as [number, string, string];
+    const page = getPage(pageId);
+    await page.expose(name, async (...fnArgs: unknown[]) => {
+      const outcome = await invokeMainThread(handlerId, fnArgs) as
+        { ok: boolean; value?: unknown; error?: string } | null;
+      if (!outcome || outcome.ok !== true) {
+        throw new Error(outcome?.error ?? `${name} handler failed`);
+      }
+      return outcome.value;
+    });
+    return { success: true };
+  },
+
   'page.onDialog': async (args) => {
     const [pageId, action] = args as [number, 'accept' | 'dismiss'];
     const page = getPage(pageId);

--- a/clients/python/src/vibium/async_api/page.py
+++ b/clients/python/src/vibium/async_api/page.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import re
 import warnings
+import weakref
 from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 from .. import errors
@@ -23,6 +25,65 @@ from .websocket_info import WebSocketInfo
 if TYPE_CHECKING:
     from ..client import BiDiClient
     from .context import BrowserContext as BrowserContextType
+
+
+# Exposed host functions are connection-scoped, not Page-instance-scoped:
+# browser.page() hands out a fresh Page object for the same context, and
+# every instance sees every event. One registry and one dispatcher per
+# client means one execution and one reply per call, whichever instance
+# registered the function. Weak keys: a registry dies with its client.
+_expose_registries: "weakref.WeakKeyDictionary[Any, Dict[str, Callable[..., Any]]]" = weakref.WeakKeyDictionary()
+
+
+def _expose_registry(client: Any) -> Dict[str, Callable[..., Any]]:
+    registry = _expose_registries.get(client)
+    if registry is None:
+        fns: Dict[str, Callable[..., Any]] = {}
+        registry = fns
+        _expose_registries[client] = fns
+
+        def _on_event(event: Dict[str, Any]) -> None:
+            if event.get("method") == "vibium:expose.call":
+                _handle_expose_call(client, fns, event.get("params") or {})
+
+        client.on_event(_on_event)
+    return registry
+
+
+def _handle_expose_call(client: Any, fns: Dict[str, Callable[..., Any]], params: Dict[str, Any]) -> None:
+    name = params.get("name", "")
+    seq = params.get("seq")
+    context = params.get("context", "")
+    realm = params.get("realm", "")
+
+    # Every outcome answers: an unanswered call leaves the page's promise
+    # parked forever. The reply carries the calling realm back, so the engine
+    # delivers into the document that made the call, not whatever the context
+    # shows after a navigation.
+    def reply(body: Dict[str, Any]) -> None:
+        asyncio.ensure_future(client.send("vibium:expose.result", {
+            "context": context, "realm": realm, "seq": seq, **body,
+        }))
+
+    fn = fns.get(name)
+    if fn is None:
+        reply({"error": f"{name} is not exposed"})
+        return
+
+    async def _run() -> None:
+        try:
+            result = fn(*params.get("args", []))
+            if hasattr(result, "__await__"):
+                result = await result
+            # Results cross as JSON; catching the serialization failure here
+            # turns it into a page-side rejection instead of a
+            # forever-pending promise.
+            json.dumps(result)
+            reply({"result": result})
+        except Exception as e:
+            reply({"error": str(e) or type(e).__name__})
+
+    asyncio.ensure_future(_run())
 
 logger = logging.getLogger("vibium")
 
@@ -506,8 +567,26 @@ class Page:
             params["content"] = source
         await self._client.send("vibium:page.addStyle", params)
 
-    async def expose(self, name: str, fn: str) -> None:
-        """Expose a function on window."""
+    async def expose(self, name: str, fn: Union[str, Callable[..., Any]]) -> None:
+        """Expose a function on window.
+
+        Pass a callable to expose a host callback: the page calls
+        window[name](*args), the callable runs here, and its return value
+        resolves the page's promise. Arguments and results cross as JSON.
+        Pass a string to inject it as JS source instead, defining
+        window[name] inside the page.
+
+        Either form survives navigation, and re-exposing a name replaces it.
+        """
+        if callable(fn):
+            _expose_registry(self._client)[name] = fn
+            await self._client.send("vibium:page.exposeFunction", {
+                "context": self._context_id, "name": name,
+            })
+            return
+        registry = _expose_registries.get(self._client)
+        if registry is not None:
+            registry.pop(name, None)
         await self._client.send("vibium:page.expose", {
             "context": self._context_id, "name": name, "fn": fn,
         })

--- a/clients/python/src/vibium/sync_api/page.py
+++ b/clients/python/src/vibium/sync_api/page.py
@@ -266,7 +266,17 @@ class Page:
     def add_style(self, source: str) -> None:
         self._loop.run(self._async.add_style(source))
 
-    def expose(self, name: str, fn: str) -> None:
+    def expose(self, name: str, fn: Union[str, Callable[..., Any]]) -> None:
+        if callable(fn):
+            async def _host(*args: Any) -> Any:
+                # The user's function is synchronous and may block or call
+                # back into this sync API; either would wedge the event loop
+                # delivering the call, so it runs on a worker thread.
+                import asyncio
+                return await asyncio.get_running_loop().run_in_executor(None, lambda: fn(*args))
+
+            self._loop.run(self._async.expose(name, _host))
+            return
         self._loop.run(self._async.expose(name, fn))
 
     # --- Emulation ---

--- a/tests/js/sync/engine/sync-api.test.js
+++ b/tests/js/sync/engine/sync-api.test.js
@@ -187,6 +187,33 @@ describe('Sync API: Evaluation', () => {
   });
 });
 
+describe('Sync API: Exposed functions', () => {
+
+  test('expose() with a host function returns its value to the page', () => {
+    const vibe = bro.page();
+    vibe.go(baseURL);
+    vibe.expose('syncAdd', (a, b) => a + b);
+    assert.strictEqual(vibe.evaluate('window.syncAdd(2, 3)'), 5);
+  });
+
+  test('a throwing host function rejects the page promise with its message', () => {
+    const vibe = bro.page();
+    vibe.go(baseURL);
+    vibe.expose('syncExplode', () => { throw new Error('no fuel'); });
+    assert.strictEqual(
+      vibe.evaluate('window.syncExplode().catch((e) => e.message)'),
+      'no fuel'
+    );
+  });
+
+  test('expose() with a string still injects JS source', () => {
+    const vibe = bro.page();
+    vibe.go(baseURL);
+    vibe.expose('syncDouble', '(n) => n * 2');
+    assert.strictEqual(vibe.evaluate('window.syncDouble(21)'), 42);
+  });
+});
+
 describe('Sync API: Element finding', () => {
 
   test('find() locates element by CSS selector', () => {

--- a/tests/py/engine/test_expose.py
+++ b/tests/py/engine/test_expose.py
@@ -1,0 +1,100 @@
+"""page.expose in both forms (#298).
+
+A string injects JS source that defines window[name] inside the page. A
+callable exposes a host function: the page calls window[name](*args), the
+callable runs in this process, and its return value resolves the page's
+promise via vibium:expose.call/result. The sync API additionally runs host
+functions on a worker thread, so they may call back into the sync API.
+"""
+
+import asyncio
+
+import pytest
+
+pytestmark = pytest.mark.capability("core")
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def expose_browser():
+    from vibium.async_api import browser
+    bro = await browser.start(headless=True)
+    yield bro
+    await bro.stop()
+
+
+async def test_source_form_defines_a_page_function(expose_browser):
+    vibe = await expose_browser.new_page()
+    await vibe.set_content("<p>x</p>")
+
+    await vibe.expose("vibium_double", "(n) => n * 2")
+    assert await vibe.evaluate("window.vibium_double(21)") == 42
+    await vibe.close()
+
+
+async def test_host_function_runs_and_returns_its_value(expose_browser):
+    vibe = await expose_browser.new_page()
+    await vibe.set_content("<p>x</p>")
+
+    await vibe.expose("vibium_add", lambda a, b: a + b)
+    assert await vibe.evaluate("window.vibium_add(2, 3)") == 5
+    await vibe.close()
+
+
+async def test_async_host_function_and_object_result(expose_browser):
+    vibe = await expose_browser.new_page()
+    await vibe.set_content("<p>x</p>")
+
+    async def lookup(key):
+        await asyncio.sleep(0.02)
+        return {"key": key, "found": True}
+
+    await vibe.expose("vibium_lookup", lookup)
+    result = await vibe.evaluate("window.vibium_lookup('user')")
+    assert result == {"key": "user", "found": True}
+    await vibe.close()
+
+
+async def test_host_error_rejects_the_page_promise(expose_browser):
+    vibe = await expose_browser.new_page()
+    await vibe.set_content("<p>x</p>")
+
+    def explode():
+        raise RuntimeError("no fuel")
+
+    await vibe.expose("vibium_explode", explode)
+    message = await vibe.evaluate("window.vibium_explode().catch((e) => e.message)")
+    assert message == "no fuel"
+    await vibe.close()
+
+
+async def test_host_function_survives_navigation_and_replacement(expose_browser, test_server):
+    vibe = await expose_browser.new_page()
+    await vibe.go(test_server + "/")
+
+    await vibe.expose("vibium_answer", lambda: "first")
+    await vibe.expose("vibium_answer", lambda: "second")
+    await vibe.reload()
+    assert await vibe.evaluate("window.vibium_answer()") == "second"
+    await vibe.close()
+
+
+def test_sync_host_function_can_call_the_sync_api(test_server):
+    # The host function runs on a worker thread, so calling back into the
+    # sync API from inside it must not deadlock the event loop delivering
+    # the call.
+    from vibium import browser
+
+    bro = browser.start(headless=True)
+    try:
+        vibe = bro.page()
+        vibe.go(test_server + "/")
+
+        def titled(prefix):
+            return prefix + ":" + vibe.title()
+
+        vibe.expose("vibium_titled", titled)
+        result = vibe.evaluate("window.vibium_titled('got')")
+        assert result.startswith("got:")
+    finally:
+        bro.stop()


### PR DESCRIPTION
Closes VibiumDev/vibium#298.

The remaining surfaces of the exposed-functions work: page.expose with a callable (Python), a Function<Object[], Object> (Java), or a function (JS sync client) registers a host function the page can call through window[name], completing what the engine and async JS client already ship. The string form keeps injecting JS source everywhere, and the CLI and MCP stay out on purpose: a one-shot invocation cannot host a callback.

Python and Java keep the function registry per connection, not per Page object, for the same reason the JS client does: browser.page() hands out a fresh Page instance for the same context on every call, and every instance sees every event, so an instance-scoped registry lets an empty instance answer "not exposed" for a sibling's function. One dispatcher per client executes each call once and replies once, with weak keys so a registry dies with its client.

Where the host function runs differs by surface, because it must not block the thread that delivers events. Java runs it on its own executor, since the event executor is single-threaded and a slow function would stall every later event. The Python sync API wraps it onto a worker thread, so a host function may block or call back into the sync API without deadlocking the event loop. The JS sync client routes the call over its callback bridge to the main thread; the bridge swallows handler exceptions, so outcomes travel in an envelope the worker unwraps, keeping a thrown host error a page-side rejection instead of a silent null.

Verified:
- Python: a new browser suite covers both forms, async host functions and object results, thrown errors carrying their message, navigation survival and replacement, and a sync host function that calls back into the sync API from inside the callback (6 tests)
- Java: ExposeTest grows host-function cases for the round trip, error propagation, and navigation-plus-replacement (5 tests)
- JS sync: round trip, error propagation through the bridge envelope, and the string form (sync suite, 75 tests)
- The API drift checker passes on every surface