### PR TITLE
Fail loudly when the sync WebSocket echo server never starts

### DIFF
--- a/tests/py/engine/test_sync_websocket.py
+++ b/tests/py/engine/test_sync_websocket.py
@@ -16,6 +16,11 @@ def sync_ws_echo_server():
     loop = asyncio.new_event_loop()
     server = None
     port = None
+    error = None
+    # An Event instead of polling a variable: the old poll fell through
+    # silently after its timeout (or when the thread died on an exception)
+    # and yielded ws://127.0.0.1:None (#468).
+    ready = threading.Event()
 
     async def _start():
         nonlocal server, port
@@ -24,27 +29,43 @@ def sync_ws_echo_server():
             async for message in websocket:
                 await websocket.send(message)
 
-        srv = await websockets.serve(echo, "127.0.0.1", 0)
-        port = srv.sockets[0].getsockname()[1]
-        server = srv
-        await srv.wait_closed()
+        server = await websockets.serve(echo, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
 
     def _run():
-        loop.run_until_complete(_start())
+        nonlocal error
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(_start())
+            ready.set()
+            loop.run_forever()
+        except Exception as exc:
+            error = exc
+            ready.set()
+        finally:
+            loop.close()
 
     t = threading.Thread(target=_run, daemon=True)
     t.start()
 
-    # Wait for server to start
-    for _ in range(50):
-        if port is not None:
-            break
-        import time
-        time.sleep(0.1)
+    if not ready.wait(30):
+        pytest.fail("WebSocket echo server did not start within 30s")
+    if error is not None:
+        pytest.fail(f"WebSocket echo server failed to start: {error!r}")
 
     yield f"ws://127.0.0.1:{port}"
-    if server:
+
+    async def _stop():
         server.close()
+        # Without this, connection handlers still pending when the loop
+        # stops surface later as "coroutine ignored GeneratorExit" noise.
+        await server.wait_closed()
+
+    # The loop belongs to the server thread; closing from here raced it
+    # and left "Event loop is closed" noise in teardown.
+    asyncio.run_coroutine_threadsafe(_stop(), loop).result(timeout=10)
+    loop.call_soon_threadsafe(loop.stop)
+    t.join(timeout=10)
 
 
 def test_fires(sync_browser, test_server, sync_ws_echo_server):


### PR DESCRIPTION
Fixes VibiumDev/vibium#468

The sync_ws_echo_server fixture in tests/py/engine/test_sync_websocket.py polled a port variable for up to 5 seconds and fell through silently, either when the server thread had not bound in time or when it died on an exception. It then yielded ws://127.0.0.1:None and the first test failed with a confusing SyntaxError from the page (seen on main, chrome job, 2026-09-01). Teardown also called server.close() from the main thread against the server thread's loop and never joined the thread, leaving "Event loop is closed" noise.

Readiness is now a threading.Event: the fixture fails loudly with the timeout or the captured thread exception before any test runs. Teardown closes the server on its own loop via run_coroutine_threadsafe, awaits wait_closed so no connection handler is left pending, stops the loop, and joins the thread.

Verified:
- With the wait temporarily forced to time out, setup errors with "WebSocket echo server did not start within 30s" instead of yielding the None URL (the silent path fails on main by handing tests a garbage URL)
- tests/py/engine/test_sync_websocket.py passes 6/6 locally with no teardown warnings; an earlier draft that stopped the loop without awaiting wait_closed reproduced pending-coroutine noise, the awaited drain removed it