### PR TITLE
Read VIBIUM_ENGINE_CHANNEL, the name the binary actually honours

### DIFF
--- a/docs/presentations/vibe-check/README.md
+++ b/docs/presentations/vibe-check/README.md
@@ -111,7 +111,7 @@ MEETUP_CAPTURE_DIR=/tmp/my-meetup-capture \
   node demo/capture.mjs
 ~~~
 
-In the repository it defaults to clicker/bin/vibium. Outside the checkout, set VIBIUM_BIN_PATH to the absolute path of a compatible Vibium binary. The script also requires unzip. It defaults to Firefox beta; set VIBIUM_FIREFOX_CHANNEL to choose another installed channel. It uses the VIBIUM_AI provider/model settings explicitly for both roles for this comparison.
+In the repository it defaults to clicker/bin/vibium. Outside the checkout, set VIBIUM_BIN_PATH to the absolute path of a compatible Vibium binary. The script also requires unzip. It defaults to Firefox beta; set VIBIUM_ENGINE_CHANNEL to choose another installed channel. It uses the VIBIUM_AI provider/model settings explicitly for both roles for this comparison.
 
 The script creates WebM files. Generate MP4 copies and captions from the saved
 recording timestamps with ffmpeg and ffprobe installed:

--- a/docs/presentations/vibe-check/demo/capture.mjs
+++ b/docs/presentations/vibe-check/demo/capture.mjs
@@ -16,7 +16,7 @@ if(!model)throw new Error('Configure VIBIUM_AI_MODEL and its provider credential
 const provider=process.env.VIBIUM_AI_PROVIDER||'openai';
 const settings=['--provider',provider,'--model',model,'--base-url',process.env.VIBIUM_AI_BASE_URL||'','--reasoning-effort',process.env.VIBIUM_AI_REASONING_EFFORT||''];
 const bin=process.env.VIBIUM_BIN_PATH||path.join(root,'clicker/bin/vibium');
-const env={...process.env,VIBIUM_SESSION:`meetup-capture-${process.pid}`,VIBIUM_ENGINE:'firefox',VIBIUM_ENGINE_PATH:'',VIBIUM_ENGINE_CHANNEL:process.env.VIBIUM_FIREFOX_CHANNEL||'beta',VIBIUM_CONNECT_URL:''};
+const env={...process.env,VIBIUM_SESSION:`meetup-capture-${process.pid}`,VIBIUM_ENGINE:'firefox',VIBIUM_ENGINE_PATH:'',VIBIUM_ENGINE_CHANNEL:process.env.VIBIUM_ENGINE_CHANNEL||'beta',VIBIUM_CONNECT_URL:''};
 const cli=async(...args)=>{
   let stdout;
   try { ({stdout}=await exec(bin,['--headless','--json',...args],{env,timeout:240000,maxBuffer:16*1024*1024})); }

--- a/scripts/var-parts-video-smoke.mjs
+++ b/scripts/var-parts-video-smoke.mjs
@@ -4,7 +4,7 @@
 //   node scripts/var-parts-video-smoke.mjs
 //
 // Firefox 154 is required for video. Until it reaches stable on 2026-08-18 the
-// beta channel is needed; VIBIUM_FIREFOX_CHANNEL overrides if that has landed.
+// beta channel is needed; VIBIUM_ENGINE_CHANNEL overrides if that has landed.
 
 import { firefox } from "../clients/javascript/dist/index.mjs";
 import { execFileSync } from "child_process";
@@ -15,7 +15,7 @@ import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const outPath = path.resolve(__dirname, "..", "var-parts-video-record.zip");
-const channel = process.env.VIBIUM_FIREFOX_CHANNEL || "beta";
+const channel = process.env.VIBIUM_ENGINE_CHANNEL || "beta";
 
 const failures = [];
 function check(ok, label) {


### PR DESCRIPTION
`2e7ca1b` renamed the engine options to engine-neutral names before they shipped, but three readers of the old spelling were missed.

There is no fallback in the binary — `paths.FirefoxChannel` looks only at `VIBIUM_ENGINE_CHANNEL`:

```go
func FirefoxChannel() string {
	if c := os.Getenv("VIBIUM_ENGINE_CHANNEL"); c != "" {
		return c
	}
	return "release"
}
```

So setting `VIBIUM_FIREFOX_CHANNEL` does nothing at all, silently, and the caller gets the beta default they were trying to override.

| file | what it did with it |
|---|---|
| `scripts/var-parts-video-smoke.mjs` | picked the channel from it |
| `docs/presentations/vibe-check/demo/capture.mjs` | forwarded it into the child environment |
| `docs/presentations/vibe-check/README.md` | told readers to set it |

A straight rename, since nothing honours the old name and there is no compatibility to preserve.

## Verification

```
$ grep -rn "VIBIUM_FIREFOX_CHANNEL\|VIBIUM_FIREFOX_PATH" .   # excluding node_modules/.venv/dist
(no matches)

$ node --check scripts/var-parts-video-smoke.mjs             # OK
$ node --check docs/presentations/vibe-check/demo/capture.mjs # OK
```

Neither script runs in CI — both are manual — so the suite cannot catch this class of drift. Found while merging `browser-clouds`, whose Java client carried the same stale name.
