### PR TITLE
Accept http(s) and in-URL credentials for connect endpoints (#101)

### DIFF
--- a/clicker/cmd/clicker/diagnostics.go
+++ b/clicker/cmd/clicker/diagnostics.go
@@ -181,12 +181,18 @@ func newWSTestCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			url := args[0]
+			// Named rather than normalized: this command exists to test a
+			// raw WebSocket URL, so say what the URL should be instead of
+			// quietly testing a different one. Redacted because the hint
+			// echoes the URL back, and a hub URL can carry an access key in
+			// its userinfo field (#101).
 			if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-				ws := strings.Replace(strings.Replace(url, "https://", "wss://", 1), "http://", "ws://", 1)
-				fmt.Fprintf(os.Stderr, "Error: %s is not a WebSocket URL. Try: %s\n", url, ws)
+				safe := bidi.RedactEndpoint(url)
+				ws := strings.Replace(strings.Replace(safe, "https://", "wss://", 1), "http://", "ws://", 1)
+				fmt.Fprintf(os.Stderr, "Error: %s is not a WebSocket URL. Try: %s\n", safe, ws)
 				os.Exit(1)
 			}
-			fmt.Printf("Connecting to %s...\n", url)
+			fmt.Printf("Connecting to %s...\n", bidi.RedactEndpoint(url))
 
 			conn, err := bidi.Connect(url)
 			if err != nil {

--- a/clicker/cmd/clicker/start.go
+++ b/clicker/cmd/clicker/start.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/vibium/clicker/internal/bidi"
 	"github.com/vibium/clicker/internal/daemon"
 	"github.com/vibium/clicker/internal/paths"
 )
@@ -21,7 +22,11 @@ With a URL argument, connects to a remote BiDi WebSocket endpoint.
 If no URL is given, checks VIBIUM_CONNECT_URL env var before falling
 back to a local browser launch.
 
-Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.`,
+Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.
+
+http:// and https:// URLs are rewritten to ws:// and wss://, and credentials
+in the URL (https://user:key@host) are sent as an Authorization: Basic header,
+so a cloud provider's hub URL works as documented.`,
 		Example: `  vibium start
   # Start with a local browser
 
@@ -130,11 +135,13 @@ Set VIBIUM_CONNECT_API_KEY to send an Authorization: Bearer header.`,
 				// Take the daemon down before reporting: it cannot reach the
 				// endpoint either, so leaving it up only defers the failure.
 				shutdownDaemonAndWait()
-				printError(fmt.Errorf("failed to connect to %s: %w", connectURL, err))
+				printError(fmt.Errorf("failed to connect to %s: %w", bidi.RedactEndpoint(connectURL), err))
 				return
 			}
 
-			msg := fmt.Sprintf("Connected to %s (daemon pid %d)", connectURL, child.Process.Pid)
+			// Redacted: a provider hub URL can carry an access key in its
+			// userinfo field, and this line is printed to the user (#101).
+			msg := fmt.Sprintf("Connected to %s (daemon pid %d)", bidi.RedactEndpoint(connectURL), child.Process.Pid)
 			if jsonOutput {
 				printJSON(jsonEnvelope{OK: true, Result: msg})
 				return

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -777,7 +777,9 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 		return &ToolsCallResult{
 			Content: []Content{{
 				Type: "text",
-				Text: fmt.Sprintf("%s remote browser at %s (session %s)", verb, h.connectURL, session.ID),
+				// Redacted: a provider hub URL can carry an access key in
+				// its userinfo field, and this goes back to the agent (#101).
+				Text: fmt.Sprintf("%s remote browser at %s (session %s)", verb, bidi.RedactEndpoint(h.connectURL), session.ID),
 			}},
 		}, nil
 	}

--- a/clicker/internal/api/router.go
+++ b/clicker/internal/api/router.go
@@ -162,7 +162,9 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 
 	if r.connectURL != "" {
 		// Remote mode: connect to an existing BiDi endpoint and create a session
-		fmt.Fprintf(os.Stderr, "[router] Connecting to remote browser for client %d: %s\n", client.ID(), r.connectURL)
+		// Redacted: a provider hub URL can carry an access key in its
+		// userinfo field, and clients drain this stream to the user (#101).
+		fmt.Fprintf(os.Stderr, "[router] Connecting to remote browser for client %d: %s\n", client.ID(), bidi.RedactEndpoint(r.connectURL))
 
 		// Handshake without a bidi.Client: this router reads the connection
 		// itself in routeBrowserToClient, so no client reader may own it.
@@ -176,6 +178,8 @@ func (r *Router) OnClientConnect(client ClientTransport) {
 			}
 		}
 		if err != nil {
+			// Safe to print verbatim: ConnectWithHeaders redacts the URL it
+			// puts in its error, and the session handshake carries no URL.
 			fmt.Fprintf(os.Stderr, "[router] Failed to connect to remote browser for client %d: %v\n", client.ID(), err)
 			client.Send(fmt.Sprintf(`{"error":{"code":-32000,"message":"Failed to connect to remote browser: %s"}}`, err.Error()))
 			client.Close()

--- a/clicker/internal/bidi/connection.go
+++ b/clicker/internal/bidi/connection.go
@@ -37,15 +37,40 @@ func Connect(url string) (*Connection, error) {
 
 // ConnectWithHeaders establishes a WebSocket connection with optional HTTP headers.
 // Headers are sent during the WebSocket handshake (useful for authentication tokens).
-func ConnectWithHeaders(url string, headers http.Header) (*Connection, error) {
+//
+// The URL goes through NormalizeEndpoint first, so an http:// or https:// hub
+// URL and credentials in its userinfo field both work (#101).
+func ConnectWithHeaders(rawURL string, headers http.Header) (*Connection, error) {
+	endpoint, urlHeaders, err := NormalizeEndpoint(rawURL)
+	if err != nil {
+		return nil, &errs.ConnectionError{URL: RedactEndpoint(rawURL), Cause: err}
+	}
+
+	// Credentials in the URL only fill a gap: an explicit header from
+	// VIBIUM_CONNECT_API_KEY or --connect-header is a deliberate choice and
+	// wins. Clone rather than mutate — the router reuses one header map for
+	// every client it connects.
+	if len(urlHeaders) > 0 {
+		merged := headers.Clone()
+		if merged == nil {
+			merged = make(http.Header)
+		}
+		for key, vals := range urlHeaders {
+			if merged.Get(key) == "" {
+				merged[key] = vals
+			}
+		}
+		headers = merged
+	}
+
 	dialer := websocket.Dialer{
 		ReadBufferSize:   maxMessageSize,
 		WriteBufferSize:  maxMessageSize,
 		HandshakeTimeout: 30 * time.Second,
 	}
-	conn, _, err := dialer.Dial(url, headers)
+	conn, _, err := dialer.Dial(endpoint, headers)
 	if err != nil {
-		return nil, &errs.ConnectionError{URL: url, Cause: err}
+		return nil, &errs.ConnectionError{URL: RedactEndpoint(endpoint), Cause: err}
 	}
 
 	// Set read limit to handle large messages (e.g., screenshots from high-res displays)

--- a/clicker/internal/bidi/endpoint.go
+++ b/clicker/internal/bidi/endpoint.go
@@ -1,0 +1,104 @@
+package bidi
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// redactedSecret replaces a credential in logs and error messages.
+const redactedSecret = "redacted"
+
+// NormalizeEndpoint rewrites a user-supplied BiDi endpoint into the form the
+// WebSocket dialer accepts and returns any headers the URL itself implied.
+//
+// Two shapes that cloud browser providers document are rejected by the dialer
+// with the same opaque "malformed ws or wss URL" (#101):
+//
+//   - An http:// or https:// scheme. BrowserStack's hub is documented as
+//     https://hub-cloud.browserstack.com, and the CLI argument, the
+//     VIBIUM_CONNECT_URL env var and the clients' connect option all pass that
+//     string through verbatim.
+//   - Credentials in the userinfo field (https://user:key@host). A WebSocket
+//     URI may not carry them at all, so they have to move to an Authorization
+//     header.
+//
+// Both are mechanical rewrites, so do them rather than fail. Anything else (an
+// unknown scheme, a missing host) is a real mistake and is named as such
+// instead of surfacing as "malformed".
+func NormalizeEndpoint(endpoint string) (string, http.Header, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return "", nil, fmt.Errorf("empty endpoint URL (expected ws:// or wss://)")
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid endpoint URL: %w", err)
+	}
+
+	switch u.Scheme {
+	case "ws", "wss":
+		// Already what the dialer wants.
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "":
+		return "", nil, fmt.Errorf("endpoint URL %q has no scheme (expected ws:// or wss://)",
+			RedactEndpoint(endpoint))
+	default:
+		return "", nil, fmt.Errorf("unsupported endpoint scheme %q (expected ws, wss, http or https)", u.Scheme)
+	}
+
+	if u.Host == "" {
+		return "", nil, fmt.Errorf("endpoint URL %q has no host", RedactEndpoint(endpoint))
+	}
+
+	var headers http.Header
+	if u.User != nil {
+		// url.Parse percent-decodes userinfo, so this is the credential the
+		// user actually meant — encode it straight into Basic auth, the
+		// scheme every provider that documents this URL shape expects.
+		password, _ := u.User.Password()
+		headers = make(http.Header)
+		headers.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString(
+			[]byte(u.User.Username()+":"+password)))
+		u.User = nil
+	}
+
+	return u.String(), headers, nil
+}
+
+// RedactEndpoint returns endpoint with any credential in its userinfo field
+// replaced, for logs and error messages. A provider access key lives in that
+// field, and connect URLs are printed on stderr, which clients drain and
+// surface to the user.
+func RedactEndpoint(endpoint string) string {
+	if u, err := url.Parse(endpoint); err == nil {
+		if u.User == nil {
+			return endpoint
+		}
+		if _, hasPassword := u.User.Password(); hasPassword {
+			u.User = url.UserPassword(u.User.Username(), redactedSecret)
+		}
+		return u.String()
+	}
+
+	// Parsing failed, so the credential's boundaries are not reliably known.
+	// Drop the whole userinfo field rather than risk printing a key.
+	scheme, rest, found := strings.Cut(endpoint, "//")
+	if !found {
+		return endpoint
+	}
+	authority, path, hasPath := strings.Cut(rest, "/")
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		authority = redactedSecret + "@" + authority[at+1:]
+	}
+	out := scheme + "//" + authority
+	if hasPath {
+		out += "/" + path
+	}
+	return out
+}

--- a/clicker/internal/bidi/endpoint_test.go
+++ b/clicker/internal/bidi/endpoint_test.go
@@ -1,0 +1,271 @@
+package bidi
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// The URL shapes cloud browser providers document. Each one used to reach the
+// dialer verbatim and come back as "malformed ws or wss URL" (#101).
+func TestNormalizeEndpointRewritesProviderURLs(t *testing.T) {
+	basic := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:key"))
+
+	tests := []struct {
+		name     string
+		in       string
+		wantURL  string
+		wantAuth string // expected Authorization header, "" for none
+	}{
+		{"ws is left alone", "ws://127.0.0.1:9515/session", "ws://127.0.0.1:9515/session", ""},
+		{"wss is left alone", "wss://cloud.example.com/bidi", "wss://cloud.example.com/bidi", ""},
+		{"https becomes wss", "https://hub-cloud.browserstack.com", "wss://hub-cloud.browserstack.com", ""},
+		{"http becomes ws", "http://127.0.0.1:9515/session", "ws://127.0.0.1:9515/session", ""},
+		{
+			"browserstack hub URL from the issue",
+			"https://user:key@hub-cloud.browserstack.com",
+			"wss://hub-cloud.browserstack.com",
+			basic,
+		},
+		{
+			"userinfo moves off a wss URL too",
+			"wss://user:key@cloud.example.com/bidi",
+			"wss://cloud.example.com/bidi",
+			basic,
+		},
+		{
+			"a username with no password still authenticates",
+			"https://user@hub.example.com",
+			"wss://hub.example.com",
+			"Basic " + base64.StdEncoding.EncodeToString([]byte("user:")),
+		},
+		{
+			"percent-encoded credentials are decoded before encoding",
+			"https://user%40corp.com:p%40ss@hub.example.com",
+			"wss://hub.example.com",
+			"Basic " + base64.StdEncoding.EncodeToString([]byte("user@corp.com:p@ss")),
+		},
+		{
+			"the query string survives the rewrite",
+			"https://user:key@hub.example.com/wd/hub?os=Windows",
+			"wss://hub.example.com/wd/hub?os=Windows",
+			basic,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, headers, err := NormalizeEndpoint(tt.in)
+			if err != nil {
+				t.Fatalf("NormalizeEndpoint(%q) returned error: %v", tt.in, err)
+			}
+			if got != tt.wantURL {
+				t.Errorf("url = %q, want %q", got, tt.wantURL)
+			}
+			if auth := headers.Get("Authorization"); auth != tt.wantAuth {
+				t.Errorf("Authorization = %q, want %q", auth, tt.wantAuth)
+			}
+		})
+	}
+}
+
+// A real mistake must be named, not passed to the dialer to come back as
+// "malformed" — that opacity is what made #101 hard to diagnose.
+func TestNormalizeEndpointRejectsBadURLsClearly(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "empty endpoint URL"},
+		{"whitespace only", "   ", "empty endpoint URL"},
+		{"no scheme", "hub-cloud.browserstack.com", "no scheme"},
+		{"unsupported scheme", "ftp://hub.example.com", "unsupported endpoint scheme"},
+		{"no host", "wss:///session", "no host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := NormalizeEndpoint(tt.in)
+			if err == nil {
+				t.Fatalf("NormalizeEndpoint(%q) should have failed", tt.in)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to mention %q", err, tt.want)
+			}
+			if strings.Contains(err.Error(), "malformed ws or wss URL") {
+				t.Errorf("error must not be the dialer's opaque message: %q", err)
+			}
+		})
+	}
+}
+
+func TestRedactEndpointHidesCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"password is replaced",
+			"https://user:key@hub-cloud.browserstack.com",
+			"https://user:redacted@hub-cloud.browserstack.com",
+		},
+		{
+			"a bare username is not a secret",
+			"https://user@hub.example.com",
+			"https://user@hub.example.com",
+		},
+		{"no userinfo, no change", "wss://cloud.example.com/bidi", "wss://cloud.example.com/bidi"},
+		{"plain local URL", "ws://127.0.0.1:9515/session", "ws://127.0.0.1:9515/session"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RedactEndpoint(tt.in); got != tt.want {
+				t.Errorf("RedactEndpoint(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// url.Parse rejects some strings outright. Redaction still may not print the
+// credential, so the whole userinfo field goes.
+func TestRedactEndpointHidesCredentialsInUnparseableURLs(t *testing.T) {
+	got := RedactEndpoint("https://user:k[e]y@hub.example.com/wd/hub")
+	if strings.Contains(got, "k[e]y") {
+		t.Fatalf("credential leaked from an unparseable URL: %q", got)
+	}
+	for _, want := range []string{"hub.example.com", "/wd/hub", redactedSecret} {
+		if !strings.Contains(got, want) {
+			t.Errorf("redacted URL %q lost %q", got, want)
+		}
+	}
+}
+
+// authCapturingServer accepts one WebSocket handshake and reports the
+// Authorization header it arrived with.
+func authCapturingServer(t *testing.T) (endpoint string, auth <-chan string) {
+	t.Helper()
+
+	got := make(chan string, 1)
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.Header.Get("Authorization")
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		ws.ReadMessage() // hold the connection open until the client closes
+	}))
+	t.Cleanup(srv.Close)
+
+	// srv.URL is http://127.0.0.1:port — exactly the scheme the dialer used
+	// to reject. Credentials go in the userinfo field, as BrowserStack
+	// documents its hub URL.
+	return strings.Replace(srv.URL, "http://", "http://user:key@", 1), got
+}
+
+// End to end over a real handshake: the http:// URL connects and the
+// credential arrives as a Basic Authorization header (#101).
+func TestConnectWithHeadersAcceptsHTTPURLWithCredentials(t *testing.T) {
+	endpoint, gotAuth := authCapturingServer(t)
+
+	conn, err := ConnectWithHeaders(endpoint, nil)
+	if err != nil {
+		t.Fatalf("connect to %q failed: %v", RedactEndpoint(endpoint), err)
+	}
+	defer conn.Close()
+
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:key"))
+	if auth := <-gotAuth; auth != want {
+		t.Errorf("Authorization = %q, want %q", auth, want)
+	}
+}
+
+// An explicit header is a deliberate choice (VIBIUM_CONNECT_API_KEY,
+// --connect-header) and must outrank a credential left in the URL.
+func TestConnectWithHeadersPrefersExplicitAuthorization(t *testing.T) {
+	endpoint, gotAuth := authCapturingServer(t)
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer explicit-token")
+
+	conn, err := ConnectWithHeaders(endpoint, headers)
+	if err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	defer conn.Close()
+
+	if auth := <-gotAuth; auth != "Bearer explicit-token" {
+		t.Errorf("Authorization = %q, want the explicit header to win", auth)
+	}
+	// The router reuses one header map across every client it connects, so
+	// the caller's map must come back untouched.
+	if got := headers.Get("Authorization"); got != "Bearer explicit-token" {
+		t.Errorf("caller's header map was mutated: Authorization = %q", got)
+	}
+	if len(headers) != 1 {
+		t.Errorf("caller's header map grew to %d entries", len(headers))
+	}
+}
+
+// Headers unrelated to auth still reach the endpoint alongside URL credentials.
+func TestConnectWithHeadersKeepsUnrelatedHeaders(t *testing.T) {
+	gotTrace := make(chan string, 1)
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTrace <- r.Header.Get("X-Trace-Id")
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+		ws.ReadMessage()
+	}))
+	t.Cleanup(srv.Close)
+
+	endpoint := strings.Replace(srv.URL, "http://", "http://user:key@", 1)
+	headers := http.Header{}
+	headers.Set("X-Trace-Id", "abc123")
+
+	conn, err := ConnectWithHeaders(endpoint, headers)
+	if err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	defer conn.Close()
+
+	if trace := <-gotTrace; trace != "abc123" {
+		t.Errorf("X-Trace-Id = %q, want it preserved", trace)
+	}
+}
+
+// The credential must not reach stderr, which clients drain and show the user.
+func TestConnectWithHeadersRedactsCredentialsInErrors(t *testing.T) {
+	// Port 1 is not listening, so the dial fails with the URL in its error.
+	_, err := ConnectWithHeaders("https://user:supersecret@127.0.0.1:1/session", nil)
+	if err == nil {
+		t.Fatal("connecting to a closed port should fail")
+	}
+	if strings.Contains(err.Error(), "supersecret") {
+		t.Fatalf("credential leaked into the error: %v", err)
+	}
+}
+
+// A bad URL fails before the dial, and its error names the problem instead of
+// repeating the dialer's "malformed ws or wss URL".
+func TestConnectWithHeadersNamesBadURLs(t *testing.T) {
+	_, err := ConnectWithHeaders("hub-cloud.browserstack.com", nil)
+	if err == nil {
+		t.Fatal("a schemeless URL should fail")
+	}
+	if !strings.Contains(err.Error(), "no scheme") {
+		t.Errorf("error should name the missing scheme, got: %v", err)
+	}
+}

--- a/docs/tutorials/remote-browser.md
+++ b/docs/tutorials/remote-browser.md
@@ -57,6 +57,8 @@ vibium stop
 
 Both endpoint shapes work: a browser-level URL like `ws://host:9515/session` (vibium creates the session) and a URL for a session that already exists, such as a chromedriver `webSocketUrl` or a Selenium Grid `ws://host:4444/session/<id>/se/bidi` (vibium attaches to it).
 
+`http://` and `https://` URLs are accepted too and rewritten to `ws://` / `wss://`, so a hub URL copied from a cloud provider's docs works as-is.
+
 ### MCP Server
 
 The MCP server reads the same env vars, so AI agents can use a remote browser:
@@ -198,13 +200,39 @@ bro = browser.start("wss://cloud.example.com/bidi", headers={
 })
 ```
 
+### Credentials in the URL
+
+Providers that document a hub URL with the credentials embedded — BrowserStack's
+`https://username:accesskey@hub-cloud.browserstack.com`, for example — work
+without any extra setup. Vibium moves the credentials out of the URL (a
+WebSocket URL may not carry them) into an `Authorization: Basic` header:
+
+```javascript
+const bro = await browser.start('https://username:accesskey@hub-cloud.browserstack.com')
+```
+
+```python
+bro = browser.start("https://username:accesskey@hub-cloud.browserstack.com")
+```
+
+```bash
+vibium start "https://username:accesskey@hub-cloud.browserstack.com"
+```
+
+An explicit header wins over a credential in the URL, so `VIBIUM_CONNECT_API_KEY`
+and `--connect-header` still override it. Credentials are replaced with
+`redacted` wherever vibium prints the endpoint.
+
+Prefer a header or `VIBIUM_CONNECT_API_KEY` where you can — a URL is easier to
+leak into shell history and CI logs than an env var.
+
 ---
 
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `VIBIUM_CONNECT_URL` | Remote BiDi WebSocket endpoint (e.g. `ws://host:9515/session`) |
+| `VIBIUM_CONNECT_URL` | Remote BiDi endpoint (e.g. `ws://host:9515/session`); `http://` and `https://` are rewritten to `ws://` / `wss://` |
 | `VIBIUM_CONNECT_API_KEY` | Sent as `Authorization: Bearer <key>` |
 
 These work everywhere — CLI commands, daemon auto-start, and the MCP server.

--- a/tests/cli/wrapper.test.js
+++ b/tests/cli/wrapper.test.js
@@ -85,6 +85,23 @@ describe('CLI: ws-test scheme hint', () => {
       assert.match(out, /ws:\/\/localhost:59999/, `should suggest the ws:// form, got: ${out.slice(0, 200)}`);
     }
   });
+
+  // The hint echoes the URL back, and a cloud provider hub URL carries an
+  // access key in its userinfo field (#101).
+  test('does not echo a credential from the URL back (#101)', () => {
+    try {
+      execSync(`${VIBIUM} ws-test "http://user:supersecretkey@localhost:59999"`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+        stdio: 'pipe',
+      });
+      assert.fail('should reject an http:// URL');
+    } catch (err) {
+      const out = err.stdout + err.stderr;
+      assert.doesNotMatch(out, /supersecretkey/, `credential leaked into output: ${out.slice(0, 300)}`);
+      assert.match(out, /redacted/, `should show the credential as redacted, got: ${out.slice(0, 300)}`);
+    }
+  });
 });
 
 describe('CLI: shell completion', () => {


### PR DESCRIPTION
A cloud provider hub URL copied from its own docs cannot be used to connect. BrowserStack documents

    https://username:accesskey@hub-cloud.browserstack.com

and the CLI argument, VIBIUM_CONNECT_URL and the clients' connect option all pass that string to the dialer verbatim, which rejects it. Reported in #101 against the Java client, but the string never reaches client-specific code, so every client is affected.

gorilla/websocket rejects that URL twice over, and both rejections produce the same opaque message (client.go, v1.5.3):

    switch u.Scheme {
    case "ws":  u.Scheme = "http"
    case "wss": u.Scheme = "https"
    default:    return nil, nil, errMalformedURL
    }
    if u.User != nil {
        // User name and password are not allowed in websocket URIs.
        return nil, nil, errMalformedURL
    }

So the scheme and the credentials each independently produce "malformed ws or wss URL", which names neither cause. That is why the report shows a correct-looking URL and an error that reads like a typo.

Both are mechanical rewrites, so do them in ConnectWithHeaders rather than fail: http/https become ws/wss, and userinfo credentials move to an Authorization: Basic header, where a WebSocket handshake can carry them. An explicit header still wins, so VIBIUM_CONNECT_API_KEY and --connect-header override a credential left in the URL. The header map is cloned rather than mutated because the api router reuses one map across every client it connects.

A URL that is genuinely wrong (unknown scheme, no host) now says so instead of reaching the dialer and coming back "malformed".

Also redact credentials wherever the endpoint is printed. This is a pre-existing leak -- the router already logged the access key to stderr, which clients drain and surface -- but accepting these URLs makes the credential-bearing form the working path, so it would go from rare to routine.

Verified end to end against a fake BiDi endpoint: a binary built before this change reproduces the reported failure exactly, including the leaked key,

    [router] Connecting to remote browser for client 1: http://myuser:supersecretkey@127.0.0.1:54157
    [router] Failed to connect to remote browser for client 1: failed to connect to
      http://myuser:supersecretkey@127.0.0.1:54157: malformed ws or wss URL
    [pipe] Failed to send ready signal: pipe closed

and after it the same URL completes session.new and reaches vibium:lifecycle.ready, with the endpoint logged as http://myuser:redacted@127.0.0.1:53836.