### PR TITLE
Let agent tool calls pin a page instead of sharing one current tab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ test-js-engine: build-go
 # Run MCP server tests (sequential - browser sessions)
 test-mcp: build-go
 	@echo "--- MCP Server Tests ---"
-	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/mcp/server.test.js
+	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/mcp/server.test.js tests/mcp/page-pinning.test.js
 
 # Run daemon tests (sequential - daemon lifecycle)
 test-daemon: build-go

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -43,6 +43,13 @@ type Handlers struct {
 	downloadDir    string
 	lastElementBox *api.BoxInfo // stashed by AgentSession.SetLastElementBox via callback
 	activeContext  string       // last page context switched to or created
+	// pageOverride pins the current call to one browsing context: callers
+	// multiplexed over a single connection (concurrent MCP subagents) pass a
+	// page id so their commands stop landing on whatever page is globally
+	// current (#383). Set and cleared by Call; both transports serialize
+	// Call (the daemon under its router mutex, MCP by its stdio loop), so a
+	// per-call field is safe here, like lastElementBox above.
+	pageOverride string
 
 	// prompts records which contexts have an open user prompt, so a command
 	// Chrome will not answer fails immediately instead of timing out.
@@ -89,11 +96,20 @@ func NewHandlers(screenshotDir string, engine string, headless bool, connectURL 
 	}
 }
 
+// currentContext is the browsing context this call targets: the pinned page
+// when the caller passed one, the ambient current page otherwise.
+func (h *Handlers) currentContext() string {
+	if h.pageOverride != "" {
+		return h.pageOverride
+	}
+	return h.activeContext
+}
+
 // newSession creates an AgentSession that writes element box info back to
 // h.lastElementBox so Call() can include it in RecordActionEnd.
 func (h *Handlers) newSession() *api.AgentSession {
 	s := api.NewAgentSession(h.client)
-	s.Context = h.activeContext
+	s.Context = h.currentContext()
 	s.Prompts = h.prompts
 	s.Navigations = h.navigations
 	s.OnBoxSet = func(box *api.BoxInfo) {
@@ -108,6 +124,17 @@ func (h *Handlers) newSession() *api.AgentSession {
 // screenshot after each non-recording action completes.
 func (h *Handlers) Call(name string, args map[string]interface{}) (*ToolsCallResult, error) {
 	log.Debug("tool call", "name", name, "args", args)
+
+	// A page argument pins this call to one browsing context. Validate it
+	// against the live tree so a stale id fails loudly here instead of the
+	// call silently acting on whatever page is current (#383).
+	if page, ok := args["page"].(string); ok && page != "" {
+		if err := h.checkPageOpen(page); err != nil {
+			return nil, err
+		}
+		h.pageOverride = page
+		defer func() { h.pageOverride = "" }()
+	}
 
 	// Inject a synthetic find trace event before selector-based actions
 	// so CLI recordings match the JS client's find→action pairs.
@@ -393,8 +420,30 @@ func (h *Handlers) recordFindStep(selector string) {
 	h.recorder.RecordActionEnd(callId, "", endTime, box)
 }
 
-// getContext returns the first browsing context from the browser tree, or "".
+// checkPageOpen verifies a caller-supplied page id names a live top-level
+// browsing context.
+func (h *Handlers) checkPageOpen(page string) error {
+	if h.client == nil {
+		return fmt.Errorf("page %q: browser is not running", page)
+	}
+	tree, err := h.client.GetTree()
+	if err != nil {
+		return fmt.Errorf("page %q: %w", page, err)
+	}
+	for _, c := range tree.Contexts {
+		if c.Context == page {
+			return nil
+		}
+	}
+	return fmt.Errorf("page %q not found; it may have been closed (browser_list_pages shows open pages)", page)
+}
+
+// getContext returns the pinned page when the caller passed one, else the
+// first browsing context from the browser tree, or "".
 func (h *Handlers) getContext() string {
+	if h.pageOverride != "" {
+		return h.pageOverride
+	}
 	if h.client == nil {
 		return ""
 	}
@@ -986,7 +1035,7 @@ func (h *Handlers) browserScreenshot(args map[string]interface{}) (*ToolsCallRes
 			}
 			return JSON.stringify({count: count});
 		}`
-		if _, err := h.client.CallFunction(h.activeContext, annotateScript, []interface{}{string(selectorsJSON)}); err != nil {
+		if _, err := h.client.CallFunction(h.currentContext(), annotateScript, []interface{}{string(selectorsJSON)}); err != nil {
 			return nil, fmt.Errorf("failed to annotate: %w", err)
 		}
 	}
@@ -1007,7 +1056,7 @@ func (h *Handlers) browserScreenshot(args map[string]interface{}) (*ToolsCallRes
 			document.querySelectorAll('.__vibium_annotation').forEach(el => el.remove());
 			return 'cleaned';
 		}`
-		h.client.CallFunction(h.activeContext, cleanupScript, nil)
+		h.client.CallFunction(h.currentContext(), cleanupScript, nil)
 	}
 
 	// If filename provided, save to file (only if screenshotDir is configured)
@@ -1388,7 +1437,7 @@ func (h *Handlers) browserEvaluate(args map[string]interface{}) (*ToolsCallResul
 		return nil, fmt.Errorf("expression is required")
 	}
 
-	result, err := h.client.Evaluate(h.activeContext, expression)
+	result, err := h.client.Evaluate(h.currentContext(), expression)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate: %w", err)
 	}
@@ -1457,9 +1506,10 @@ func (h *Handlers) browserNewPage(args map[string]interface{}) (*ToolsCallResult
 	}
 	h.activeContext = contextID
 
-	msg := "New page opened"
+	// The id lets a caller pin later calls to this page (#383).
+	msg := fmt.Sprintf("New page opened (page: %s)", contextID)
 	if url != "" {
-		msg = fmt.Sprintf("New page opened and navigated to %s", url)
+		msg = fmt.Sprintf("New page opened and navigated to %s (page: %s)", url, contextID)
 	}
 
 	return &ToolsCallResult{
@@ -1484,7 +1534,7 @@ func (h *Handlers) browserListPages(args map[string]interface{}) (*ToolsCallResu
 
 	var text string
 	for i, page := range pages {
-		text += fmt.Sprintf("[%d] %s\n", i, page.URL)
+		text += fmt.Sprintf("[%d] %s (page: %s)\n", i, page.URL, page.Context)
 	}
 	if text == "" {
 		text = "No pages open"
@@ -1857,7 +1907,7 @@ func (h *Handlers) browserFindAll(args map[string]interface{}) (*ToolsCallResult
 		}
 		return JSON.stringify(results);
 	}`
-	result, err := h.client.CallFunction(h.activeContext, findAllScript, []interface{}{selector, limit})
+	result, err := h.client.CallFunction(h.currentContext(), findAllScript, []interface{}{selector, limit})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find elements: %w", err)
 	}
@@ -2254,7 +2304,7 @@ func pollCallFunction(h *Handlers, script string, args []interface{}, timeout ti
 	interval := 100 * time.Millisecond
 
 	for {
-		result, err := h.client.CallFunction(h.activeContext, script, args)
+		result, err := h.client.CallFunction(h.currentContext(), script, args)
 		if err == nil && result != nil {
 			s := fmt.Sprintf("%v", result)
 			if s != "" && s != "null" && s != "<nil>" {
@@ -2919,7 +2969,7 @@ func (h *Handlers) browserMap(args map[string]interface{}) (*ToolsCallResult, er
 	if sel, ok := args["selector"].(string); ok && sel != "" {
 		scopeSelector = sel
 	}
-	result, err := h.client.CallFunction(h.activeContext, mapScript(), []interface{}{scopeSelector})
+	result, err := h.client.CallFunction(h.currentContext(), mapScript(), []interface{}{scopeSelector})
 	if err != nil {
 		return nil, fmt.Errorf("failed to map elements: %w", err)
 	}
@@ -3080,7 +3130,7 @@ func (h *Handlers) browserHighlight(args map[string]interface{}) (*ToolsCallResu
 		return 'highlighted';
 	}`
 
-	result, err := h.client.CallFunction(h.activeContext, script, []interface{}{selector})
+	result, err := h.client.CallFunction(h.currentContext(), script, []interface{}{selector})
 	if err != nil {
 		return nil, fmt.Errorf("failed to highlight: %w", err)
 	}
@@ -4304,7 +4354,7 @@ func (h *Handlers) browserStorageState(args map[string]interface{}) (*ToolsCallR
 		})()
 	})`
 
-	storageResult, err := h.client.Evaluate(h.activeContext, script)
+	storageResult, err := h.client.Evaluate(h.currentContext(), script)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get storage: %w", err)
 	}
@@ -4391,7 +4441,7 @@ func (h *Handlers) browserRestoreStorage(args map[string]interface{}) (*ToolsCal
 			}
 			return 'ok';
 		})()`, string(storageJSON))
-		if _, err := h.client.Evaluate(h.activeContext, script); err != nil {
+		if _, err := h.client.Evaluate(h.currentContext(), script); err != nil {
 			return nil, fmt.Errorf("failed to restore storage: %w", err)
 		}
 	}

--- a/clicker/internal/agent/page_param_test.go
+++ b/clicker/internal/agent/page_param_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import "testing"
+
+// Every page-scoped tool advertises the page argument, and the exclusion
+// list holds only session lifecycle, page management, recording control, and
+// plain waits (#383). Injection happens centrally in GetToolSchemas, so a
+// new tool gets the argument unless it is deliberately listed.
+func TestPageParamOnEveryPageScopedTool(t *testing.T) {
+	tools := GetToolSchemas()
+	names := make(map[string]bool, len(tools))
+
+	for _, tool := range tools {
+		names[tool.Name] = true
+		props, ok := tool.InputSchema["properties"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s: schema has no properties object", tool.Name)
+		}
+		_, hasPage := props["page"]
+		if noPageParam[tool.Name] && hasPage {
+			t.Errorf("%s is listed as not page-scoped but has a page argument", tool.Name)
+		}
+		if !noPageParam[tool.Name] && !hasPage {
+			t.Errorf("%s should accept a page argument", tool.Name)
+		}
+	}
+
+	// A stale exclusion entry would silently stop guarding anything.
+	for name := range noPageParam {
+		if !names[name] {
+			t.Errorf("noPageParam lists %q, which is not a tool", name)
+		}
+	}
+}
+
+// A page argument without a running browser fails loudly instead of falling
+// through to whatever the ambient page would have been.
+func TestPageArgumentWithoutBrowserFails(t *testing.T) {
+	h := NewHandlers("", "chrome", true, "", nil)
+	_, err := h.Call("browser_get_url", map[string]interface{}{"page": "no-such-page"})
+	if err == nil {
+		t.Fatal("a page argument with no browser must error")
+	}
+}

--- a/clicker/internal/agent/schema.go
+++ b/clicker/internal/agent/schema.go
@@ -1,8 +1,29 @@
 package agent
 
+// noPageParam lists the tools that are not scoped to a page: session
+// lifecycle, page management, recording control, and plain waits. Every
+// other tool accepts an optional page argument (added in GetToolSchemas)
+// that pins the call to one browsing context (#383).
+var noPageParam = map[string]bool{
+	"browser_start":              true,
+	"browser_stop":               true,
+	"browser_new_page":           true,
+	"browser_list_pages":         true,
+	"browser_switch_page":        true,
+	"browser_close_page":         true,
+	"browser_sleep":              true,
+	"browser_record_start":       true,
+	"browser_record_stop":        true,
+	"browser_record_start_group": true,
+	"browser_record_stop_group":  true,
+	"browser_record_start_chunk": true,
+	"browser_record_stop_chunk":  true,
+	"browser_download_set_dir":   true,
+}
+
 // GetToolSchemas returns the list of available MCP tools with their schemas.
 func GetToolSchemas() []Tool {
-	return []Tool{
+	tools := []Tool{
 		{
 			Name:        "browser_start",
 			Description: "Start a browser session",
@@ -1564,4 +1585,22 @@ func GetToolSchemas() []Tool {
 			},
 		},
 	}
+
+	// One definition of the page argument for every page-scoped tool, added
+	// here instead of once per literal so a new tool cannot forget it.
+	for i := range tools {
+		if noPageParam[tools[i].Name] {
+			continue
+		}
+		props, ok := tools[i].InputSchema["properties"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		props["page"] = map[string]interface{}{
+			"type": "string",
+			"description": "Page id (from browser_new_page or browser_list_pages) that pins this call to that page instead of the globally current one. " +
+				"Concurrent callers sharing this server should create their own page and pass its id on every call.",
+		}
+	}
+	return tools
 }

--- a/tests/mcp/page-pinning.test.js
+++ b/tests/mcp/page-pinning.test.js
@@ -1,0 +1,147 @@
+/**
+ * MCP Tests: pinning tool calls to a page
+ *
+ * Concurrent callers multiplexed over one MCP connection used to share a
+ * single ambient "current page", so one caller's navigate moved the page
+ * under another caller's click. Page-scoped tools now take an optional page
+ * argument that pins the call to that browsing context, and a stale id
+ * fails loudly instead of acting on whatever page is current (#383).
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawn, execFileSync } = require('node:child_process');
+const { VIBIUM } = require('../helpers');
+
+class MCPClient {
+  constructor() {
+    this.proc = null;
+    this.buffer = '';
+    this.responses = [];
+    this.resolvers = [];
+  }
+
+  start() {
+    return new Promise((resolve, reject) => {
+      this.proc = spawn(VIBIUM, ['mcp', '--headless'], { stdio: ['pipe', 'pipe', 'pipe'] });
+      this.proc.stdout.on('data', (data) => {
+        this.buffer += data.toString();
+        const lines = this.buffer.split('\n');
+        this.buffer = lines.pop();
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const response = JSON.parse(line);
+            if (this.resolvers.length > 0) this.resolvers.shift()(response);
+            else this.responses.push(response);
+          } catch { /* non-JSON line */ }
+        }
+      });
+      this.proc.on('error', reject);
+      setTimeout(resolve, 100);
+    });
+  }
+
+  async call(method, params = {}) {
+    const id = Date.now() + Math.random();
+    this.proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    const response = await new Promise((resolve, reject) => {
+      if (this.responses.length > 0) return resolve(this.responses.shift());
+      const timer = setTimeout(() => reject(new Error('Timeout waiting for response')), 120000);
+      this.resolvers.push((r) => { clearTimeout(timer); resolve(r); });
+    });
+    assert.strictEqual(response.id, id);
+    return response;
+  }
+
+  async tool(name, args = {}) {
+    const response = await this.call('tools/call', { name, arguments: args });
+    return response.result;
+  }
+
+  stop() {
+    if (!this.proc) return;
+    if (process.platform === 'win32') {
+      try { execFileSync('taskkill', ['/T', '/F', '/PID', this.proc.pid.toString()], { stdio: 'ignore' }); } catch {}
+    } else {
+      this.proc.kill();
+    }
+    this.proc = null;
+  }
+}
+
+function text(result) {
+  return (result.content || []).map((c) => c.text || '').join('');
+}
+
+function pageIdFrom(result) {
+  const match = text(result).match(/\(page: ([^)]+)\)/);
+  assert.ok(match, `expected a page id in: ${text(result)}`);
+  return match[1];
+}
+
+const URL_A = 'data:text/html,<title>page-a</title><h1 id="h">A</h1>';
+const URL_B = 'data:text/html,<title>page-b</title><h1 id="h">B</h1>';
+
+let client;
+
+describe('MCP: page pinning', () => {
+  before(async () => {
+    client = new MCPClient();
+    await client.start();
+    await client.call('initialize', { capabilities: {} });
+  });
+
+  after(() => {
+    client.stop();
+  });
+
+  test('a pinned call targets its page, not the globally current one', async () => {
+    const pageA = pageIdFrom(await client.tool('browser_new_page', { url: URL_A }));
+    const pageB = pageIdFrom(await client.tool('browser_new_page', { url: URL_B }));
+    assert.notStrictEqual(pageA, pageB);
+
+    // Page B is globally current (last created). Pinned reads must not care.
+    const urlA = text(await client.tool('browser_get_url', { page: pageA }));
+    const urlB = text(await client.tool('browser_get_url', { page: pageB }));
+    assert.match(urlA, /page-a/, 'pinned to A must read A');
+    assert.match(urlB, /page-b/, 'pinned to B must read B');
+
+    // Unpinned calls keep today's ambient behavior.
+    const ambient = text(await client.tool('browser_get_url', {}));
+    assert.match(ambient, /page-b/, 'no page argument means the current page');
+  });
+
+  test('a pinned navigate moves its page and leaves the current one alone', async () => {
+    const pageA = pageIdFrom(await client.tool('browser_new_page', { url: URL_A }));
+    const pageB = pageIdFrom(await client.tool('browser_new_page', { url: URL_B }));
+
+    await client.tool('browser_navigate', {
+      page: pageA,
+      url: 'data:text/html,<title>page-a2</title>',
+    });
+
+    assert.match(text(await client.tool('browser_get_title', { page: pageA })), /page-a2/);
+    assert.match(text(await client.tool('browser_get_title', { page: pageB })), /page-b/, 'the other page must be untouched');
+    assert.match(text(await client.tool('browser_get_title', {})), /page-b/, 'the ambient page must not move on a pinned navigate');
+  });
+
+  test('a pinned evaluate and find run against the pinned page', async () => {
+    const pageA = pageIdFrom(await client.tool('browser_new_page', { url: URL_A }));
+    await client.tool('browser_new_page', { url: URL_B });
+
+    assert.match(text(await client.tool('browser_evaluate', { page: pageA, expression: 'document.title' })), /page-a/);
+    assert.match(text(await client.tool('browser_get_text', { page: pageA, selector: '#h' })), /A/);
+  });
+
+  test('a stale page id fails loudly instead of acting on the current page', async () => {
+    const result = await client.tool('browser_get_url', { page: 'gone-1234' });
+    assert.ok(result.isError, 'a bad page id must be an error');
+    assert.match(text(result), /not found/, 'the error should say the page is gone');
+  });
+
+  test('browser_list_pages includes the id to pin with', async () => {
+    const listing = text(await client.tool('browser_list_pages', {}));
+    assert.match(listing, /\(page: /, 'every row should carry the page id');
+  });
+});


### PR DESCRIPTION
Part of VibiumDev/vibium#383; the first of the two steps proposed there.

Every caller of the daemon and MCP engines shares a single ambient current page, so concurrent callers multiplexed over one connection silently collide: one caller's navigate moves the page under another caller's click, and checking the URL first cannot close the gap, because another caller can navigate between the check and the action. MCP tool calls carry no caller identity, so implicit per-caller stickiness is impossible; the fix is an explicit handle. Every page-scoped tool now takes an optional page argument that pins that call to one browsing context.

Absent, nothing changes: the call targets the ambient current page as always. Present, the id is validated against the live tree first, so a stale handle fails loudly instead of the call silently acting on whatever page is current — which also delivers the issue's fallback ask (detect the collision) for free. browser_new_page and browser_list_pages include the id in their output, and the argument's schema description tells concurrent callers to create their own page and pass its id on every call.

The argument is injected into the tool schemas centrally, with an exclusion list naming the tools that are not page-scoped (session lifecycle, page management, recording control, plain waits), so a new tool cannot forget it; a test locks the two lists together. The override rides a per-call field on the handlers, which is safe because both transports serialize tool calls: the daemon under its router mutex, MCP by its stdio loop.

One deliberate choice: a pinned navigate does not move the ambient current page. The pinned caller asked for isolation, and moving the shared pointer is exactly the collision this exists to stop.

The second step from the issue, cookie and storage isolation through named sessions backed by browser user contexts, builds on this and comes separately.

Verified:
- A new MCP suite drives two pages over one connection: pinned reads and navigates target their page and leave the other and the ambient page untouched, a stale id errors with "not found", and the page listing carries the ids (5 tests)
- A schema test asserts every page-scoped tool advertises the argument and that the exclusion list names only real tools
- The existing MCP suite (47 tests), the daemon suite (63 tests), the full Go suite, and the API drift checker pass