### PR TITLE
Give concurrent agents isolated pages and per-page element refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ test-js-engine: build-go
 # Run MCP server tests (sequential - browser sessions)
 test-mcp: build-go
 	@echo "--- MCP Server Tests ---"
-	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/mcp/server.test.js tests/mcp/page-pinning.test.js
+	VIBIUM_ENGINE=$(ENGINE) $(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/mcp/server.test.js tests/mcp/page-pinning.test.js tests/mcp/page-isolation.test.js
 
 # Run daemon tests (sequential - daemon lifecycle)
 test-daemon: build-go

--- a/clicker/cmd/clicker/page.go
+++ b/clicker/cmd/clicker/page.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -18,6 +16,7 @@ func newPageCmd() *cobra.Command {
 		},
 	}
 
+	var isolated bool
 	newCmd := &cobra.Command{
 		Use:   "new [url]",
 		Short: "Open a new browser page",
@@ -25,12 +24,19 @@ func newPageCmd() *cobra.Command {
   # Open a blank new page
 
   vibium page new https://example.com
-  # Open a new page and navigate to URL`,
+  # Open a new page and navigate to URL
+
+  vibium page new --isolated https://example.com
+  # Open the page in its own isolated context (separate cookies/storage):
+  #   New isolated page opened and navigated to https://example.com (page: A1B2...)`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			toolArgs := map[string]interface{}{}
 			if len(args) == 1 {
 				toolArgs["url"] = args[0]
+			}
+			if isolated {
+				toolArgs["isolated"] = true
 			}
 
 			result, err := daemonCall("browser_new_page", toolArgs)
@@ -41,25 +47,29 @@ func newPageCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
+	newCmd.Flags().BoolVar(&isolated, "isolated", false, "Open the page in its own isolated context (separate cookies and storage)")
 
 	closeCmd := &cobra.Command{
-		Use:   "close [index]",
-		Short: "Close a browser page by index (default: current page)",
+		Use:   "close [index or page id]",
+		Short: "Close a browser page by index or id (default: current page)",
 		Example: `  vibium page close
   # Close current page (index 0)
 
   vibium page close 1
-  # Close page at index 1`,
+  # Close page at index 1
+
+  vibium page close A1B2C3D4
+  # Close the page with that id (from "vibium page new")`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			toolArgs := map[string]interface{}{}
 			if len(args) == 1 {
-				idx, err := strconv.Atoi(args[0])
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error: invalid page index: %s\n", args[0])
-					os.Exit(1)
+				// An integer is an index; anything else is a page id.
+				if idx, err := strconv.Atoi(args[0]); err == nil {
+					toolArgs["index"] = float64(idx)
+				} else {
+					toolArgs["page"] = args[0]
 				}
-				toolArgs["index"] = float64(idx)
 			}
 
 			result, err := daemonCall("browser_close_page", toolArgs)

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -36,8 +36,8 @@ type Handlers struct {
 	connectURL     string            // remote BiDi WebSocket URL (empty = local browser)
 	connectHeaders http.Header       // headers for remote WebSocket connection
 	ownsRemote     bool              // remote session was created here, so Close() ends it
-	refMap         map[string]string // @e1 -> CSS selector
-	lastMap        string            // last map output (for diff)
+	refMaps        map[string]map[string]string // context -> @e1 -> CSS selector
+	lastMaps       map[string]string            // context -> last map output (for diff)
 	recorder       *api.Recorder
 	recordDropBase uint64 // client.DroppedEvents() at record start
 	downloadDir    string
@@ -458,6 +458,34 @@ func (h *Handlers) getContext() string {
 		return ""
 	}
 	return tree.Contexts[0].Context
+}
+
+// refKey is the browsing context whose element refs and map snapshot this
+// call reads and writes. Refs are scoped per page so concurrent callers
+// pinned to different pages cannot resolve each other's selectors (#383).
+// An ambient call with no tracked page resolves to the real current
+// context, so refs minted before any explicit page switch are still found
+// after switching back to that page.
+func (h *Handlers) refKey() string {
+	if ctx := h.currentContext(); ctx != "" {
+		return ctx
+	}
+	if h.client == nil {
+		return ""
+	}
+	tree, err := h.client.GetTree()
+	if err != nil || len(tree.Contexts) == 0 {
+		return ""
+	}
+	return tree.Contexts[0].Context
+}
+
+// setRefs replaces the ref table for one page.
+func (h *Handlers) setRefs(key string, refs map[string]string) {
+	if h.refMaps == nil {
+		h.refMaps = make(map[string]map[string]string)
+	}
+	h.refMaps[key] = refs
 }
 
 // queryViewport queries the browser for the current viewport size.
@@ -1008,11 +1036,12 @@ func (h *Handlers) browserScreenshot(args map[string]interface{}) (*ToolsCallRes
 			return nil, fmt.Errorf("failed to map for annotation: %w", err)
 		}
 
-		// Build ordered list of selectors from refMap (@e1, @e2, ...)
-		selectors := make([]string, 0, len(h.refMap))
-		for i := 1; i <= len(h.refMap); i++ {
+		// Build ordered list of selectors from this page's refs (@e1, @e2, ...)
+		refs := h.refMaps[h.refKey()]
+		selectors := make([]string, 0, len(refs))
+		for i := 1; i <= len(refs); i++ {
 			ref := fmt.Sprintf("@e%d", i)
-			if sel, ok := h.refMap[ref]; ok {
+			if sel, ok := refs[ref]; ok {
 				selectors = append(selectors, sel)
 			}
 		}
@@ -1163,9 +1192,8 @@ func (h *Handlers) browserFind(args map[string]interface{}) (*ToolsCallResult, e
 			return nil, fmt.Errorf("failed to parse find result: %w", err)
 		}
 
-		// Store ref in refMap
-		h.refMap = make(map[string]string)
-		h.refMap["@e1"] = found.Selector
+		// Store ref in this page's ref table
+		h.setRefs(h.refKey(), map[string]string{"@e1": found.Selector})
 
 		return &ToolsCallResult{
 			Content: []Content{{
@@ -1204,9 +1232,8 @@ func (h *Handlers) browserFind(args map[string]interface{}) (*ToolsCallResult, e
 		return nil, fmt.Errorf("element not found: %s (timeout %s)", selector, timeout)
 	}
 
-	// Store ref in refMap
-	h.refMap = make(map[string]string)
-	h.refMap["@e1"] = selector
+	// Store ref in this page's ref table
+	h.setRefs(h.refKey(), map[string]string{"@e1": selector})
 
 	labelStr := fmt.Sprintf("%v", labelResult)
 	return &ToolsCallResult{
@@ -1993,13 +2020,14 @@ func (h *Handlers) browserFindAll(args map[string]interface{}) (*ToolsCallResult
 	}
 
 	// Build ref map and output
-	h.refMap = make(map[string]string)
+	refs := make(map[string]string)
 	var lines []string
 	for i, el := range elements {
 		ref := fmt.Sprintf("@e%d", i+1)
-		h.refMap[ref] = el.Selector
+		refs[ref] = el.Selector
 		lines = append(lines, fmt.Sprintf("%s %s", ref, el.Label))
 	}
+	h.setRefs(h.refKey(), refs)
 
 	text := strings.Join(lines, "\n")
 	if text == "" {
@@ -2897,8 +2925,8 @@ func (h *Handlers) discardSession() {
 	h.client = nil
 	h.conn = nil
 	h.prompts = nil
-	h.refMap = nil
-	h.lastMap = ""
+	h.refMaps = nil
+	h.lastMaps = nil
 	h.activeContext = ""
 	h.ownedUserContexts = nil
 }
@@ -2922,10 +2950,12 @@ func (h *Handlers) resolveRefsInArgs(args map[string]interface{}) map[string]int
 	return cp
 }
 
-// resolveSelector resolves @ref selectors to CSS selectors from the refMap.
+// resolveSelector resolves @ref selectors to CSS selectors from this
+// page's ref table, so a pinned caller cannot pick up selectors another
+// caller's map minted on a different page (#383).
 func (h *Handlers) resolveSelector(selector string) string {
 	if strings.HasPrefix(selector, "@e") {
-		if resolved, ok := h.refMap[selector]; ok {
+		if resolved, ok := h.refMaps[h.refKey()][selector]; ok {
 			return resolved
 		}
 	}
@@ -3058,19 +3088,24 @@ func (h *Handlers) browserMap(args map[string]interface{}) (*ToolsCallResult, er
 	}
 
 	// Build ref map and output
-	h.refMap = make(map[string]string)
+	refs := make(map[string]string)
 	var lines []string
 	for i, el := range elements {
 		ref := fmt.Sprintf("@e%d", i+1)
-		h.refMap[ref] = el.Selector
+		refs[ref] = el.Selector
 		lines = append(lines, fmt.Sprintf("%s %s", ref, el.Label))
 	}
+	key := h.refKey()
+	h.setRefs(key, refs)
 
 	output := strings.Join(lines, "\n")
 	if output == "" {
 		output = "No interactive elements found"
 	}
-	h.lastMap = output
+	if h.lastMaps == nil {
+		h.lastMaps = make(map[string]string)
+	}
+	h.lastMaps[key] = output
 
 	return &ToolsCallResult{
 		Content: []Content{{
@@ -3080,19 +3115,20 @@ func (h *Handlers) browserMap(args map[string]interface{}) (*ToolsCallResult, er
 	}, nil
 }
 
-// browserDiffMap compares current page state vs last map.
+// browserDiffMap compares current page state vs this page's last map.
 func (h *Handlers) browserDiffMap(args map[string]interface{}) (*ToolsCallResult, error) {
-	if h.lastMap == "" {
+	key := h.refKey()
+	if h.lastMaps[key] == "" {
 		return nil, fmt.Errorf("no previous map to diff against — run browser_map first")
 	}
 
 	// Get current map
-	prevMap := h.lastMap
+	prevMap := h.lastMaps[key]
 	_, err := h.browserMap(args)
 	if err != nil {
 		return nil, err
 	}
-	currentMap := h.lastMap
+	currentMap := h.lastMaps[key]
 
 	// Simple line-based diff
 	prevLines := strings.Split(prevMap, "\n")

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -51,6 +51,12 @@ type Handlers struct {
 	// per-call field is safe here, like lastElementBox above.
 	pageOverride string
 
+	// ownedUserContexts holds the user contexts created for isolated pages
+	// (#383), so closing the last page of one also removes the context and
+	// its storage partition. Only mutated inside serialized Call paths, like
+	// pageOverride above.
+	ownedUserContexts map[string]bool
+
 	// prompts records which contexts have an open user prompt, so a command
 	// Chrome will not answer fails immediately instead of timing out.
 	prompts     *api.PromptTracker
@@ -674,6 +680,7 @@ func (h *Handlers) Close() {
 	ownsRemote := h.ownsRemote
 	h.conn, h.client, h.launchResult = nil, nil, nil
 	h.ownsRemote = false
+	h.ownedUserContexts = nil
 	recorder := h.recorder
 	h.recorder = nil
 	h.sessionMu.Unlock()
@@ -1494,11 +1501,31 @@ func (h *Handlers) browserNewPage(args map[string]interface{}) (*ToolsCallResult
 	}
 
 	url, _ := args["url"].(string)
+	isolated, _ := args["isolated"].(bool)
 
 	s := h.newSession()
-	contextID, err := api.NewPage(s, url)
+	userContext := ""
+	if isolated {
+		uc, err := api.NewUserContext(s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create isolated context: %w", err)
+		}
+		userContext = uc
+	}
+	contextID, err := api.NewPageInContext(s, url, userContext)
 	if err != nil {
+		if userContext != "" {
+			if rmErr := api.RemoveUserContext(s, userContext); rmErr != nil {
+				log.Warn("failed to remove isolated context after page creation failed", "userContext", userContext, "error", rmErr)
+			}
+		}
 		return nil, fmt.Errorf("failed to create page: %w", err)
+	}
+	if userContext != "" {
+		if h.ownedUserContexts == nil {
+			h.ownedUserContexts = make(map[string]bool)
+		}
+		h.ownedUserContexts[userContext] = true
 	}
 	// Activate and track the new page so subsequent commands target it
 	if err := api.SwitchPage(s, contextID); err != nil {
@@ -1507,9 +1534,13 @@ func (h *Handlers) browserNewPage(args map[string]interface{}) (*ToolsCallResult
 	h.activeContext = contextID
 
 	// The id lets a caller pin later calls to this page (#383).
-	msg := fmt.Sprintf("New page opened (page: %s)", contextID)
+	kind := "page"
+	if isolated {
+		kind = "isolated page"
+	}
+	msg := fmt.Sprintf("New %s opened (page: %s)", kind, contextID)
 	if url != "" {
-		msg = fmt.Sprintf("New page opened and navigated to %s (page: %s)", url, contextID)
+		msg = fmt.Sprintf("New %s opened and navigated to %s (page: %s)", kind, url, contextID)
 	}
 
 	return &ToolsCallResult{
@@ -1534,7 +1565,11 @@ func (h *Handlers) browserListPages(args map[string]interface{}) (*ToolsCallResu
 
 	var text string
 	for i, page := range pages {
-		text += fmt.Sprintf("[%d] %s (page: %s)\n", i, page.URL, page.Context)
+		isolated := ""
+		if h.ownedUserContexts[page.UserContext] {
+			isolated = " [isolated]"
+		}
+		text += fmt.Sprintf("[%d] %s (page: %s)%s\n", i, page.URL, page.Context, isolated)
 	}
 	if text == "" {
 		text = "No pages open"
@@ -1597,7 +1632,7 @@ func (h *Handlers) browserSwitchPage(args map[string]interface{}) (*ToolsCallRes
 	}, nil
 }
 
-// browserClosePage closes a page by index (default: current page).
+// browserClosePage closes a page by id or index (default: current page).
 func (h *Handlers) browserClosePage(args map[string]interface{}) (*ToolsCallResult, error) {
 	if err := h.ensureBrowser(); err != nil {
 		return nil, err
@@ -1613,27 +1648,36 @@ func (h *Handlers) browserClosePage(args map[string]interface{}) (*ToolsCallResu
 		return nil, fmt.Errorf("no pages open")
 	}
 
-	idx := -1
-	if i, ok := argFloat(args, "index"); ok {
-		idx = int(i)
-	} else if h.activeContext != "" {
-		// No index given — default to the active page
-		for i, page := range pages {
-			if page.Context == h.activeContext {
-				idx = i
-				break
+	var closedContext, label string
+	if page, ok := args["page"].(string); ok && page != "" {
+		// Already validated as live by Call, like any page argument.
+		closedContext = page
+		label = page
+	} else {
+		idx := -1
+		if i, ok := argFloat(args, "index"); ok {
+			idx = int(i)
+		} else if h.activeContext != "" {
+			// No index given — default to the active page
+			for i, page := range pages {
+				if page.Context == h.activeContext {
+					idx = i
+					break
+				}
 			}
 		}
-	}
-	if idx < 0 {
-		idx = 0 // fall back to first page
+		if idx < 0 {
+			idx = 0 // fall back to first page
+		}
+
+		if idx >= len(pages) {
+			return nil, fmt.Errorf("page index %d out of range (0-%d)", idx, len(pages)-1)
+		}
+
+		closedContext = pages[idx].Context
+		label = strconv.Itoa(idx)
 	}
 
-	if idx < 0 || idx >= len(pages) {
-		return nil, fmt.Errorf("page index %d out of range (0-%d)", idx, len(pages)-1)
-	}
-
-	closedContext := pages[idx].Context
 	if err := api.ClosePage(s, closedContext); err != nil {
 		return nil, err
 	}
@@ -1641,10 +1685,38 @@ func (h *Handlers) browserClosePage(args map[string]interface{}) (*ToolsCallResu
 		h.activeContext = ""
 	}
 
+	// Closing the last page of an isolated context removes the context too,
+	// so its storage partition does not outlive its pages.
+	note := ""
+	closedUserContext := ""
+	for _, page := range pages {
+		if page.Context == closedContext {
+			closedUserContext = page.UserContext
+			break
+		}
+	}
+	if h.ownedUserContexts[closedUserContext] {
+		lastInContext := true
+		for _, page := range pages {
+			if page.UserContext == closedUserContext && page.Context != closedContext {
+				lastInContext = false
+				break
+			}
+		}
+		if lastInContext {
+			if err := api.RemoveUserContext(s, closedUserContext); err != nil {
+				log.Warn("failed to remove isolated context", "userContext", closedUserContext, "error", err)
+			} else {
+				delete(h.ownedUserContexts, closedUserContext)
+				note = " and its isolated context"
+			}
+		}
+	}
+
 	return &ToolsCallResult{
 		Content: []Content{{
 			Type: "text",
-			Text: fmt.Sprintf("Closed page %d", idx),
+			Text: fmt.Sprintf("Closed page %s%s", label, note),
 		}},
 	}, nil
 }
@@ -2828,6 +2900,7 @@ func (h *Handlers) discardSession() {
 	h.refMap = nil
 	h.lastMap = ""
 	h.activeContext = ""
+	h.ownedUserContexts = nil
 }
 
 // resolveRefsInArgs returns a copy of args with any @ref selector resolved

--- a/clicker/internal/agent/schema.go
+++ b/clicker/internal/agent/schema.go
@@ -10,7 +10,6 @@ var noPageParam = map[string]bool{
 	"browser_new_page":           true,
 	"browser_list_pages":         true,
 	"browser_switch_page":        true,
-	"browser_close_page":         true,
 	"browser_sleep":              true,
 	"browser_record_start":       true,
 	"browser_record_stop":        true,
@@ -283,6 +282,11 @@ func GetToolSchemas() []Tool {
 						"type":        "string",
 						"description": "URL to navigate to in the new page (optional)",
 					},
+					"isolated": map[string]interface{}{
+						"type": "boolean",
+						"description": "Open the page in its own isolated context with separate cookies and storage (default: false). " +
+							"Concurrent callers sharing this server should open an isolated page and pass its id as the page argument on every call.",
+					},
 				},
 				"additionalProperties": false,
 			},
@@ -316,13 +320,13 @@ func GetToolSchemas() []Tool {
 		},
 		{
 			Name:        "browser_close_page",
-			Description: "Close a browser page by index (default: current page)",
+			Description: "Close a browser page by id or index (default: current page)",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
 					"index": map[string]interface{}{
 						"type":        "number",
-						"description": "Page index to close (default: 0, the current page)",
+						"description": "Page index to close (default: 0, the current page); ignored when a page id is given",
 						"default":     0,
 					},
 				},

--- a/clicker/internal/api/handlers_lifecycle.go
+++ b/clicker/internal/api/handlers_lifecycle.go
@@ -239,8 +239,17 @@ type PageInfo struct {
 
 // NewPage creates a new page and returns its context ID.
 func NewPage(s Session, url string) (string, error) {
+	return NewPageInContext(s, url, "")
+}
+
+// NewPageInContext creates a new page inside the given user context; an empty
+// userContext means the browser default.
+func NewPageInContext(s Session, url, userContext string) (string, error) {
 	params := map[string]interface{}{
 		"type": "tab",
+	}
+	if userContext != "" {
+		params["userContext"] = userContext
 	}
 	resp, err := s.SendBidiCommand("browsingContext.create", params)
 	if err != nil {
@@ -256,6 +265,32 @@ func NewPage(s Session, url string) (string, error) {
 		}
 	}
 	return context, nil
+}
+
+// NewUserContext creates a user context (isolated cookies/storage) and
+// returns its id.
+func NewUserContext(s Session) (string, error) {
+	resp, err := s.SendBidiCommand("browser.createUserContext", map[string]interface{}{})
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Result struct {
+			UserContext string `json:"userContext"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return "", fmt.Errorf("failed to parse createUserContext response: %w", err)
+	}
+	return result.Result.UserContext, nil
+}
+
+// RemoveUserContext closes a user context along with any pages still in it.
+func RemoveUserContext(s Session, userContext string) error {
+	_, err := s.SendBidiCommand("browser.removeUserContext", map[string]interface{}{
+		"userContext": userContext,
+	})
+	return err
 }
 
 // ListPages returns all browsing contexts (pages).

--- a/skills/vibe-check/SKILL.md
+++ b/skills/vibe-check/SKILL.md
@@ -177,8 +177,9 @@ vibium record stop
 ### Pages
 - `vibium pages` — list open pages
 - `vibium page new [url]` — open new page
+- `vibium page new --isolated [url]` — open page with its own cookies/storage
 - `vibium page switch <index|url>` — switch page
-- `vibium page close [index]` — close page
+- `vibium page close [index|page id]` — close page
 
 ### Debug
 - `vibium highlight "<selector>"` — highlight element visually (3 seconds)
@@ -289,6 +290,14 @@ vibium daemon stop
 # Or per command, to drive two browsers from one script
 vibium --session buyer go https://shop.example.com
 vibium --session seller go https://shop.example.com/admin
+```
+
+### Isolated pages (one browser, separate cookies/storage)
+```sh
+# Lighter than a session: two logins in one browser, no second launch
+vibium page new --isolated https://shop.example.com   # prints (page: <id>)
+vibium page new --isolated https://shop.example.com
+vibium page close <id>   # also removes the page's isolated context
 ```
 
 ### Multi-page workflow

--- a/tests/mcp/page-isolation.test.js
+++ b/tests/mcp/page-isolation.test.js
@@ -1,0 +1,166 @@
+/**
+ * MCP Tests: isolated pages
+ *
+ * Every page in the agent engine used to share one browser profile, so
+ * concurrent callers saw each other's cookies and storage even when they
+ * pinned their calls to their own page. browser_new_page now takes an
+ * isolated flag that opens the page in its own user context, and closing
+ * the last page of an isolated context removes the context with it (#383).
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawn, execFileSync } = require('node:child_process');
+const http = require('node:http');
+const { VIBIUM } = require('../helpers');
+
+class MCPClient {
+  constructor() {
+    this.proc = null;
+    this.buffer = '';
+    this.responses = [];
+    this.resolvers = [];
+  }
+
+  start() {
+    return new Promise((resolve, reject) => {
+      this.proc = spawn(VIBIUM, ['mcp', '--headless'], { stdio: ['pipe', 'pipe', 'pipe'] });
+      this.proc.stdout.on('data', (data) => {
+        this.buffer += data.toString();
+        const lines = this.buffer.split('\n');
+        this.buffer = lines.pop();
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const response = JSON.parse(line);
+            if (this.resolvers.length > 0) this.resolvers.shift()(response);
+            else this.responses.push(response);
+          } catch { /* non-JSON line */ }
+        }
+      });
+      this.proc.on('error', reject);
+      setTimeout(resolve, 100);
+    });
+  }
+
+  async call(method, params = {}) {
+    const id = Date.now() + Math.random();
+    this.proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    const response = await new Promise((resolve, reject) => {
+      if (this.responses.length > 0) return resolve(this.responses.shift());
+      const timer = setTimeout(() => reject(new Error('Timeout waiting for response')), 120000);
+      this.resolvers.push((r) => { clearTimeout(timer); resolve(r); });
+    });
+    assert.strictEqual(response.id, id);
+    return response;
+  }
+
+  async tool(name, args = {}) {
+    const response = await this.call('tools/call', { name, arguments: args });
+    return response.result;
+  }
+
+  stop() {
+    if (!this.proc) return;
+    if (process.platform === 'win32') {
+      try { execFileSync('taskkill', ['/T', '/F', '/PID', this.proc.pid.toString()], { stdio: 'ignore' }); } catch {}
+    } else {
+      this.proc.kill();
+    }
+    this.proc = null;
+  }
+}
+
+function text(result) {
+  return (result.content || []).map((c) => c.text || '').join('');
+}
+
+function pageIdFrom(result) {
+  const match = text(result).match(/\(page: ([^)]+)\)/);
+  assert.ok(match, `expected a page id in: ${text(result)}`);
+  return match[1];
+}
+
+let client;
+let server;
+let origin; // cookies need a real http origin; data: URLs are opaque
+
+describe('MCP: isolated pages', () => {
+  before(async () => {
+    server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<title>isolation</title><h1>ok</h1>');
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    origin = `http://127.0.0.1:${server.address().port}/`;
+
+    client = new MCPClient();
+    await client.start();
+    await client.call('initialize', { capabilities: {} });
+  });
+
+  after(() => {
+    client.stop();
+    server.close();
+  });
+
+  test('an isolated page does not share cookies with the default context', async () => {
+    const plain = pageIdFrom(await client.tool('browser_new_page', { url: origin }));
+    await client.tool('browser_evaluate', { page: plain, expression: 'document.cookie = "who=default"' });
+
+    const result = await client.tool('browser_new_page', { url: origin, isolated: true });
+    assert.match(text(result), /isolated page/, 'the reply should say the page is isolated');
+    const isolated = pageIdFrom(result);
+
+    const seen = text(await client.tool('browser_evaluate', { page: isolated, expression: 'document.cookie' }));
+    assert.ok(!seen.includes('who=default'), `isolated page must not see the default cookie, got: ${seen}`);
+
+    await client.tool('browser_evaluate', { page: isolated, expression: 'document.cookie = "who=isolated"' });
+    const plainSees = text(await client.tool('browser_evaluate', { page: plain, expression: 'document.cookie' }));
+    assert.ok(!plainSees.includes('who=isolated'), `default page must not see the isolated cookie, got: ${plainSees}`);
+    assert.match(plainSees, /who=default/, 'the default page keeps its own cookie');
+  });
+
+  test('two isolated pages do not share cookies with each other', async () => {
+    const a = pageIdFrom(await client.tool('browser_new_page', { url: origin, isolated: true }));
+    const b = pageIdFrom(await client.tool('browser_new_page', { url: origin, isolated: true }));
+
+    await client.tool('browser_evaluate', { page: a, expression: 'document.cookie = "agent=a"' });
+    const bSees = text(await client.tool('browser_evaluate', { page: b, expression: 'document.cookie' }));
+    assert.ok(!bSees.includes('agent=a'), `page b must not see page a's cookie, got: ${bSees}`);
+  });
+
+  test('browser_list_pages marks isolated pages', async () => {
+    const isolated = pageIdFrom(await client.tool('browser_new_page', { isolated: true }));
+    const listing = text(await client.tool('browser_list_pages', {}));
+    for (const line of listing.split('\n')) {
+      if (line.includes(`(page: ${isolated})`)) {
+        assert.match(line, /\[isolated\]/, `the isolated page's row should be marked: ${line}`);
+        return;
+      }
+    }
+    assert.fail(`isolated page ${isolated} missing from listing: ${listing}`);
+  });
+
+  test('closing an isolated page by id removes its context too', async () => {
+    const isolated = pageIdFrom(await client.tool('browser_new_page', { isolated: true }));
+
+    const closed = await client.tool('browser_close_page', { page: isolated });
+    assert.match(text(closed), /and its isolated context/, 'the reply should confirm the context was removed');
+
+    const listing = text(await client.tool('browser_list_pages', {}));
+    assert.ok(!listing.includes(isolated), 'the closed page must be gone from the listing');
+  });
+
+  test('closing a default-context page by id leaves no context note', async () => {
+    const plain = pageIdFrom(await client.tool('browser_new_page', {}));
+    const closed = await client.tool('browser_close_page', { page: plain });
+    assert.match(text(closed), new RegExp(`Closed page ${plain}$`), 'a plain page close names the page and nothing else');
+  });
+
+  test('closing by a stale page id fails loudly', async () => {
+    const result = await client.tool('browser_close_page', { page: 'gone-5678' });
+    assert.ok(result.isError, 'a bad page id must be an error');
+    assert.match(text(result), /not found/);
+  });
+});

--- a/tests/mcp/page-pinning.test.js
+++ b/tests/mcp/page-pinning.test.js
@@ -144,4 +144,40 @@ describe('MCP: page pinning', () => {
     const listing = text(await client.tool('browser_list_pages', {}));
     assert.match(listing, /\(page: /, 'every row should carry the page id');
   });
+
+  // Element refs (@e1, ...) used to live in one table shared by every page,
+  // so one caller's map replaced another's selectors and a pinned click
+  // could faithfully target its own page with a selector minted on a
+  // different one. Refs are now scoped per page.
+  test('a map on one page does not replace another page\'s refs', async () => {
+    // #two exists on both pages, so the old shared table resolved A's @e1
+    // to B's selector and still found an element — silently the wrong one.
+    const pageA = pageIdFrom(await client.tool('browser_new_page', {
+      url: 'data:text/html,<button id="one">alpha</button><button id="two">beta</button>',
+    }));
+    const pageB = pageIdFrom(await client.tool('browser_new_page', {
+      url: 'data:text/html,<button id="two">gamma</button>',
+    }));
+
+    await client.tool('browser_map', { page: pageA });
+    await client.tool('browser_map', { page: pageB });
+
+    const seen = text(await client.tool('browser_get_text', { page: pageA, selector: '@e1' }));
+    assert.strictEqual(seen, 'alpha', "page A's @e1 must still be its own first element");
+  });
+
+  test('browser_diff compares against the same page\'s previous map', async () => {
+    const pageA = pageIdFrom(await client.tool('browser_new_page', {
+      url: 'data:text/html,<button>stable</button>',
+    }));
+    const pageB = pageIdFrom(await client.tool('browser_new_page', {
+      url: 'data:text/html,<button>other</button>',
+    }));
+
+    await client.tool('browser_map', { page: pageA });
+    await client.tool('browser_map', { page: pageB });
+
+    const diff = text(await client.tool('browser_diff_map', { page: pageA }));
+    assert.strictEqual(diff, 'No changes detected', "an unchanged page must not diff against another page's map");
+  });
 });


### PR DESCRIPTION
Fixes VibiumDev/vibium#383

Page pinning (#467) stopped concurrent callers on one MCP connection from mis-targeting each other's pages, but they still shared one browser profile and one element ref table. A caller saw other callers' cookies and logins, and one caller's `browser_map` replaced everyone's `@e` selectors, so a pinned click could faithfully target its own page with a selector minted on a different one.

Two pieces:

1. `browser_new_page` takes an `isolated` flag that opens the page in its own user context (separate cookies and storage). `browser_close_page` accepts a page id and removes the context when its last page closes, so storage partitions do not outlive their pages. Popups opened inside the context keep it alive until they close too. `browser_list_pages` marks isolated rows. The CLI gets the same via `vibium page new --isolated` and `vibium page close <id>`. The engine already had user contexts on the pipe surface; this is agent-surface plumbing only, no new tools and no wire change.

2. Element refs and the `browser_diff_map` baseline are keyed by browsing context instead of living in one global table. Ambient calls with no tracked page resolve to the real current context first, so refs minted before any explicit page switch are still found after switching back to that page. One deliberate behavior change: after the mapped page closes, `@e1` fails loudly instead of silently resolving against whatever page is current.

The recommended pattern for concurrent agents is now: open an isolated page, pass its id on every call. `VIBIUM_SESSION` semantics are unchanged; sessions still give a separate daemon and browser when full process isolation is wanted.

Verified:
- New `tests/mcp/page-isolation.test.js` (wired into `make test-mcp`): 6/6 on Chrome and 6/6 on Firefox; 5/6 fail on a main-built binary (the stale-id test passes on main because pinning already validates ids).
- Two new ref-scoping tests in `tests/mcp/page-pinning.test.js` return the wrong element deterministically on a binary without the second commit; 7/7 on the branch.
- No regression on ref-heavy single-agent flows: `make test-mcp` 60/60, `make test-daemon` 63/63, `make test-cli-shared` 82/82, `go test ./internal/agent ./internal/api` green, `make check-api-drift` in sync.