### PR TITLE
Install the baked known-good browser version by default

### DIFF
--- a/clicker/internal/browser/installer.go
+++ b/clicker/internal/browser/installer.go
@@ -20,6 +20,14 @@ const (
 	lastKnownGoodURL     = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
 )
 
+// pinnedChromeVersion is the known-good Chrome for Testing version
+// stable-channel installs default to. CI tests exactly this version; the
+// version-bump workflow opens a tested PR when Google ships a new Stable
+// (#470). Bumping it also renews test.yml's Chrome cache key, which hashes
+// this file, so the bump PR installs the new version instead of a cached
+// old one.
+const pinnedChromeVersion = "152.0.7977.82"
+
 // VersionInfo represents the Chrome for Testing version information.
 type VersionInfo struct {
 	Version   string                `json:"version"`
@@ -153,14 +161,30 @@ var chromeChannelKeys = map[string]string{
 }
 
 // resolveChromeVersionInfo returns the version to install:
-// VIBIUM_ENGINE_VERSION when set, otherwise the channel's current version.
-// Unlike Firefox there is no offline path for a pin: Chrome for Testing
+// VIBIUM_ENGINE_VERSION when set, the baked known-good version for the
+// stable channel, otherwise the channel's current version. Unlike Firefox
+// there is no offline path even for a pinned version: Chrome for Testing
 // download URLs come from its versions JSON, not a constructible pattern.
+// But a pinned lookup can never resolve to an untested new release.
 func resolveChromeVersionInfo() (*VersionInfo, error) {
-	if v := os.Getenv("VIBIUM_ENGINE_VERSION"); v != "" {
+	if v := chromeInstallVersion(); v != "" {
 		return fetchVersionInfoFor(v)
 	}
 	return fetchChannelVersion(paths.ChromeChannel())
+}
+
+// chromeInstallVersion returns the exact version to install, or "" when the
+// channel's current version should be fetched instead. Beta, dev, and
+// canary track their moving edge on purpose: beta-watch needs the current
+// beta, and pinning a canary would defeat it entirely.
+func chromeInstallVersion() string {
+	if v := os.Getenv("VIBIUM_ENGINE_VERSION"); v != "" {
+		return v
+	}
+	if paths.ChromeChannel() == "stable" {
+		return pinnedChromeVersion
+	}
+	return ""
 }
 
 // fetchChannelVersion fetches the channel's current Chrome for Testing version.

--- a/clicker/internal/browser/installer_chrome_pin_test.go
+++ b/clicker/internal/browser/installer_chrome_pin_test.go
@@ -1,9 +1,49 @@
 package browser
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// With no override, stable installs the baked known-good version instead of
+// whatever Google shipped today (#470). Version resolution is offline; only
+// the download-URL lookup for that exact version touches the network.
+func TestChromeStableChannelResolvesToBakedPin(t *testing.T) {
+	t.Setenv("VIBIUM_ENGINE_VERSION", "")
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "")
+	if got := chromeInstallVersion(); got != pinnedChromeVersion {
+		t.Errorf("chromeInstallVersion() = %q, want the baked %q", got, pinnedChromeVersion)
+	}
+}
+
+func TestChromeVersionOverrideBeatsBakedPin(t *testing.T) {
+	t.Setenv("VIBIUM_ENGINE_VERSION", "140.0.7000.10")
+	if got := chromeInstallVersion(); got != "140.0.7000.10" {
+		t.Errorf("chromeInstallVersion() = %q, want the override 140.0.7000.10", got)
+	}
+}
+
+// Non-stable channels keep resolving their current version: a pinned beta
+// would blind beta-watch.
+func TestChromeBetaChannelSkipsBakedPin(t *testing.T) {
+	t.Setenv("VIBIUM_ENGINE_VERSION", "")
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "beta")
+	if got := chromeInstallVersion(); got != "" {
+		t.Errorf("chromeInstallVersion() = %q, want \"\" so beta fetches its current version", got)
+	}
+}
+
+// The version-bump workflow rewrites the pins mechanically; this catches a
+// bad write (a "null" from jq, a beta like 156.0b3) before it can ship.
+func TestBakedPinsAreExactReleaseVersions(t *testing.T) {
+	if !regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+$`).MatchString(pinnedChromeVersion) {
+		t.Errorf("pinnedChromeVersion = %q, want four dotted numbers", pinnedChromeVersion)
+	}
+	if !regexp.MustCompile(`^\d+\.\d+(\.\d+)?$`).MatchString(pinnedFirefoxVersion) {
+		t.Errorf("pinnedFirefoxVersion = %q, want a release version, not a beta", pinnedFirefoxVersion)
+	}
+}
 
 // An unknown channel must fail before any network request, with the
 // supported values in the message.

--- a/clicker/internal/browser/installer_firefox.go
+++ b/clicker/internal/browser/installer_firefox.go
@@ -19,6 +19,14 @@ import (
 
 const firefoxVersionsURL = "https://product-details.mozilla.org/1.0/firefox_versions.json"
 
+// pinnedFirefoxVersion is the known-good Firefox version release-channel
+// installs default to. CI tests exactly this version; the version-bump
+// workflow opens a tested PR when Mozilla ships a new release (#469).
+// Bumping it also renews test.yml's Firefox cache key, which hashes this
+// file, so the bump PR installs the new version instead of a cached old
+// one.
+const pinnedFirefoxVersion = "155.0.1"
+
 // InstallFirefox downloads Firefox from Mozilla's release archive into the
 // vibium cache and returns the executable path. Skips the download if the
 // current version is already installed. The channel comes from
@@ -118,13 +126,18 @@ func IsFirefoxInstalled() bool {
 }
 
 // resolveFirefoxVersion returns the Firefox version to install:
-// VIBIUM_ENGINE_VERSION when set, otherwise the channel's current version
-// from Mozilla's product-details JSON. The pin exists because "latest"
-// changes out from under CI and fleets (a beta pin silently jumped 154 to
-// 155 the day 154 reached release); it also skips the network round-trip.
+// VIBIUM_ENGINE_VERSION when set, the baked known-good version for the
+// release channel, otherwise the channel's current version from Mozilla's
+// product-details JSON. Release installs stay off the network and off
+// untested versions — Firefox 155 broke every fresh install on its release
+// day (#464) because this used to resolve "latest" for everyone. Beta
+// keeps tracking the current beta: a pinned beta would blind beta-watch.
 func resolveFirefoxVersion(channel string) (string, error) {
 	if v := os.Getenv("VIBIUM_ENGINE_VERSION"); v != "" {
 		return v, nil
+	}
+	if channel == "release" {
+		return pinnedFirefoxVersion, nil
 	}
 	return fetchLatestFirefoxVersion(channel)
 }

--- a/clicker/internal/browser/installer_firefox_pin_test.go
+++ b/clicker/internal/browser/installer_firefox_pin_test.go
@@ -2,6 +2,21 @@ package browser
 
 import "testing"
 
+// With no override, the release channel installs the baked known-good
+// version, offline (#469). Firefox 155 broke every fresh install on its
+// release day (#464) because this used to resolve Mozilla's current
+// release.
+func TestFirefoxReleaseChannelResolvesToBakedPin(t *testing.T) {
+	t.Setenv("VIBIUM_ENGINE_VERSION", "")
+	v, err := resolveFirefoxVersion("release")
+	if err != nil {
+		t.Fatalf("resolveFirefoxVersion(release) error = %v", err)
+	}
+	if v != pinnedFirefoxVersion {
+		t.Errorf("resolveFirefoxVersion(release) = %q, want the baked %q", v, pinnedFirefoxVersion)
+	}
+}
+
 // A pinned version must not consult the network: resolution returns the pin
 // as-is, for any channel (#326).
 func TestResolveFirefoxVersionHonorsPin(t *testing.T) {

--- a/docs/how-to-guides/using-firefox.md
+++ b/docs/how-to-guides/using-firefox.md
@@ -103,11 +103,16 @@ currently requires Firefox, while PDF output may differ between engines.
 |----------|--------|
 | `VIBIUM_ENGINE` | Default engine (`chrome` or `firefox`) when `--engine` is not given |
 | `VIBIUM_ENGINE_PATH` | Use this Firefox executable instead of the vibium cache; when set, channel selection does not apply |
-| `VIBIUM_ENGINE_CHANNEL` | Channel to install and run: `release` (default) or `beta`; same as `--channel` or the clients' `channel` option |
-| `VIBIUM_ENGINE_VERSION` | Pin the exact version to install and run (e.g. `153.0.4`) instead of the channel's latest; keeps CI and fleets on one version until you move the pin |
+| `VIBIUM_ENGINE_CHANNEL` | Channel to install and run: `release` (default) or `beta` for Firefox, `stable` (default), `beta`, `dev`, or `canary` for Chrome; same as `--channel` or the clients' `channel` option |
+| `VIBIUM_ENGINE_VERSION` | Pin the exact version to install and run (e.g. `153.0.4`) instead of the default; keeps CI and fleets on one version until you move the pin |
 
-The names are engine-neutral, but only Firefox implements them today. Setting
-any of them with `--engine chrome` is an error rather than a silent no-op.
+Without a pin, the default channels (`release`/`stable`) install the
+known-good version baked into this vibium release, so a browser release
+cannot break installs before a vibium release has tested it. The other
+channels install their current version. `VIBIUM_ENGINE_CHANNEL` and
+`VIBIUM_ENGINE_VERSION` apply to both engines; `VIBIUM_ENGINE_PATH` is
+Firefox-only, and setting it with `--engine chrome` is an error rather than
+a silent no-op.
 
 ## Feature notes
 


### PR DESCRIPTION
Part of VibiumDev/vibium#469 (item 1) and VibiumDev/vibium#470 (item 2).

Fresh installs resolve the channel's current version at install time, so a browser release reaches users the day it ships, before any vibium test has seen it. Firefox 155 broke every fresh install on its release day this way (#464). With both browsers on a biweekly cadence, that is ~26 untested releases a year per engine landing straight on users.

Stable and release channel installs now default to a known-good version baked into the binary. Firefox release installs no longer touch product-details at all; Chrome still fetches the download URL from the known-good-versions JSON (there is no constructible URL pattern), but for the pinned version, never the day's Stable. `VIBIUM_ENGINE_VERSION` still overrides, and the beta, dev, and canary channels keep tracking their current version so beta-watch keeps its signal.

The pins live in installer.go and installer_firefox.go on purpose: test.yml's browser cache keys hash those files, so a pin bump automatically installs the new version in CI instead of reusing a cached old one.

Also updates the env var table in using-firefox.md, which still said only Firefox honors `VIBIUM_ENGINE_CHANNEL`/`VIBIUM_ENGINE_VERSION` (stale since #473).

Verified:
- New resolution tests: release/stable resolve to the pin offline, `VIBIUM_ENGINE_VERSION` beats the pin, beta skips the pin, and a pin-format guard catches a bad mechanical rewrite (the bump workflow edits these lines with sed). They fail on main, where release/stable resolve the day's latest.
- `go build ./...` and `go test ./...` green locally.
- Both pinned versions verified resolvable: Firefox 155.0.1 SHA256SUMS returns 200, Chrome 152.0.7977.82 present in known-good-versions with downloads.
- Fork CI installs both pins fresh (the cache keys change with this diff).