### PR TITLE
Honor VIBIUM_ENGINE_VERSION and VIBIUM_ENGINE_CHANNEL for Chrome

### DIFF
--- a/clicker/cmd/clicker/daemon_client.go
+++ b/clicker/cmd/clicker/daemon_client.go
@@ -63,7 +63,7 @@ func requestedLaunchOptions() map[string]interface{} {
 		args["engine"] = engineName
 	}
 	if channelSet {
-		channel := firefoxChannel
+		channel := engineChannel
 		if channel == "" {
 			channel = paths.FirefoxChannel()
 		}

--- a/clicker/cmd/clicker/daemon_client_test.go
+++ b/clicker/cmd/clicker/daemon_client_test.go
@@ -6,10 +6,10 @@ import (
 )
 
 func TestRequestedLaunchOptionsOnlyIncludesExplicitValues(t *testing.T) {
-	oldHeadless, oldEngine, oldChannel := headless, engineName, firefoxChannel
+	oldHeadless, oldEngine, oldChannel := headless, engineName, engineChannel
 	oldHeadlessSet, oldEngineSet, oldChannelSet := headlessSet, engineSet, channelSet
 	t.Cleanup(func() {
-		headless, engineName, firefoxChannel = oldHeadless, oldEngine, oldChannel
+		headless, engineName, engineChannel = oldHeadless, oldEngine, oldChannel
 		headlessSet, engineSet, channelSet = oldHeadlessSet, oldEngineSet, oldChannelSet
 	})
 
@@ -45,7 +45,7 @@ func TestRequestedLaunchOptionsOnlyIncludesExplicitValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			headless = tt.headless
 			engineName = tt.engine
-			firefoxChannel = tt.channel
+			engineChannel = tt.channel
 			headlessSet, engineSet, channelSet = tt.headlessSet, tt.engineSet, tt.channelSet
 			if got := requestedLaunchOptions(); !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("requestedLaunchOptions() = %#v, want %#v", got, tt.want)

--- a/clicker/cmd/clicker/main.go
+++ b/clicker/cmd/clicker/main.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vibium/clicker/internal/log"
@@ -35,7 +37,7 @@ var (
 	jsonOutput     bool
 	session        string
 	engineName     string
-	firefoxChannel string
+	engineChannel string
 	headlessSet    bool
 	engineSet      bool
 	channelSet     bool
@@ -73,29 +75,30 @@ func main() {
 			if engineName != "chrome" && engineName != "firefox" {
 				return fmt.Errorf("unsupported engine %q (supported: chrome, firefox)", engineName)
 			}
-			if firefoxChannel != "" && firefoxChannel != "release" && firefoxChannel != "beta" {
-				return fmt.Errorf("unsupported channel %q (supported: release, beta)", firefoxChannel)
-			}
-			// VIBIUM_ENGINE_CHANNEL, VIBIUM_ENGINE_PATH, and VIBIUM_ENGINE_VERSION are
-			// engine-neutral names but only Firefox implements them. Say so
-			// rather than accepting the setting and ignoring it.
-			if engineName != "firefox" {
-				for _, unsupported := range []struct{ name, value string }{
-					{"--channel/VIBIUM_ENGINE_CHANNEL", firefoxChannel},
-					{"VIBIUM_ENGINE_PATH", os.Getenv("VIBIUM_ENGINE_PATH")},
-					{"VIBIUM_ENGINE_VERSION", os.Getenv("VIBIUM_ENGINE_VERSION")},
-				} {
-					if unsupported.value != "" {
-						return fmt.Errorf("%s is not supported for engine %q (firefox only)", unsupported.name, engineName)
-					}
+			// Channels differ per engine: Mozilla's are release/beta, Chrome
+			// for Testing's are stable/beta/dev/canary.
+			if engineChannel != "" {
+				valid := map[string][]string{
+					"firefox": {"release", "beta"},
+					"chrome":  {"stable", "beta", "dev", "canary"},
+				}[engineName]
+				if !slices.Contains(valid, engineChannel) {
+					return fmt.Errorf("unsupported channel %q for %s (supported: %s)",
+						engineChannel, engineName, strings.Join(valid, ", "))
 				}
+			}
+			// VIBIUM_ENGINE_PATH is an engine-neutral name but only Firefox
+			// implements it. Say so rather than accepting the setting and
+			// ignoring it.
+			if engineName != "firefox" && os.Getenv("VIBIUM_ENGINE_PATH") != "" {
+				return fmt.Errorf("VIBIUM_ENGINE_PATH is not supported for engine %q (firefox only)", engineName)
 			}
 			// Bridge the flag to the env var, like --session: the paths
 			// package resolves the channel from the environment at both
 			// install and launch time, and a daemon child process spawned
 			// later inherits it.
-			if firefoxChannel != "" {
-				if err := os.Setenv("VIBIUM_ENGINE_CHANNEL", firefoxChannel); err != nil {
+			if engineChannel != "" {
+				if err := os.Setenv("VIBIUM_ENGINE_CHANNEL", engineChannel); err != nil {
 					return err
 				}
 			}
@@ -109,7 +112,7 @@ func main() {
 	// Add global flags for browser commands
 	rootCmd.PersistentFlags().BoolVar(&headless, "headless", false, "Hide browser window (visible by default)")
 	rootCmd.PersistentFlags().StringVar(&engineName, "engine", defaultEngine(), "Browser engine to launch: chrome or firefox (env: VIBIUM_ENGINE)")
-	rootCmd.PersistentFlags().StringVar(&firefoxChannel, "channel", os.Getenv("VIBIUM_ENGINE_CHANNEL"), "Engine release channel to install and run: release (default) or beta; Firefox only for now (env: VIBIUM_ENGINE_CHANNEL)")
+	rootCmd.PersistentFlags().StringVar(&engineChannel, "channel", os.Getenv("VIBIUM_ENGINE_CHANNEL"), "Engine release channel to install and run (env: VIBIUM_ENGINE_CHANNEL); firefox: release (default) or beta; chrome: stable (default), beta, dev, or canary")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logging")
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	rootCmd.PersistentFlags().StringVar(&session, "session", "", "Named daemon session for isolated concurrent use (env: VIBIUM_SESSION)")

--- a/clicker/internal/browser/installer.go
+++ b/clicker/internal/browser/installer.go
@@ -68,16 +68,20 @@ func Install() (*InstallResult, error) {
 
 	platform := paths.GetPlatformString()
 
-	// Fetch latest stable version info
-	versionInfo, err := fetchLatestStableVersion()
+	versionInfo, err := resolveChromeVersionInfo()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch version info: %w", err)
 	}
 
-	fmt.Printf("Installing Chrome for Testing v%s...\n", versionInfo.Version)
+	channel := paths.ChromeChannel()
+	if channel == "stable" {
+		fmt.Printf("Installing Chrome for Testing v%s...\n", versionInfo.Version)
+	} else {
+		fmt.Printf("Installing Chrome for Testing v%s (%s channel)...\n", versionInfo.Version, channel)
+	}
 
 	// Create version directory
-	cftDir, err := paths.GetChromeForTestingDir()
+	cftDir, err := paths.GetChromeChannelDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cache dir: %w", err)
 	}
@@ -139,8 +143,33 @@ func Install() (*InstallResult, error) {
 	}, nil
 }
 
-// fetchLatestStableVersion fetches the latest stable Chrome for Testing version.
-func fetchLatestStableVersion() (*VersionInfo, error) {
+// chromeChannelKeys maps VIBIUM_ENGINE_CHANNEL values to the channel names
+// used in the Chrome for Testing JSON.
+var chromeChannelKeys = map[string]string{
+	"stable": "Stable",
+	"beta":   "Beta",
+	"dev":    "Dev",
+	"canary": "Canary",
+}
+
+// resolveChromeVersionInfo returns the version to install:
+// VIBIUM_ENGINE_VERSION when set, otherwise the channel's current version.
+// Unlike Firefox there is no offline path for a pin: Chrome for Testing
+// download URLs come from its versions JSON, not a constructible pattern.
+func resolveChromeVersionInfo() (*VersionInfo, error) {
+	if v := os.Getenv("VIBIUM_ENGINE_VERSION"); v != "" {
+		return fetchVersionInfoFor(v)
+	}
+	return fetchChannelVersion(paths.ChromeChannel())
+}
+
+// fetchChannelVersion fetches the channel's current Chrome for Testing version.
+func fetchChannelVersion(channel string) (*VersionInfo, error) {
+	key, ok := chromeChannelKeys[channel]
+	if !ok {
+		return nil, fmt.Errorf("unknown Chrome channel %q (supported: stable, beta, dev, canary)", channel)
+	}
+
 	resp, err := http.Get(lastKnownGoodURL)
 	if err != nil {
 		return nil, err
@@ -156,12 +185,49 @@ func fetchLatestStableVersion() (*VersionInfo, error) {
 		return nil, err
 	}
 
-	stable, ok := data.Channels["Stable"]
+	info, ok := data.Channels[key]
 	if !ok {
-		return nil, fmt.Errorf("no Stable channel found")
+		return nil, fmt.Errorf("no %s channel found", key)
 	}
 
-	return &stable, nil
+	return &info, nil
+}
+
+// fetchVersionInfoFor returns download info for an exact version from the
+// known-good-versions list.
+func fetchVersionInfoFor(version string) (*VersionInfo, error) {
+	resp, err := http.Get(knownGoodVersionsURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var data struct {
+		Versions []VersionInfo `json:"versions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	info := findVersionInfo(data.Versions, version)
+	if info == nil {
+		return nil, fmt.Errorf("version %q not found in Chrome for Testing known good versions", version)
+	}
+	return info, nil
+}
+
+// findVersionInfo returns the entry matching version exactly, or nil.
+func findVersionInfo(versions []VersionInfo, version string) *VersionInfo {
+	for i := range versions {
+		if versions[i].Version == version {
+			return &versions[i]
+		}
+	}
+	return nil
 }
 
 // findDownloadURL finds the download URL for the given platform.
@@ -320,6 +386,10 @@ func extractVersionFromPath(path string) string {
 	parts := strings.Split(path, string(os.PathSeparator))
 	for i, part := range parts {
 		if part == "chrome-for-testing" && i+1 < len(parts) {
+			// Non-stable channels nest their version dirs one level deeper.
+			if ch := paths.ChromeChannel(); ch != "stable" && parts[i+1] == ch && i+2 < len(parts) {
+				return parts[i+2]
+			}
 			return parts[i+1]
 		}
 	}

--- a/clicker/internal/browser/installer_chrome_pin_test.go
+++ b/clicker/internal/browser/installer_chrome_pin_test.go
@@ -1,0 +1,31 @@
+package browser
+
+import (
+	"strings"
+	"testing"
+)
+
+// An unknown channel must fail before any network request, with the
+// supported values in the message.
+func TestFetchChannelVersionRejectsUnknownChannel(t *testing.T) {
+	_, err := fetchChannelVersion("nightly")
+	if err == nil {
+		t.Fatal("fetchChannelVersion(nightly): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "stable, beta, dev, canary") {
+		t.Errorf("error %q does not list the supported channels", err)
+	}
+}
+
+func TestFindVersionInfoMatchesExactly(t *testing.T) {
+	versions := []VersionInfo{
+		{Version: "140.0.7000.10"},
+		{Version: "140.0.7000.100"},
+	}
+	if got := findVersionInfo(versions, "140.0.7000.10"); got == nil || got.Version != "140.0.7000.10" {
+		t.Errorf("findVersionInfo(140.0.7000.10) = %v, want exact match", got)
+	}
+	if got := findVersionInfo(versions, "140.0.7000.1"); got != nil {
+		t.Errorf("findVersionInfo(140.0.7000.1) = %v, want nil for a prefix", got)
+	}
+}

--- a/clicker/internal/paths/paths.go
+++ b/clicker/internal/paths/paths.go
@@ -70,6 +70,33 @@ func GetChromeForTestingDir() (string, error) {
 	return filepath.Join(cacheDir, "chrome-for-testing"), nil
 }
 
+// ChromeChannel returns the Chrome release channel to install and run.
+// Defaults to "stable"; override with VIBIUM_ENGINE_CHANNEL (e.g. "beta").
+// The same variable steers the Firefox channel, so an engine-agnostic
+// "beta" selects each engine's beta.
+func ChromeChannel() string {
+	if c := os.Getenv("VIBIUM_ENGINE_CHANNEL"); c != "" {
+		return c
+	}
+	return "stable"
+}
+
+// GetChromeChannelDir returns the directory holding the channel's version
+// dirs. Stable keeps the historical chrome-for-testing root so existing
+// caches stay valid; other channels nest one level deeper, which also keeps
+// a beta's higher version number from shadowing stable under the
+// newest-first resolution below.
+func GetChromeChannelDir() (string, error) {
+	cftDir, err := GetChromeForTestingDir()
+	if err != nil {
+		return "", err
+	}
+	if ch := ChromeChannel(); ch != "stable" {
+		return filepath.Join(cftDir, ch), nil
+	}
+	return cftDir, nil
+}
+
 // resolveVersionDir returns the newest cached version directory containing BOTH
 // Chrome and chromedriver.
 //
@@ -79,10 +106,25 @@ func GetChromeForTestingDir() (string, error) {
 // failure surfaced later as chromedriver's "only supports Chrome version N"
 // (#265). Newest-first also replaces os.ReadDir's lexical order, under which
 // "99.0" sorts above "100.0".
+//
+// VIBIUM_ENGINE_VERSION pins the choice: the pinned version must also be
+// what launches, or newest-cached would silently run a different Chrome
+// than the pin installed.
 func resolveVersionDir() (string, error) {
-	cftDir, err := GetChromeForTestingDir()
+	cftDir, err := GetChromeChannelDir()
 	if err != nil {
 		return "", err
+	}
+
+	if v := os.Getenv("VIBIUM_ENGINE_VERSION"); v != "" {
+		dir := filepath.Join(cftDir, v)
+		if _, err := os.Stat(getChromePathInVersion(dir)); err != nil {
+			return "", err
+		}
+		if _, err := os.Stat(getChromedriverPathInVersion(dir)); err != nil {
+			return "", err
+		}
+		return dir, nil
 	}
 
 	entries, err := os.ReadDir(cftDir)

--- a/clicker/internal/paths/paths_chrome_channel_test.go
+++ b/clicker/internal/paths/paths_chrome_channel_test.go
@@ -1,0 +1,96 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// installFakeChrome creates the files resolveVersionDir requires (both Chrome
+// and chromedriver) inside cacheDir under the given channel-relative segments.
+func installFakeChrome(t *testing.T, cacheDir string, segments ...string) {
+	t.Helper()
+	dir := filepath.Join(append([]string{cacheDir, "chrome-for-testing"}, segments...)...)
+	for _, p := range []string{getChromePathInVersion(dir), getChromedriverPathInVersion(dir)} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("fake"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestResolveVersionDirHonorsPin(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("VIBIUM_CACHE_DIR", cache)
+	installFakeChrome(t, cache, "140.0.7000.10")
+	installFakeChrome(t, cache, "141.0.7100.20")
+
+	// Unpinned picks the newest complete version.
+	dir, err := resolveVersionDir()
+	if err != nil {
+		t.Fatalf("resolveVersionDir() error = %v", err)
+	}
+	if got := filepath.Base(dir); got != "141.0.7100.20" {
+		t.Errorf("unpinned resolveVersionDir() = %s, want 141.0.7100.20", got)
+	}
+
+	// A pin selects that version even with a newer one cached.
+	t.Setenv("VIBIUM_ENGINE_VERSION", "140.0.7000.10")
+	dir, err = resolveVersionDir()
+	if err != nil {
+		t.Fatalf("pinned resolveVersionDir() error = %v", err)
+	}
+	if got := filepath.Base(dir); got != "140.0.7000.10" {
+		t.Errorf("pinned resolveVersionDir() = %s, want 140.0.7000.10", got)
+	}
+
+	// A pin on a version that is not cached fails instead of silently
+	// falling back to whatever is newest.
+	t.Setenv("VIBIUM_ENGINE_VERSION", "139.0.6900.1")
+	if _, err := resolveVersionDir(); err == nil {
+		t.Error("resolveVersionDir() with missing pinned version: want error, got nil")
+	}
+}
+
+func TestChromeChannelDirsAreSeparate(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("VIBIUM_CACHE_DIR", cache)
+	installFakeChrome(t, cache, "141.0.7100.20")
+	// A beta with a higher version number than stable.
+	installFakeChrome(t, cache, "beta", "142.0.7200.5")
+
+	// Stable resolution must not pick up the beta despite its higher version.
+	dir, err := resolveVersionDir()
+	if err != nil {
+		t.Fatalf("stable resolveVersionDir() error = %v", err)
+	}
+	if got := filepath.Base(dir); got != "141.0.7100.20" {
+		t.Errorf("stable resolveVersionDir() = %s, want 141.0.7100.20", got)
+	}
+
+	// Beta resolution sees only the beta subdirectory.
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "beta")
+	dir, err = resolveVersionDir()
+	if err != nil {
+		t.Fatalf("beta resolveVersionDir() error = %v", err)
+	}
+	if got := filepath.Base(dir); got != "142.0.7200.5" {
+		t.Errorf("beta resolveVersionDir() = %s, want 142.0.7200.5", got)
+	}
+	if got := filepath.Base(filepath.Dir(dir)); got != "beta" {
+		t.Errorf("beta version dir parent = %s, want beta", got)
+	}
+}
+
+func TestChromeChannelDefaultsToStable(t *testing.T) {
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "")
+	if got := ChromeChannel(); got != "stable" {
+		t.Errorf("ChromeChannel() = %q, want stable", got)
+	}
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "beta")
+	if got := ChromeChannel(); got != "beta" {
+		t.Errorf("ChromeChannel() = %q, want beta", got)
+	}
+}

--- a/skills/vibe-check/SKILL.md
+++ b/skills/vibe-check/SKILL.md
@@ -369,7 +369,7 @@ Refs (`@e1`, `@e2`) are invalidated when the page changes. Always re-map after:
 | Flag | Description |
 |------|-------------|
 | `--engine <name>` | Browser engine: `chrome` (default) or `firefox` (env: `VIBIUM_ENGINE`) |
-| `--channel <ch>` | Engine release channel: `release` (default) or `beta` — Firefox only (env: `VIBIUM_ENGINE_CHANNEL`) |
+| `--channel <ch>` | Engine release channel — Firefox: `release` (default) or `beta`; Chrome: `stable` (default), `beta`, `dev`, or `canary` (env: `VIBIUM_ENGINE_CHANNEL`) |
 | `--headless` | Hide browser window |
 | `--json` | Output as JSON |
 | `-v, --verbose` | Debug logging |

--- a/tests/js/async/firefox.test.js
+++ b/tests/js/async/firefox.test.js
@@ -299,4 +299,47 @@ describe('JS Firefox', () => {
         `Channel "${channel}" should pass CLI validation`);
     }
   });
+
+  test('--channel accepts the Chrome channels for chrome (#470)', (t) => {
+    const bin = process.env.VIBIUM_BIN_PATH;
+    if (!bin) return skipOrFail(t, 'VIBIUM_BIN_PATH not set');
+
+    for (const channel of ['stable', 'beta', 'dev', 'canary']) {
+      let stderr = '';
+      try {
+        execFileSync(bin, ['is-installed', '--engine', 'chrome', '--channel', channel],
+          { stdio: 'pipe' });
+      } catch (err) {
+        stderr = err.stderr.toString();
+      }
+      assert.ok(!/unsupported channel|not supported for engine/.test(stderr),
+        `Chrome channel "${channel}" should pass CLI validation`);
+    }
+
+    // Firefox's channel names stay Firefox's: release is not a Chrome channel.
+    assert.throws(
+      () => execFileSync(bin,
+        ['is-installed', '--engine', 'chrome', '--channel', 'release'],
+        { stdio: 'pipe' }),
+      (err) => /unsupported channel/.test(err.stderr.toString()),
+      'Channel "release" should be rejected for chrome'
+    );
+  });
+
+  test('VIBIUM_ENGINE_VERSION passes CLI validation for chrome (#470)', (t) => {
+    const bin = process.env.VIBIUM_BIN_PATH;
+    if (!bin) return skipOrFail(t, 'VIBIUM_BIN_PATH not set');
+
+    let stderr = '';
+    try {
+      execFileSync(bin, ['is-installed', '--engine', 'chrome'], {
+        stdio: 'pipe',
+        env: { ...process.env, VIBIUM_ENGINE_VERSION: '140.0.7000.10' },
+      });
+    } catch (err) {
+      stderr = err.stderr.toString();
+    }
+    assert.ok(!/not supported for engine/.test(stderr),
+      'A version pin should pass CLI validation for chrome');
+  });
 });


### PR DESCRIPTION
Part of VibiumDev/vibium#470; item 1 there, the standalone piece.

The Chrome installer always fetched the latest Stable at install time, untested by vibium, and unlike Firefox offered no pin or channel: the CLI rejected VIBIUM_ENGINE_VERSION and VIBIUM_ENGINE_CHANNEL as "firefox only". A user hit by a bad Chrome release had no way to install an older version through vibium.

VIBIUM_ENGINE_VERSION now installs and launches that exact version, resolved against the known-good-versions list so an unknown version fails with a clear error instead of a 404 mid-download. VIBIUM_ENGINE_CHANNEL selects a Chrome for Testing channel (stable, beta, dev, canary), mirroring the Firefox contract and giving the coming beta-watch Chrome leg its install path. Two deliberate choices:

- Stable keeps the historical chrome-for-testing cache layout so every existing install stays valid; non-stable channels nest their version dirs one level deeper, which also keeps a beta's higher version number from shadowing stable under newest-first resolution (the lesson from the Firefox channel dirs).
- A pin steers launch resolution too, not just the download, or newest-cached would silently run a different Chrome than the pin installed (mirrors resolveFirefoxVersionDir).

CLI --channel validation is per engine now (firefox: release/beta; chrome: stable/beta/dev/canary) and VIBIUM_ENGINE_PATH stays firefox-only since Chrome resolution does not implement it. The MCP launch tool's channel argument stays firefox-only too; wiring it for chrome is a follow-up with its own relaunch-mismatch semantics.

Verified:
- New hermetic Go tests (VIBIUM_CACHE_DIR temp cache): a pin beats a newer cached version and fails loudly when absent; beta and stable resolve from separate dirs with a higher-versioned beta not shadowing stable; unknown channel errors before any network call; exact-version lookup rejects prefixes
- New CLI tests fail against a main-built binary (chrome + channel/version rejected as "not supported for engine") and pass with this diff; the existing firefox channel validation tests still pass
- Full clicker go test ./... green