### PR TITLE
Make the engine a parameter of the Check and Run suites

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,21 +235,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-firefox-
 
+      # The Check and Run suites below drive Chrome for their non-Firefox
+      # cases. Same key as the chrome job, so this restores what that job
+      # saved rather than downloading Chrome again.
+      - name: Cache Chrome for Testing
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/vibium/chrome-for-testing
+          key: ${{ runner.os }}-chrome-${{ hashFiles('clicker/internal/browser/installer.go') }}
+          restore-keys: |
+            ${{ runner.os }}-chrome-
+
+      # Chrome's sandbox needs this on Ubuntu 24.04, same as the chrome job.
+      - name: Configure kernel for Chrome sandbox
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
       - name: Install dependencies
         run: |
           npm ci
           npm install --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('rollup/package.json').version")
 
-      - name: Build and install Firefox
+      - name: Build and install browsers
         run: |
           make
           make install-firefox
+          make install-browser
 
       - name: Test Firefox capabilities
         run: xvfb-run --auto-servernum make test-firefox-capabilities
 
       - name: Test focused Firefox behavior
         run: xvfb-run --auto-servernum make test-firefox
+
+      # Same suites the chrome job runs, with the engine parameter pointed at
+      # Firefox — the shape every other engine-parity target already uses. A
+      # handful of cases used to name Firefox inside the default suite instead,
+      # so the chrome job ran them against a browser it never installs.
+      - name: Test Check and Run on Firefox
+        run: xvfb-run --auto-servernum make test-check test-run ENGINE=firefox
 
       - name: Clean up zombie processes
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,4 +36,5 @@ Power users can override defaults (headless mode, custom paths, etc.) when neede
 - Prioritize bug fixes over new features
 - Run tests before committing: `make test`
 - Always fix flaky tests immediately when they show up — never dismiss them as "pre-existing"
+- The browser under test is a parameter, never a literal in a test. Suites read `ENGINE` from tests/helpers.js (`VIBIUM_ENGINE`, threaded through the Makefile as `ENGINE=`), and CI runs each suite once per engine job. Naming an engine inside a case in the default suite runs it in the chrome job, which installs no other browser. Adding an engine should be a new job, not a new branch in a test.
 - When adding new command line options to the vibium binary, add a simple example and sample output (or short description)

--- a/Makefile
+++ b/Makefile
@@ -723,10 +723,11 @@ help:
 
 # Check acceptance across the existing pipe and MCP surfaces.
 test-check: build-go build-js build-java python-venv
-	node --test --test-concurrency=1 tests/check/surfaces.test.js tests/daemon/check.test.js tests/daemon/check-lifecycle.test.js tests/daemon/check-archive.test.js
-	VIBIUM_CHECK_ENGINE=firefox node --test --test-concurrency=1 tests/daemon/check.test.js tests/daemon/check-lifecycle.test.js
+	@echo "--- Check Tests ($(ENGINE)) ---"
+	VIBIUM_ENGINE=$(ENGINE) node --test --test-concurrency=1 tests/check/surfaces.test.js tests/daemon/check.test.js tests/daemon/check-lifecycle.test.js tests/daemon/check-archive.test.js
 
 # Deterministic native-provider contracts, live browser behavior, and SDK parity.
 # Real-provider runs are opt-in; no credentials or local model server required.
 test-run: build-go build-js build-java python-venv
-	node --test --test-concurrency=1 tests/naming/*.test.js tests/run/cli.test.js tests/run/overrides.test.js tests/run/surfaces.test.js tests/run/live.test.js
+	@echo "--- Run Tests ($(ENGINE)) ---"
+	VIBIUM_ENGINE=$(ENGINE) node --test --test-concurrency=1 tests/naming/*.test.js tests/run/cli.test.js tests/run/overrides.test.js tests/run/surfaces.test.js tests/run/live.test.js

--- a/tests/check/surfaces.test.js
+++ b/tests/check/surfaces.test.js
@@ -8,6 +8,7 @@ const os = require('node:os');
 const path = require('node:path');
 const exec = promisify(execFile);
 const root = path.resolve(__dirname, '../..');
+const { ENGINE } = require('../helpers');
 const listen = s => new Promise(r => s.listen(0, '127.0.0.1', () => r(`http://127.0.0.1:${s.address().port}`)));
 
 test('Check SDK and MCP surfaces share the native runtime', { timeout: 300000 }, async t => {
@@ -49,11 +50,10 @@ test('Check SDK and MCP surfaces share the native runtime', { timeout: 300000 },
     if (req.url === '/other') { res.end('<h1>Other page</h1><input id="name" value="Other">'); return; }
     res.end(`<!doctype html><title>Account</title><h1>Account</h1><form><label>Display name<input id="name"></label><button>Save</button></form><script>const input=document.querySelector('input');input.value=localStorage.getItem('name')||'Original';document.querySelector('form').onsubmit=e=>{e.preventDefault();localStorage.setItem('name',input.value);console.log('Saved')};</script>`);
   });
-  const env = { ...process.env, VIBIUM_BIN_PATH: path.join(root, 'clicker/bin/vibium'), VIBIUM_CONNECT_URL: '', VIBIUM_ENGINE: 'chrome', VIBIUM_ENGINE_PATH: '', VIBIUM_ENGINE_CHANNEL: '', VIBIUM_AI_PROVIDER: 'openai-compatible', VIBIUM_AI_MODEL: 'fixture', OPENAI_API_KEY: 'fixture-secret', VIBIUM_AI_BASE_URL: `${await listen(provider)}/v1`, CHECK_TEST_URL: await listen(app), CHECK_TEST_INPUT: path.join(root, 'tests/fixtures/check/playwright-checkout.zip') };
+  const env = { ...process.env, VIBIUM_BIN_PATH: path.join(root, 'clicker/bin/vibium'), VIBIUM_CONNECT_URL: '', VIBIUM_ENGINE: ENGINE, VIBIUM_ENGINE_PATH: '', VIBIUM_ENGINE_CHANNEL: '', VIBIUM_AI_PROVIDER: 'openai-compatible', VIBIUM_AI_MODEL: 'fixture', OPENAI_API_KEY: 'fixture-secret', VIBIUM_AI_BASE_URL: `${await listen(provider)}/v1`, CHECK_TEST_URL: await listen(app), CHECK_TEST_INPUT: path.join(root, 'tests/fixtures/check/playwright-checkout.zip') };
   try {
     const runners = [
       ['JavaScript async', process.execPath, [path.join(__dirname, 'sdk-js.cjs')], '0'],
-      ['JavaScript Firefox', process.execPath, [path.join(__dirname, 'sdk-js.cjs')], '0'],
       ['JavaScript sync', process.execPath, [path.join(__dirname, 'sdk-js.cjs')], '1'],
       ['Python async', path.join(root, process.platform === 'win32' ? 'clients/python/.venv/Scripts/python.exe' : 'clients/python/.venv/bin/python'), [path.join(__dirname, 'sdk-python.py')], '0'],
       ['Python sync', path.join(root, process.platform === 'win32' ? 'clients/python/.venv/Scripts/python.exe' : 'clients/python/.venv/bin/python'), [path.join(__dirname, 'sdk-python.py')], '1'],
@@ -64,7 +64,7 @@ test('Check SDK and MCP surfaces share the native runtime', { timeout: 300000 },
       for (const archived of ['0', '1']) {
         await t.test(`${label} ${archived === '1' ? 'archive without browser' : 'live pinned page'}`, async () => {
           const output = path.join(dir, `result-${label.replaceAll(" ", "-")}-${archived}.zip`);
-          const localEnv = { ...env, CHECK_TEST_ENGINE: label.includes('Firefox') ? 'firefox' : 'chrome', CHECK_TEST_SYNC: sync, CHECK_TEST_ARCHIVE_ONLY: archived, CHECK_TEST_OUTPUT: output };
+          const localEnv = { ...env, CHECK_TEST_ENGINE: ENGINE, CHECK_TEST_SYNC: sync, CHECK_TEST_ARCHIVE_ONLY: archived, CHECK_TEST_OUTPUT: output };
           if (archived === '1') { localEnv.VIBIUM_ENGINE = 'firefox'; localEnv.VIBIUM_ENGINE_PATH = '/browser-must-not-launch'; }
           try { await exec(binary, args, { env: localEnv, timeout: 90000 }); }
           catch (err) { t.diagnostic(errors.join('\n')); throw err; }

--- a/tests/daemon/check-lifecycle.test.js
+++ b/tests/daemon/check-lifecycle.test.js
@@ -7,7 +7,7 @@ const http = require('node:http');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { VIBIUM } = require('../helpers');
+const { VIBIUM, ENGINE } = require('../helpers');
 const exec = promisify(execFile);
 
 async function lifecycle(t, { status = 'passed', keepOpen = false, existing = false, idleDaemon = false, mismatch = false, record = true } = {}) {
@@ -31,8 +31,8 @@ async function lifecycle(t, { status = 'passed', keepOpen = false, existing = fa
   });
   await new Promise(resolve => provider.listen(0, '127.0.0.1', resolve));
   const env = { ...process.env, VIBIUM_SESSION: `vl-${process.pid}`,
-    VIBIUM_ENGINE: process.env.VIBIUM_CHECK_ENGINE || 'chrome', VIBIUM_ENGINE_PATH: '',
-    VIBIUM_ENGINE_CHANNEL: process.env.VIBIUM_CHECK_ENGINE === 'firefox' ? 'beta' : '',
+    VIBIUM_ENGINE: ENGINE, VIBIUM_ENGINE_PATH: '',
+    VIBIUM_ENGINE_CHANNEL: ENGINE === 'firefox' ? 'beta' : '',
     VIBIUM_CONNECT_URL: '', VIBIUM_AI_PROVIDER: 'openai-compatible',
     VIBIUM_AI_MODEL: 'fixture', VIBIUM_AI_REASONING_EFFORT: '',
     VIBIUM_AI_BASE_URL: `http://127.0.0.1:${provider.address().port}/v1`, OPENAI_API_KEY: '' };

--- a/tests/daemon/check.test.js
+++ b/tests/daemon/check.test.js
@@ -9,7 +9,7 @@ const http = require('node:http');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { VIBIUM } = require('../helpers');
+const { VIBIUM, ENGINE } = require('../helpers');
 const exec = promisify(execFile);
 const live = process.env.VIBIUM_CHECK_LIVE === '1';
 
@@ -24,7 +24,7 @@ async function acceptance(t, broken = false) {
   const output = path.join(dir, 'verification.zip');
   const report = path.join(dir, 'verdict.json');
   const claim = 'changing my display name persists after refresh';
-  const env = { ...process.env, VIBIUM_SESSION: session, VIBIUM_CONNECT_URL: '', VIBIUM_ENGINE: process.env.VIBIUM_CHECK_ENGINE || 'chrome', VIBIUM_ENGINE_PATH: '', VIBIUM_ENGINE_CHANNEL: process.env.VIBIUM_CHECK_ENGINE === 'firefox' ? 'beta' : '' };
+  const env = { ...process.env, VIBIUM_SESSION: session, VIBIUM_CONNECT_URL: '', VIBIUM_ENGINE: ENGINE, VIBIUM_ENGINE_PATH: '', VIBIUM_ENGINE_CHANNEL: ENGINE === 'firefox' ? 'beta' : '' };
   const cli = async (...args) => {
     const { stdout } = await exec(VIBIUM, ['--json', '--headless', ...args], { env, timeout: 230000, maxBuffer: 4 * 1024 * 1024 });
     const out = JSON.parse(stdout); assert.equal(out.ok, true); return out.result;
@@ -199,7 +199,7 @@ async function acceptance(t, broken = false) {
   }
 }
 
-test(`Check reuses live ${process.env.VIBIUM_CHECK_ENGINE || 'chrome'} and records persistence evidence`, { timeout: 300000 }, t => acceptance(t));
+test(`Check reuses live ${ENGINE} and records persistence evidence`, { timeout: 300000 }, t => acceptance(t));
 test('Check reports a persistence regression', { timeout: 300000, skip: live }, t => acceptance(t, true));
 
 test('Check saves error evidence and preserves recording ownership', { timeout: 120000, skip: live }, async t => {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,4 +1,10 @@
 const path = require('node:path');
 const EXE = process.platform === 'win32' ? '.exe' : '';
 const VIBIUM = path.join(__dirname, '../clicker/bin/vibium') + EXE;
-module.exports = { VIBIUM };
+// The engine under test. CI runs each suite once per engine job by setting
+// VIBIUM_ENGINE, the same parameter the Makefile threads through every
+// engine-parity target as ENGINE. Suites read this instead of naming a
+// browser: a new engine is a new job, not a new branch in the test.
+const ENGINE = process.env.VIBIUM_ENGINE || 'chrome';
+
+module.exports = { VIBIUM, ENGINE };

--- a/tests/run/cli.test.js
+++ b/tests/run/cli.test.js
@@ -5,13 +5,13 @@ const { promisify } = require('node:util');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { VIBIUM } = require('../helpers');
+const { VIBIUM, ENGINE } = require('../helpers');
 const { fixture } = require('./fixture.cjs');
 const exec = promisify(execFile);
 
 async function run(t, options = {}) {
   const f = await fixture(), dir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-cli-'));
-  const env = { ...process.env, ...f.env, VIBIUM_SESSION: `run-${process.pid}`, VIBIUM_ENGINE: options.engine || 'chrome', VIBIUM_ENGINE_CHANNEL: '', VIBIUM_ENGINE_PATH: '', VIBIUM_CONNECT_URL: '', VIBIUM_AI_PROVIDER: options.provider || 'openai-compatible' };
+  const env = { ...process.env, ...f.env, VIBIUM_SESSION: `run-${process.pid}`, VIBIUM_ENGINE: ENGINE, VIBIUM_ENGINE_CHANNEL: '', VIBIUM_ENGINE_PATH: '', VIBIUM_CONNECT_URL: '', VIBIUM_AI_PROVIDER: options.provider || 'openai-compatible' };
   if (env.VIBIUM_AI_PROVIDER === 'openai') env.OPENAI_API_KEY = 'openai-test-key';
   const cli = async (...args) => JSON.parse((await exec(VIBIUM, ['--json', '--headless', ...args], { env, timeout: 230000, maxBuffer: 8*1024*1024 })).stdout).result;
   const output = path.join(dir, 'run.zip'), original = path.join(dir, 'builder.zip');
@@ -53,7 +53,7 @@ async function run(t, options = {}) {
     assert.ok(!trace.includes('native-key') && !trace.includes('PRIVATE-REASONING'));
     const names = (await exec('unzip', ['-Z1', output])).stdout;
     if (options.privacy) { assert.ok(!trace.includes('TEST-PASSWORD-SECRET')); assert.ok(events[0].vibiumPrivacy); assert.ok(!names.includes('video/')); }
-    else if (options.engine === 'firefox' && !options.existing) assert.match(names, /video\/.+\.webm/);
+    else if (ENGINE === 'firefox' && !options.existing) assert.match(names, /video\/.+\.webm/);
     assert.match(await cli('stop'), options.existing || options.keepOpen ? /Browser session closed/ : /No browser session to close/);
   } finally {
     await exec(VIBIUM, ['daemon', 'stop'], { env, timeout: 15000 }).catch(() => {});
@@ -61,7 +61,7 @@ async function run(t, options = {}) {
   }
 }
 for (const provider of ['openai', 'anthropic', 'google', 'openai-compatible', 'local']) test(`Run CLI uses ${provider} browser tools and shared AI configuration`, { timeout: 120000 }, t => run(t, { provider, existing: true }));
-for (const state of [{}, { incomplete: true }, { error: true }, { keepOpen: true }, { keepOpen: true, error: true }, { existing: true, error: true }, { existing: true, privacy: true }, { engine: 'firefox' }]) test(`Run ownership and evidence ${JSON.stringify(state)}`, { timeout: 120000 }, t => run(t, state));
+for (const state of [{}, { incomplete: true }, { error: true }, { keepOpen: true }, { keepOpen: true, error: true }, { existing: true, error: true }, { existing: true, privacy: true }]) test(`Run ownership and evidence ${JSON.stringify(state)}`, { timeout: 120000 }, t => run(t, state));
 test('Run rejects archive/report flags and requires shared AI configuration', async () => {
   // Old per-feature variables must not silently configure the shared model loop.
   for (const args of [['run', 'goal', '-i', 'record.zip'], ['run', 'goal', '--report', 'result.json'], ['run', 'goal']]) {

--- a/tests/run/surfaces.test.js
+++ b/tests/run/surfaces.test.js
@@ -6,17 +6,17 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { fixture } = require('./fixture.cjs');
+const { ENGINE } = require('../helpers');
 const exec = promisify(execFile), root = path.resolve(__dirname, '../..');
 
 test('Run surfaces share tools, recording, and shared AI configuration', { timeout: 300000 }, async t => {
   const f = await fixture(), dir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-surfaces-'));
-  const base = { ...process.env, ...f.env, VIBIUM_BIN_PATH: path.join(root, 'clicker/bin/vibium'), VIBIUM_ENGINE: 'chrome', VIBIUM_ENGINE_CHANNEL: '', VIBIUM_ENGINE_PATH: '', VIBIUM_CONNECT_URL: '', RUN_TEST_URL: f.url };
+  const base = { ...process.env, ...f.env, VIBIUM_BIN_PATH: path.join(root, 'clicker/bin/vibium'), VIBIUM_ENGINE: ENGINE, VIBIUM_ENGINE_CHANNEL: '', VIBIUM_ENGINE_PATH: '', VIBIUM_CONNECT_URL: '', RUN_TEST_URL: f.url };
   try {
     const cases = [
       ['JavaScript async', process.execPath, ['sdk-js.cjs'], '0', 'anthropic'],
       ['JavaScript privacy', process.execPath, ['sdk-js.cjs'], '0', 'google'],
       ['JavaScript sync', process.execPath, ['sdk-js.cjs'], '1', 'google'],
-      ['JavaScript Firefox', process.execPath, ['sdk-js.cjs'], '0', 'local'],
       ['Python async', path.join(root, process.platform === 'win32' ? 'clients/python/.venv/Scripts/python.exe' : 'clients/python/.venv/bin/python'), ['sdk-python.py'], '0', 'openai-compatible'],
       ['Python sync', path.join(root, process.platform === 'win32' ? 'clients/python/.venv/Scripts/python.exe' : 'clients/python/.venv/bin/python'), ['sdk-python.py'], '1', 'anthropic'],
       ['Java', 'java', ['-cp', path.join(root, 'clients/java/build/libs/*') + path.delimiter + path.join(root, 'clients/java/build/dependencies/*'), 'RunSDK.java'], '0', 'google'],
@@ -24,7 +24,7 @@ test('Run surfaces share tools, recording, and shared AI configuration', { timeo
     ];
     for (const [name, bin, args, sync, provider] of cases) await t.test(name, async () => {
       const output = path.join(dir, `${name}.zip`);
-      const env = { ...base, RUN_TEST_OUTPUT: output, RUN_TEST_SYNC: sync, RUN_TEST_PRIVACY: name.includes('privacy') ? '1' : '0', RUN_TEST_ENGINE: name.includes('Firefox') ? 'firefox' : 'chrome', VIBIUM_AI_PROVIDER: provider };
+      const env = { ...base, RUN_TEST_OUTPUT: output, RUN_TEST_SYNC: sync, RUN_TEST_PRIVACY: name.includes('privacy') ? '1' : '0', RUN_TEST_ENGINE: ENGINE, VIBIUM_AI_PROVIDER: provider };
       try { await exec(bin, args.map(a => /\.(cjs|py|java)$/.test(a) ? path.join(__dirname, a) : a), { env, timeout: 120000 }); }
       catch (err) { t.diagnostic(f.errors.join('\n')); throw err; }
       const trace = (await exec('unzip', ['-p', output, 'trace.trace'], { maxBuffer: 16*1024*1024 })).stdout;


### PR DESCRIPTION
Closes #493. Supersedes #489, which GitHub auto-closed when its base branch (#486) was merged and deleted; same commit, retargeted to `main`.

## Why

Five Firefox tests run inside the **chrome** CI job, which installs only Chrome:

```
✔ JavaScript Firefox live pinned page   (15899ms)   tests/check/surfaces.test.js  ← channel: beta
✔ JavaScript Firefox archive without browser         tests/check/surfaces.test.js
✔ Check reuses live firefox              (5484ms)   Makefile test-check, 2nd pass
✔ JavaScript Firefox                    (16399ms)   tests/run/surfaces.test.js
✖ Run ownership and evidence {"engine":"firefox"}    tests/run/cli.test.js
```

Minutes earlier in the same job, the correctly-written Firefox tests self-skip:

```
﹣ navigate, click, and screenshot work on Firefox   # Firefox not installed
﹣ recording captures a native video track           # Firefox not installed
```

Firefox is absent, and four Firefox tests run anyway — the client path downloads one mid-suite. There is no Firefox cache in that job, so it repeats every run, release *and* beta. The fifth goes through the CLI and simply failed; that is what turned #484's run red.

## The change

Every other engine-parity target already had the answer: `ENGINE ?= chrome`, threaded to tests as `VIBIUM_ENGINE`, with a firefox job re-running the same files at `ENGINE=firefox` (`test-firefox-capabilities` is literally `test-engine ENGINE=firefox`). The engine is a **parameter**; those tests never name a browser.

The Check and Run suites now follow it:

- they read `ENGINE` from `tests/helpers.js`
- `test-check` / `test-run` take `ENGINE` like their neighbours
- the firefox job runs `make test-check test-run ENGINE=firefox`
- `tests/daemon/check*.test.js` drop `VIBIUM_CHECK_ENGINE`, a private spelling of the same parameter
- the hardcoded `{engine:'firefox'}` case and both `JavaScript Firefox` rows are gone

An engine literal is now absent from these suites, so a third engine is **a new job, not a new branch in every suite**. No skip flags, no `requireFirefox`. I built that version first and threw it away — it was one hack per browser.

## Coverage goes up

Firefox used to reach exactly one surface, the JavaScript async client:

```
--- Check Tests (firefox) ---
  ✔ JavaScript async live pinned page   ✔ JavaScript sync live pinned page
  ✔ Python async live pinned page       ✔ Python sync live pinned page
  ✔ Java live pinned page               ✔ MCP live pinned page
  29 pass, 0 fail
```

…and the chrome job stops launching Firefox at all.

## Verification

Locally, both engines, both suites:

| | chrome | firefox |
|---|---|---|
| `make test-check` | 29 pass, 0 fail | 29 pass, 0 fail |
| `make test-run` | 28 pass, 0 fail | 28 pass, 0 fail |

The firefox job gains the Chrome cache (same key as the chrome job, so it restores rather than downloads) and `make install-browser`, since the suites' non-engine-specific surfaces still drive Chrome.

`CLAUDE.md` gains the rule — the convention was discoverable only by reading the Makefile, which is how it got missed.
