### PR TITLE
Add alert-only beta watch workflow for Firefox

### DIFF
--- a/.github/workflows/beta-watch.yml
+++ b/.github/workflows/beta-watch.yml
@@ -1,0 +1,149 @@
+# Alert-only early warning for browser beta releases (#469). Runs the full
+# Firefox suite against the current beta so breakage like Firefox 155
+# (#464) is found during the beta window, not on release day. Kept out of
+# test.yml on purpose: nothing here may ever gate a PR or a release, or
+# the reflex under pressure is to pin the beta away and lose the signal.
+name: Beta Watch
+
+on:
+  schedule:
+    - cron: '43 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: beta-watch
+  cancel-in-progress: false
+
+jobs:
+  firefox-beta:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      VIBIUM_REQUIRE_FIREFOX: 1
+      VIBIUM_ENGINE_CHANNEL: beta
+    outputs:
+      version: ${{ steps.beta.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve current Firefox beta version
+        id: beta
+        run: |
+          version=$(curl -fsSL https://product-details.mozilla.org/1.0/firefox_versions.json \
+            | jq -r '.LATEST_FIREFOX_DEVEL_VERSION')
+          test -n "$version"
+          test "$version" != "null"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Current Firefox beta: $version"
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: clicker/go.mod
+          cache-dependency-path: clicker/go.sum
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.9'
+          cache: pip
+          cache-dependency-path: |
+            clients/python/pyproject.toml
+            packages/python/vibium_linux_x64/pyproject.toml
+
+      - name: Set up Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: gradle
+
+      # Keyed on the beta version itself: a new beta means a fresh install,
+      # the same beta reuses yesterday's download.
+      - name: Cache Firefox beta
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/vibium/firefox/beta
+          key: ${{ runner.os }}-firefox-beta-${{ steps.beta.outputs.version }}
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm install --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('rollup/package.json').version")
+
+      - name: Build and install Firefox beta
+        run: |
+          make
+          make install-firefox
+
+      - name: Test Firefox capabilities
+        run: xvfb-run --auto-servernum make test-firefox-capabilities
+
+      - name: Test focused Firefox behavior
+        run: xvfb-run --auto-servernum make test-firefox
+
+      - name: Clean up zombie processes
+        if: always()
+        run: make double-tap
+
+  notify:
+    if: always()
+    needs: [firefox-beta]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+    steps:
+      - name: Open, update, or resolve the beta breakage issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RESULT: ${{ needs.firefox-beta.result }}
+          VERSION: ${{ needs.firefox-beta.outputs.version }}
+        with:
+          script: |
+            // Issues are titled per engine and version ("Firefox 156.0b3
+            // (beta) breaks the suite") so the next beta opens a fresh
+            // issue instead of burying new breakage in an old thread.
+            // When the chrome leg lands (#470) its titles start with
+            // "Chrome" and this prefix keeps the engines' issues apart.
+            const failed = process.env.RESULT !== 'success';
+            const version = process.env.VERSION;
+            const prefix = 'Firefox ';
+            const title = version
+              ? `Firefox ${version} (beta) breaks the suite`
+              : 'Firefox beta watch failed before the suite ran';
+            try {
+              await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name: 'beta-watch' });
+            } catch {
+              await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo,
+                name: 'beta-watch', color: 'D93F0B', description: 'A browser beta breaks the suite' });
+            }
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: 'beta-watch', per_page: 100,
+            });
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            if (failed) {
+              const marker = open.find(issue => issue.title === title);
+              const body = `Firefox beta ${version || '(version unresolved)'} failed the suite.\n\n${run}`;
+              if (marker) await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: marker.number, body });
+              else await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['beta-watch'] });
+            } else {
+              for (const issue of open.filter(i => i.title.startsWith(prefix))) {
+                await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: issue.number, body: `Green again on beta ${version} in ${run}.` });
+                await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: issue.number, state: 'closed' });
+              }
+            }


### PR DESCRIPTION
Part of VibiumDev/vibium#469; item 3 there, split out because it needs no product code.

Firefox 155 broke every vibium install on its release day (VibiumDev/vibium#464), and Firefox now ships biweekly, so the beta window is the only time left to find breakage before users get it. This adds beta-watch.yml: a daily job that resolves the current beta from Mozilla's product-details JSON, installs it through the existing VIBIUM_ENGINE_CHANNEL=beta path, and runs the capability and full Firefox suites.

Deliberately alert-only and outside test.yml: nothing here gates a PR or a release, so there is never pressure to pin a red beta away and lose the signal. The notify job follows the nightly failure-issue pattern: a beta-watch labeled issue titled after the breaking version ("Firefox 156.0b3 (beta) breaks the suite"), so each new beta surfaces as a fresh issue; repeat failures comment on it, and a green run comments and closes. Titles are engine-prefixed so the Chrome leg (VibiumDev/vibium#470) can share the label later. The Firefox cache is keyed on the resolved beta version: a new beta means a fresh install, the same beta reuses yesterday's download.

Verified:
- Workflow YAML parses; job steps and pinned action SHAs mirror the firefox job in test.yml
- The resolve step's curl+jq returns 156.0b2 against live product-details today
- VIBIUM_ENGINE_CHANNEL=beta install and the per-channel cache dir (~/.cache/vibium/firefox/beta) already exist in the installer, no product change needed
- A live run needs the schedule or workflow_dispatch, which only work once the file is on the default branch, so first execution is post-merge; happy to babysit the first dispatch