### PR TITLE
Raise a pinned page before screenshotting it

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -1126,6 +1126,25 @@ func (h *Handlers) browserScreenshot(args map[string]interface{}) (*ToolsCallRes
 	if err != nil {
 		return nil, err
 	}
+
+	// A pinned page (#383) is usually not the foreground tab, and headless
+	// Chrome composites no frame for a background one: captureScreenshot then
+	// blocks until the BiDi timeout instead of returning. Raise the target for
+	// the capture and put the previous tab back. This surface reaches it and
+	// the router-backed clients do not because browser_new_page activates the
+	// page it creates (browserNewPage) while vibium:browser.newPage leaves the
+	// foreground alone. Firefox 155 refuses activate as privileged, so a
+	// failure here is not fatal — the capture is still worth attempting.
+	if ctx != "" && h.activeContext != "" && ctx != h.activeContext {
+		if err := api.SwitchPage(s, ctx); err == nil {
+			defer func() {
+				if err := api.SwitchPage(s, h.activeContext); err != nil {
+					log.Warn("failed to restore the active page after a pinned screenshot", "context", h.activeContext, "error", err)
+				}
+			}()
+		}
+	}
+
 	base64Data, err := api.Screenshot(s, ctx, fullPage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to capture screenshot: %w", err)

--- a/tests/mcp/page-pinning.test.js
+++ b/tests/mcp/page-pinning.test.js
@@ -180,4 +180,30 @@ describe('MCP: page pinning', () => {
     const diff = text(await client.tool('browser_diff_map', { page: pageA }));
     assert.strictEqual(diff, 'No changes detected', "an unchanged page must not diff against another page's map");
   });
+
+  test('a pinned screenshot captures its background page without stalling', async () => {
+    // browser_new_page activates what it creates, so a pinned page is normally
+    // the background tab. Headless Chrome composites no frame for one, and
+    // captureScreenshot then blocked until the 60s BiDi timeout rather than
+    // returning: the whole verifier run died on it under xvfb on CI while
+    // every router-backed client passed, because vibium:browser.newPage leaves
+    // the foreground alone. Times out here rather than hanging the suite.
+    const pageA = pageIdFrom(await client.tool('browser_new_page', { url: URL_A }));
+    const pageB = pageIdFrom(await client.tool('browser_new_page', { url: URL_B }));
+
+    const started = Date.now();
+    const result = await client.tool('browser_screenshot', { page: pageA });
+    const elapsed = Date.now() - started;
+
+    assert.ok(!result.isError, `pinned screenshot failed: ${text(result)}`);
+    assert.ok((result.content || []).some((c) => c.type === 'image'),
+      `expected image content, got: ${JSON.stringify(result.content)}`);
+    assert.ok(elapsed < 30000, `pinned screenshot took ${elapsed}ms; a background-tab stall runs to the 60s BiDi timeout`);
+
+    // Raising the pinned page for the capture must not leave it in front.
+    assert.match(text(await client.tool('browser_get_title', {})), /page-b/,
+      'the ambient page must be restored after a pinned screenshot');
+    assert.match(text(await client.tool('browser_get_title', { page: pageA })), /page-a/);
+    assert.ok(pageB);
+  });
 });


### PR DESCRIPTION
## The failure

The Check suite's verifier step has been killing CI:

```
✖ MCP live pinned page (86721ms)
  verifier browser action: failed to capture screenshot: timeout waiting for
  response to browsingContext.captureScreenshot after 1m0s
```

It took down `#484`'s merge run (leaving main red) and `#485`'s run. Same commit passed on `#484`'s own PR run, which is what made it look like ordinary flake.

It is not flake in the usual sense — it is one surface, every time the timing lines up. Every other client runs the identical eight-step flow over the identical two pages:

```
✔ JavaScript async   live pinned page (12181ms)
✔ JavaScript Firefox live pinned page (16552ms)
✔ JavaScript sync    live pinned page  (7220ms)
✔ Python async       live pinned page  (7201ms)
✔ Python sync        live pinned page  (7249ms)
✔ Java               live pinned page  (4425ms)
✖ MCP                live pinned page (86721ms)   ← 60s BiDi timeout + overhead
```

## Root cause

The asymmetry is in how the second page gets created:

- `browserNewPage` (MCP/CLI, `handlers.go:1577`) calls `api.SwitchPage` → `browsingContext.activate`, bringing the new tab to the front. The comment says *"Activate and track the new page so subsequent commands target it."*
- `handleBrowserNewPage` (router, `handlers_lifecycle.go:41`) creates the context with `browsingContext.create` and never activates.

So a check pinned to the *first* page (#383) targets a **background** tab on MCP and the **foreground** tab everywhere else. Headless Chrome composites no frame for a background tab, so `browsingContext.captureScreenshot` never answers and runs out the 60s timeout. macOS still composites one, which is why it never reproduced locally.

## The change

Raise the target context for the capture, put the previous one back:

- `browser_new_page` keeps activating — a visible browser is the point of the default, and the ambient page is restored either way, so pinning semantics are unchanged.
- Firefox 155 refuses `browsingContext.activate` as privileged (see `launcher_firefox.go:105`), so a failed activate falls through to the capture rather than failing the call.
- The restore is logged, not fatal.

## Verification

`make test-mcp` (61 pass) and `make test-check` (15 pass) green locally, plus three back-to-back runs of `tests/check/surfaces.test.js` before the fix to confirm macOS cannot reproduce the stall (`MCP live pinned page` passed in ~9s each time).

**The honest caveat:** since macOS composites background tabs, neither the failure nor the fix reproduces locally. The new regression test asserts the capture returns well inside the BiDi timeout and that the ambient page survives it — it guards the behavior on Linux headless, which is where the defect lives. CI on this PR is the real verification, and CI has been failing this test 2 runs out of 3.
