### PR TITLE
Install the engine from the CLI and MCP, not just from pipe

### DIFF
--- a/clicker/cmd/clicker/mcp_cmd.go
+++ b/clicker/cmd/clicker/mcp_cmd.go
@@ -105,6 +105,13 @@ with LLM agents like Claude Code.
 				})
 				defer server.Close()
 
+				// NewServer captured the real stdout for protocol output, so
+				// point os.Stdout at stderr now: a tool call that installs the
+				// browser prints progress with fmt.Print, and those lines would
+				// otherwise land in the middle of the JSON-RPC stream. Same
+				// guard `vibium pipe` uses.
+				os.Stdout = os.Stderr
+
 				// Handle SIGTERM so Chrome is cleaned up even if stdin isn't closed
 				sigCh := make(chan os.Signal, 1)
 				signal.Notify(sigCh, syscall.SIGTERM)

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -1126,6 +1126,25 @@ func (h *Handlers) browserScreenshot(args map[string]interface{}) (*ToolsCallRes
 	if err != nil {
 		return nil, err
 	}
+
+	// A pinned page (#383) is usually not the foreground tab, and headless
+	// Chrome composites no frame for a background one: captureScreenshot then
+	// blocks until the BiDi timeout instead of returning. Raise the target for
+	// the capture and put the previous tab back. This surface reaches it and
+	// the router-backed clients do not because browser_new_page activates the
+	// page it creates (browserNewPage) while vibium:browser.newPage leaves the
+	// foreground alone. Firefox 155 refuses activate as privileged, so a
+	// failure here is not fatal — the capture is still worth attempting.
+	if ctx != "" && h.activeContext != "" && ctx != h.activeContext {
+		if err := api.SwitchPage(s, ctx); err == nil {
+			defer func() {
+				if err := api.SwitchPage(s, h.activeContext); err != nil {
+					log.Warn("failed to restore the active page after a pinned screenshot", "context", h.activeContext, "error", err)
+				}
+			}()
+		}
+	}
+
 	base64Data, err := api.Screenshot(s, ctx, fullPage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to capture screenshot: %w", err)

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -82,11 +82,22 @@ type Handlers struct {
 	// daemon sets it per request under the same mutex that serializes
 	// handler calls; it must not be mutated while a call is in flight.
 	launchNotify func()
+
+	// installNotify, when set, is called when a launch finds the engine
+	// missing and starts downloading it. A download is not bounded by the
+	// launch budget, so callers need to distinguish it from a slow launch.
+	// Set and cleared alongside launchNotify.
+	installNotify func()
 }
 
 // SetLaunchNotify installs (or clears, with nil) the launch-start callback.
 func (h *Handlers) SetLaunchNotify(fn func()) {
 	h.launchNotify = fn
+}
+
+// SetInstallNotify installs (or clears, with nil) the install-start callback.
+func (h *Handlers) SetInstallNotify(fn func()) {
+	h.installNotify = fn
 }
 
 // NewHandlers creates a new Handlers instance.
@@ -857,6 +868,20 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 				return nil, fmt.Errorf("unknown Firefox channel %q (supported: release, beta)", val)
 			}
 			useChannel = val
+		}
+	}
+
+	// Install the engine if this machine has never had one. The client
+	// libraries get this from `vibium pipe` (#312), but the CLI and MCP reach
+	// the browser through here instead and used to fail with "Chrome not
+	// found" / "Firefox not found" telling the user to go run an install
+	// command by hand. VIBIUM_SKIP_BROWSER_DOWNLOAD restores that error.
+	if !browser.SkipBrowserDownload() && !browser.EngineInstalledForChannel(useEngine, useChannel) {
+		if h.installNotify != nil {
+			h.installNotify()
+		}
+		if err := browser.EnsureInstalledForChannel(useEngine, useChannel); err != nil {
+			return nil, fmt.Errorf("failed to install %s: %w", useEngine, err)
 		}
 	}
 

--- a/clicker/internal/browser/ensure.go
+++ b/clicker/internal/browser/ensure.go
@@ -16,8 +16,16 @@ func SkipBrowserDownload() bool {
 // EngineInstalled reports whether the selected engine is already installed.
 // It only stats local paths — no network.
 func EngineInstalled(engine string) bool {
+	return EngineInstalledForChannel(engine, "")
+}
+
+// EngineInstalledForChannel reports whether the engine is installed for a
+// specific Firefox channel. An empty channel means the VIBIUM_ENGINE_CHANNEL
+// default. Chrome resolves its own channel from the environment and ignores
+// the argument.
+func EngineInstalledForChannel(engine, channel string) bool {
 	if engine == "firefox" {
-		return IsFirefoxInstalled()
+		return IsFirefoxInstalledForChannel(channel)
 	}
 	return IsInstalled()
 }
@@ -26,11 +34,19 @@ func EngineInstalled(engine string) bool {
 // When VIBIUM_SKIP_BROWSER_DOWNLOAD is set it is a no-op, so a later launch
 // fails (or finds a user-provided browser) exactly as it did before.
 func EnsureInstalled(engine string) error {
-	if SkipBrowserDownload() || EngineInstalled(engine) {
+	return EnsureInstalledForChannel(engine, "")
+}
+
+// EnsureInstalledForChannel installs the engine for a specific Firefox
+// channel. The daemon resolves a per-call --channel that need not match the
+// environment, so installing the environment's channel there would download
+// a Firefox the launch then fails to find.
+func EnsureInstalledForChannel(engine, channel string) error {
+	if SkipBrowserDownload() || EngineInstalledForChannel(engine, channel) {
 		return nil
 	}
 	if engine == "firefox" {
-		_, err := InstallFirefox()
+		_, err := InstallFirefoxForChannel(channel)
 		return err
 	}
 	_, err := Install()

--- a/clicker/internal/browser/ensure_test.go
+++ b/clicker/internal/browser/ensure_test.go
@@ -2,8 +2,12 @@ package browser
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vibium/clicker/internal/paths"
 )
 
 func TestSkipBrowserDownload(t *testing.T) {
@@ -91,5 +95,44 @@ func TestProgressWriterUnknownTotal(t *testing.T) {
 	}
 	if want := "  50 MB downloaded"; lines[1] != want {
 		t.Errorf("second line = %q, want %q", lines[1], want)
+	}
+}
+
+// A per-call channel must decide the install on its own: the daemon resolves
+// --channel per request, so consulting VIBIUM_ENGINE_CHANNEL here would report
+// beta installed because release is, then fail the launch.
+func TestEngineInstalledForChannelIgnoresEnvironmentChannel(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("VIBIUM_CACHE_DIR", cache)
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "release")
+	t.Setenv("VIBIUM_ENGINE_PATH", "")
+	t.Setenv("VIBIUM_ENGINE_VERSION", "")
+
+	exe := paths.FirefoxPathInVersion(filepath.Join(cache, "firefox", "release", "155.0.1"))
+	if err := os.MkdirAll(filepath.Dir(exe), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !EngineInstalledForChannel("firefox", "release") {
+		t.Error("release channel should be installed")
+	}
+	if EngineInstalledForChannel("firefox", "beta") {
+		t.Error("beta channel should not be installed")
+	}
+	if !EngineInstalledForChannel("firefox", "") {
+		t.Error("empty channel should fall back to VIBIUM_ENGINE_CHANNEL (release)")
+	}
+}
+
+// The skip switch must still produce the old hard launch error rather than a
+// silent download, whatever channel is asked for.
+func TestEnsureInstalledForChannelHonorsSkip(t *testing.T) {
+	t.Setenv("VIBIUM_CACHE_DIR", t.TempDir())
+	t.Setenv("VIBIUM_SKIP_BROWSER_DOWNLOAD", "1")
+	if err := EnsureInstalledForChannel("firefox", "beta"); err != nil {
+		t.Errorf("EnsureInstalledForChannel with skip set = %v, want nil (no-op)", err)
 	}
 }

--- a/clicker/internal/browser/installer_firefox.go
+++ b/clicker/internal/browser/installer_firefox.go
@@ -27,15 +27,23 @@ const firefoxVersionsURL = "https://product-details.mozilla.org/1.0/firefox_vers
 // one.
 const pinnedFirefoxVersion = "155.0.1"
 
-// InstallFirefox downloads Firefox from Mozilla's release archive into the
-// vibium cache and returns the executable path. Skips the download if the
-// current version is already installed. The channel comes from
-// VIBIUM_ENGINE_CHANNEL (default "release"; "beta" for pre-release testing).
+// InstallFirefox downloads Firefox for the VIBIUM_ENGINE_CHANNEL channel
+// (default "release"; "beta" for pre-release testing).
+func InstallFirefox() (string, error) {
+	return InstallFirefoxForChannel("")
+}
+
+// InstallFirefoxForChannel downloads Firefox from Mozilla's release archive
+// into the vibium cache and returns the executable path. Skips the download
+// if the current version is already installed. An empty channel means the
+// VIBIUM_ENGINE_CHANNEL default; passing it explicitly lets a long-lived
+// daemon install for a per-call channel without mutating process-wide
+// environment state, mirroring paths.GetFirefoxExecutableForChannel.
 //
 // Windows is unsupported: Mozilla ships only installer executables there, no
 // archive build we can unpack into the cache. Install Firefox manually and
 // set VIBIUM_ENGINE_PATH instead.
-func InstallFirefox() (string, error) {
+func InstallFirefoxForChannel(channel string) (string, error) {
 	if os.Getenv("VIBIUM_SKIP_BROWSER_DOWNLOAD") == "1" {
 		return "", fmt.Errorf("browser download skipped (VIBIUM_SKIP_BROWSER_DOWNLOAD=1)")
 	}
@@ -51,13 +59,15 @@ func InstallFirefox() (string, error) {
 		return "", fmt.Errorf("Firefox auto-install is not supported on Windows: install Firefox and set VIBIUM_ENGINE_PATH to firefox.exe")
 	}
 
-	channel := paths.FirefoxChannel()
+	if channel == "" {
+		channel = paths.FirefoxChannel()
+	}
 	version, err := resolveFirefoxVersion(channel)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch Firefox version info: %w", err)
 	}
 
-	ffDir, err := paths.GetFirefoxDir()
+	ffDir, err := paths.GetFirefoxDirForChannel(channel)
 	if err != nil {
 		return "", fmt.Errorf("failed to get cache dir: %w", err)
 	}
@@ -115,9 +125,19 @@ func InstallFirefox() (string, error) {
 	return exePath, nil
 }
 
-// IsFirefoxInstalled checks if a usable Firefox executable is available.
+// IsFirefoxInstalled checks if a usable Firefox executable is available for
+// the VIBIUM_ENGINE_CHANNEL channel.
 func IsFirefoxInstalled() bool {
-	p, err := paths.GetFirefoxExecutable()
+	return IsFirefoxInstalledForChannel("")
+}
+
+// IsFirefoxInstalledForChannel checks a specific channel's cache. An empty
+// channel means the VIBIUM_ENGINE_CHANNEL default.
+func IsFirefoxInstalledForChannel(channel string) bool {
+	if channel == "" {
+		channel = paths.FirefoxChannel()
+	}
+	p, err := paths.GetFirefoxExecutableForChannel(channel)
 	if err != nil {
 		return false
 	}

--- a/clicker/internal/daemon/client.go
+++ b/clicker/internal/daemon/client.go
@@ -25,6 +25,12 @@ var (
 	// wedged daemon: no launch notification means the plain readTimeout
 	// still applies (#407).
 	launchGrace = browser.LaunchBudget
+
+	// installGrace covers a browser download, which has no bound of its own:
+	// it is the network's, not the launch path's. Matches the ready timeout
+	// the JS, Python, and Java clients already allow when `vibium pipe`
+	// reports the same install (#312).
+	installGrace = 5 * time.Minute
 )
 
 // ToolError is an error the daemon itself reported. It means the daemon was
@@ -158,6 +164,7 @@ func sendRequest(method string, params json.RawMessage) (*agent.Response, error)
 	reader := bufio.NewReader(conn)
 	var line []byte
 	extended := false
+	installExtended := false
 	for {
 		line, err = reader.ReadBytes('\n')
 		if err != nil && len(line) == 0 {
@@ -183,6 +190,13 @@ func sendRequest(method string, params json.RawMessage) (*agent.Response, error)
 			if msg.Method == launchingBrowserMethod && !extended {
 				extended = true
 				conn.SetReadDeadline(time.Now().Add(launchGrace + responseTimeout))
+			}
+			// An install always follows the launch notification that already
+			// extended once, so it gets its own grace on top rather than
+			// sharing the one-shot flag.
+			if msg.Method == installingBrowserMethod && !installExtended {
+				installExtended = true
+				conn.SetReadDeadline(time.Now().Add(installGrace + launchGrace + responseTimeout))
 			}
 			continue
 		}

--- a/clicker/internal/daemon/router.go
+++ b/clicker/internal/daemon/router.go
@@ -31,6 +31,13 @@ type StatusResult struct {
 // JSON-RPC notification (no id) ahead of the response on the same connection.
 const launchingBrowserMethod = "daemon/launchingBrowser"
 
+// installingBrowserMethod is the notification the daemon writes when a launch
+// finds the engine missing and starts downloading it. Distinct from
+// launchingBrowser because a download is not bounded by the launch budget —
+// the client extends by an install grace instead, matching the marker the
+// client libraries already watch for on `vibium pipe` stderr (#312).
+const installingBrowserMethod = "daemon/installingBrowser"
+
 // handleConnection processes a single client connection.
 // Each connection sends one JSON-RPC request and receives one response,
 // optionally preceded by notifications.
@@ -51,12 +58,12 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 
 	// The handler runs synchronously in this goroutine, so the notification
 	// write cannot interleave with the response write below.
-	notifyLaunch := func() {
+	notify := func(method string) {
 		conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-		fmt.Fprintf(conn, "{\"jsonrpc\":\"2.0\",\"method\":%q}\n", launchingBrowserMethod)
+		fmt.Fprintf(conn, "{\"jsonrpc\":\"2.0\",\"method\":%q}\n", method)
 	}
 
-	response := d.handleRequest(line, notifyLaunch)
+	response := d.handleRequest(line, notify)
 	if response == nil {
 		return
 	}
@@ -71,9 +78,10 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 	fmt.Fprintf(conn, "%s\n", data)
 }
 
-// handleRequest parses and routes a JSON-RPC request. notifyLaunch is invoked
-// if handling the request starts a browser launch.
-func (d *Daemon) handleRequest(data []byte, notifyLaunch func()) *agent.Response {
+// handleRequest parses and routes a JSON-RPC request. notify writes a
+// JSON-RPC notification back to the caller when handling the request starts a
+// browser launch, and again if that launch has to download the browser first.
+func (d *Daemon) handleRequest(data []byte, notify func(method string)) *agent.Response {
 	var req agent.Request
 	if err := json.Unmarshal(data, &req); err != nil {
 		return &agent.Response{
@@ -98,7 +106,7 @@ func (d *Daemon) handleRequest(data []byte, notifyLaunch func()) *agent.Response
 		}
 	}
 
-	result, mcpErr := d.route(req, notifyLaunch)
+	result, mcpErr := d.route(req, notify)
 
 	if req.ID == nil {
 		return nil
@@ -120,7 +128,7 @@ func (d *Daemon) handleRequest(data []byte, notifyLaunch func()) *agent.Response
 }
 
 // route dispatches requests to the appropriate handler.
-func (d *Daemon) route(req agent.Request, notifyLaunch func()) (interface{}, *agent.Error) {
+func (d *Daemon) route(req agent.Request, notify func(method string)) (interface{}, *agent.Error) {
 	log.Debug("daemon request", "method", req.Method, "id", req.ID)
 
 	switch req.Method {
@@ -133,9 +141,11 @@ func (d *Daemon) route(req agent.Request, notifyLaunch func()) (interface{}, *ag
 			return nil, &agent.Error{Code: agent.InvalidParams, Message: "Invalid run request"}
 		}
 		d.mu.Lock()
-		d.handlers.SetLaunchNotify(notifyLaunch)
+		d.handlers.SetLaunchNotify(func() { notify(launchingBrowserMethod) })
+		d.handlers.SetInstallNotify(func() { notify(installingBrowserMethod) })
 		result, err := d.handlers.RunCLI(p.Request, p.CLI)
 		d.handlers.SetLaunchNotify(nil)
+		d.handlers.SetInstallNotify(nil)
 		d.mu.Unlock()
 		if err != nil {
 			return nil, &agent.Error{Code: agent.InternalError, Message: err.Error()}
@@ -147,7 +157,8 @@ func (d *Daemon) route(req agent.Request, notifyLaunch func()) (interface{}, *ag
 			return nil, &agent.Error{Code: agent.InvalidParams, Message: "Invalid verification request"}
 		}
 		d.mu.Lock()
-		d.handlers.SetLaunchNotify(notifyLaunch)
+		d.handlers.SetLaunchNotify(func() { notify(launchingBrowserMethod) })
+		d.handlers.SetInstallNotify(func() { notify(installingBrowserMethod) })
 		var result verifier.Result
 		var err error
 		if p.CLI != nil {
@@ -156,6 +167,7 @@ func (d *Daemon) route(req agent.Request, notifyLaunch func()) (interface{}, *ag
 			result, err = d.handlers.Check(p.Request)
 		}
 		d.handlers.SetLaunchNotify(nil)
+		d.handlers.SetInstallNotify(nil)
 		d.mu.Unlock()
 		if err != nil {
 			return nil, &agent.Error{Code: agent.InternalError, Message: err.Error()}
@@ -167,7 +179,7 @@ func (d *Daemon) route(req agent.Request, notifyLaunch func()) (interface{}, *ag
 		go d.Shutdown() // Shutdown asynchronously so we can send response
 		return map[string]string{"status": "shutting down"}, nil
 	case "tools/call":
-		return d.handleToolsCall(req.Params, notifyLaunch)
+		return d.handleToolsCall(req.Params, notify)
 	case "tools/list":
 		return agent.ToolsListResult{
 			Tools: agent.GetToolSchemas(),
@@ -212,7 +224,7 @@ func (d *Daemon) handleInitialize() (interface{}, *agent.Error) {
 }
 
 // handleToolsCall executes a tool and returns the result.
-func (d *Daemon) handleToolsCall(params json.RawMessage, notifyLaunch func()) (interface{}, *agent.Error) {
+func (d *Daemon) handleToolsCall(params json.RawMessage, notify func(method string)) (interface{}, *agent.Error) {
 	var p agent.ToolsCallParams
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, &agent.Error{
@@ -226,9 +238,11 @@ func (d *Daemon) handleToolsCall(params json.RawMessage, notifyLaunch func()) (i
 	// callback targets this request's connection, so it is installed and
 	// cleared under the same lock.
 	d.mu.Lock()
-	d.handlers.SetLaunchNotify(notifyLaunch)
+	d.handlers.SetLaunchNotify(func() { notify(launchingBrowserMethod) })
+	d.handlers.SetInstallNotify(func() { notify(installingBrowserMethod) })
 	result, err := d.handlers.Call(p.Name, p.Arguments)
 	d.handlers.SetLaunchNotify(nil)
+	d.handlers.SetInstallNotify(nil)
 	d.mu.Unlock()
 
 	if err != nil {

--- a/docs/how-to-guides/using-firefox.md
+++ b/docs/how-to-guides/using-firefox.md
@@ -14,7 +14,7 @@ Firefox: /Users/you/Library/Caches/vibium/firefox/release/153.0.3/Firefox.app/Co
 
 Firefox installs into the vibium cache next to Chrome for Testing. The vibium
 binary auto-installs the selected engine on first launch on macOS and Linux,
-same as Chrome, so all clients get it for free. On Windows, Firefox auto-install is not available:
+same as Chrome, so the CLI, MCP, and every client get it for free. On Windows, Firefox auto-install is not available:
 install Firefox yourself and point `VIBIUM_ENGINE_PATH` at `firefox.exe`.
 
 ### Release channels

--- a/tests/mcp/page-pinning.test.js
+++ b/tests/mcp/page-pinning.test.js
@@ -180,4 +180,30 @@ describe('MCP: page pinning', () => {
     const diff = text(await client.tool('browser_diff_map', { page: pageA }));
     assert.strictEqual(diff, 'No changes detected', "an unchanged page must not diff against another page's map");
   });
+
+  test('a pinned screenshot captures its background page without stalling', async () => {
+    // browser_new_page activates what it creates, so a pinned page is normally
+    // the background tab. Headless Chrome composites no frame for one, and
+    // captureScreenshot then blocked until the 60s BiDi timeout rather than
+    // returning: the whole verifier run died on it under xvfb on CI while
+    // every router-backed client passed, because vibium:browser.newPage leaves
+    // the foreground alone. Times out here rather than hanging the suite.
+    const pageA = pageIdFrom(await client.tool('browser_new_page', { url: URL_A }));
+    const pageB = pageIdFrom(await client.tool('browser_new_page', { url: URL_B }));
+
+    const started = Date.now();
+    const result = await client.tool('browser_screenshot', { page: pageA });
+    const elapsed = Date.now() - started;
+
+    assert.ok(!result.isError, `pinned screenshot failed: ${text(result)}`);
+    assert.ok((result.content || []).some((c) => c.type === 'image'),
+      `expected image content, got: ${JSON.stringify(result.content)}`);
+    assert.ok(elapsed < 30000, `pinned screenshot took ${elapsed}ms; a background-tab stall runs to the 60s BiDi timeout`);
+
+    // Raising the pinned page for the capture must not leave it in front.
+    assert.match(text(await client.tool('browser_get_title', {})), /page-b/,
+      'the ambient page must be restored after a pinned screenshot');
+    assert.match(text(await client.tool('browser_get_title', { page: pageA })), /page-a/);
+    assert.ok(pageB);
+  });
 });


### PR DESCRIPTION
## The gap

`#312` moved browser install orchestration out of the JS, Python and Java clients and into the binary — but wired it into the one entrypoint those clients use, `vibium pipe`. `browser.EnsureInstalled` has had exactly one caller in the repo ever since.

The CLI and MCP reach a browser through the daemon's launch path instead. It never called it, so on a machine with no engine installed:

```
$ vibium --engine firefox go https://example.com
failed to launch browser: Firefox not found: run `vibium install --engine firefox` or set VIBIUM_ENGINE_PATH
```

…while the same launch from a client library downloads Firefox and just works. `docs/how-to-guides/using-firefox.md` already promised the former behavior ("auto-installs the selected engine on first launch … same as Chrome").

CI has been showing both halves in a single job. The chrome job's `test-run` suite drives Firefox twice — once through the CLI (`tests/run/cli.test.js`), once through the JS client (`tests/run/surfaces.test.js`). Nothing installs Firefox in that job, so the client case installs it and passes, and the CLI case is what turned #484's run red:

```
✖ Run ownership and evidence {"engine":"firefox"}
  {"ok":false,"error":"failed to launch browser: Firefox not found: ..."}
```

## The change

`browserLaunch` ensures the engine before launching. `VIBIUM_SKIP_BROWSER_DOWNLOAD` restores the old hard error.

Three things follow from putting it there rather than in `pipe`:

- **Per-call channel.** The daemon resolves `--channel` per request and it need not match `VIBIUM_ENGINE_CHANNEL`, so `EnsureInstalledForChannel` / `EngineInstalledForChannel` take the channel explicitly, mirroring the existing `paths.GetFirefoxExecutableForChannel` convention. Installing the environment's channel here would download a Firefox the launch then fails to find.
- **Deadline.** A download is not bounded by the launch budget, so the daemon sends a distinct `daemon/installingBrowser` notification and the client extends its read deadline by a 5 minute install grace — the same allowance the clients already make for `pipe`'s install marker. Without it the CLI times out mid-download on a slow link.
- **MCP stdout.** The MCP server runs handlers in process and writes JSON-RPC to `os.Stdout`, so it now points `os.Stdout` at stderr once the server has captured the real one. Installer progress would otherwise land in the middle of the protocol stream. Same guard `pipe` uses.

## Verification

Simulated a fresh machine with `VIBIUM_CACHE_DIR` pointed at an empty directory:

```
# escape hatch unchanged
$ VIBIUM_SKIP_BROWSER_DOWNLOAD=1 vibium --json --headless --engine firefox go ...
{"ok":false,"error":"failed to launch browser: Firefox not found: run `vibium install --engine firefox` ..."}

# fresh machine, CLI installs and launches (39s, incl. download)
$ vibium --json --headless --engine firefox go ...
{"ok":true,"result":"Navigated to ..."}
$ ls $CACHE/firefox/release/   # 155.0.1

# release cached, beta asked for -> installs beta, launches beta
$ vibium --json --headless --engine firefox --channel beta go ...
$ ls $CACHE/firefox/           # beta  release
```

Plus two hermetic unit tests in `ensure_test.go` covering the channel routing and the skip switch.

`make test` green locally (11m42s), including `Run ownership and evidence {"engine":"firefox"}`.

## Note on coverage

This makes the failing case pass in the chrome job for the right reason, and adds no CI time — the job already downloads Firefox once for the client case; it just happens earlier now. Worth a separate look: the `firefox` job runs only `test-firefox` and `test-firefox-capabilities`, so it never exercises `test-run` at all. Left alone here.
