### PR TITLE
Re-apply global flags after the late flag parse

### DIFF
--- a/clicker/cmd/clicker/helpers.go
+++ b/clicker/cmd/clicker/helpers.go
@@ -89,5 +89,14 @@ func parseFlagsAllowNegative(cmd *cobra.Command, raw []string) ([]string, error)
 		os.Exit(0)
 	}
 
+	// The root's PersistentPreRunE ran before this parse, so it computed the
+	// *Set booleans, the validations and the env-var bridges from unset
+	// values. Re-apply them now that the flags hold what the user passed;
+	// otherwise --session and --channel are accepted and silently ignored on
+	// every command that reaches this helper (#482).
+	if err := applyGlobalFlags(cmd); err != nil {
+		return nil, err
+	}
+
 	return positionals, nil
 }

--- a/clicker/cmd/clicker/main.go
+++ b/clicker/cmd/clicker/main.go
@@ -75,6 +75,69 @@ func defaultEngine() string {
 	return "chrome"
 }
 
+// applyGlobalFlags computes the state the persistent flags control: the *Set
+// booleans, the log level, the env-var bridges for --session and --channel,
+// and the engine, channel and session validation.
+//
+// It runs from the root's PersistentPreRunE, and again from
+// parseFlagsAllowNegative for the commands that set DisableFlagParsing. Those
+// parse their flags inside Run, after PersistentPreRunE has already read them
+// as unset, so without the second pass --session and --channel are accepted
+// and silently ignored (#482).
+func applyGlobalFlags(cmd *cobra.Command) error {
+	headlessSet = cmd.Flags().Changed("headless")
+	engineSet = cmd.Flags().Changed("engine") || os.Getenv("VIBIUM_ENGINE") != ""
+	channelSet = cmd.Flags().Changed("channel") || os.Getenv("VIBIUM_ENGINE_CHANNEL") != ""
+	// Enable logging only if --verbose is used
+	if verbose {
+		log.Setup(log.LevelVerbose)
+	}
+	// Bridge the flag to the env var so the paths package and any
+	// auto-started daemon child process resolve the same session.
+	if session != "" {
+		if err := os.Setenv("VIBIUM_SESSION", session); err != nil {
+			return err
+		}
+	}
+	if cmd.Name() == "pipe" {
+		noBrowser, _ := cmd.Flags().GetBool("no-browser")
+		if noBrowser {
+			return paths.ValidateSessionName(paths.SessionName())
+		}
+	}
+	if engineName != "chrome" && engineName != "firefox" {
+		return fmt.Errorf("unsupported engine %q (supported: chrome, firefox)", engineName)
+	}
+	// Channels differ per engine: Mozilla's are release/beta, Chrome
+	// for Testing's are stable/beta/dev/canary.
+	if engineChannel != "" {
+		valid := map[string][]string{
+			"firefox": {"release", "beta"},
+			"chrome":  {"stable", "beta", "dev", "canary"},
+		}[engineName]
+		if !slices.Contains(valid, engineChannel) {
+			return fmt.Errorf("unsupported channel %q for %s (supported: %s)",
+				engineChannel, engineName, strings.Join(valid, ", "))
+		}
+	}
+	// VIBIUM_ENGINE_PATH is an engine-neutral name but only Firefox
+	// implements it. Say so rather than accepting the setting and
+	// ignoring it.
+	if engineName != "firefox" && os.Getenv("VIBIUM_ENGINE_PATH") != "" {
+		return fmt.Errorf("VIBIUM_ENGINE_PATH is not supported for engine %q (firefox only)", engineName)
+	}
+	// Bridge the flag to the env var, like --session: the paths
+	// package resolves the channel from the environment at both
+	// install and launch time, and a daemon child process spawned
+	// later inherits it.
+	if engineChannel != "" {
+		if err := os.Setenv("VIBIUM_ENGINE_CHANNEL", engineChannel); err != nil {
+			return err
+		}
+	}
+	return paths.ValidateSessionName(paths.SessionName())
+}
+
 func main() {
 	progName := filepath.Base(os.Args[0])
 
@@ -95,57 +158,7 @@ func main() {
 			if isReadyCommand(cmd) {
 				return nil
 			}
-			headlessSet = cmd.Flags().Changed("headless")
-			engineSet = cmd.Flags().Changed("engine") || os.Getenv("VIBIUM_ENGINE") != ""
-			channelSet = cmd.Flags().Changed("channel") || os.Getenv("VIBIUM_ENGINE_CHANNEL") != ""
-			// Enable logging only if --verbose is used
-			if verbose {
-				log.Setup(log.LevelVerbose)
-			}
-			// Bridge the flag to the env var so the paths package and any
-			// auto-started daemon child process resolve the same session.
-			if session != "" {
-				if err := os.Setenv("VIBIUM_SESSION", session); err != nil {
-					return err
-				}
-			}
-			if cmd.Name() == "pipe" {
-				noBrowser, _ := cmd.Flags().GetBool("no-browser")
-				if noBrowser {
-					return paths.ValidateSessionName(paths.SessionName())
-				}
-			}
-			if engineName != "chrome" && engineName != "firefox" {
-				return fmt.Errorf("unsupported engine %q (supported: chrome, firefox)", engineName)
-			}
-			// Channels differ per engine: Mozilla's are release/beta, Chrome
-			// for Testing's are stable/beta/dev/canary.
-			if engineChannel != "" {
-				valid := map[string][]string{
-					"firefox": {"release", "beta"},
-					"chrome":  {"stable", "beta", "dev", "canary"},
-				}[engineName]
-				if !slices.Contains(valid, engineChannel) {
-					return fmt.Errorf("unsupported channel %q for %s (supported: %s)",
-						engineChannel, engineName, strings.Join(valid, ", "))
-				}
-			}
-			// VIBIUM_ENGINE_PATH is an engine-neutral name but only Firefox
-			// implements it. Say so rather than accepting the setting and
-			// ignoring it.
-			if engineName != "firefox" && os.Getenv("VIBIUM_ENGINE_PATH") != "" {
-				return fmt.Errorf("VIBIUM_ENGINE_PATH is not supported for engine %q (firefox only)", engineName)
-			}
-			// Bridge the flag to the env var, like --session: the paths
-			// package resolves the channel from the environment at both
-			// install and launch time, and a daemon child process spawned
-			// later inherits it.
-			if engineChannel != "" {
-				if err := os.Setenv("VIBIUM_ENGINE_CHANNEL", engineChannel); err != nil {
-					return err
-				}
-			}
-			return paths.ValidateSessionName(paths.SessionName())
+			return applyGlobalFlags(cmd)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()

--- a/tests/cli/global-flags.test.js
+++ b/tests/cli/global-flags.test.js
@@ -1,0 +1,70 @@
+/**
+ * CLI Tests: global flags on commands that disable cobra flag parsing
+ *
+ * fill, type, geolocation, and sleep parse their flags inside Run, after the
+ * root's PersistentPreRunE has already read them as unset. Regression tests
+ * for #482: --session and --channel were accepted and silently ignored, so
+ * the command targeted the default session and --channel validation (#314)
+ * never ran.
+ *
+ * All cases must short-circuit on validation before any daemon call, so no
+ * browser or daemon is needed.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { VIBIUM } = require('../helpers');
+
+function run(args) {
+  const result = spawnSync(VIBIUM, args, {
+    encoding: 'utf-8',
+    timeout: 30000,
+    env: { ...process.env, VIBIUM_SESSION: `global-flags-test-${process.pid}` },
+  });
+  assert.strictEqual(result.error, undefined, `spawn failed: ${result.error}`);
+  return result;
+}
+
+// Arguments that would be valid if the flag under test were honored.
+const COMMANDS = {
+  fill: ['#a', 'x'],
+  type: ['#a', 'x'],
+  geolocation: ['37.8', '-122.4'],
+  sleep: ['100'],
+};
+
+describe('CLI: late-parsed commands honor global flag validation (#482)', () => {
+  // --channel validation lives in the global-flag bridge; before the fix it
+  // ran against an unset value on these four commands, so a bogus channel
+  // was accepted and the setting dropped.
+  for (const [cmd, args] of Object.entries(COMMANDS)) {
+    test(`${cmd} rejects --channel bogus like every other command`, () => {
+      const result = run([cmd, ...args, '--channel', 'bogus']);
+      assert.strictEqual(result.status, 1, `expected exit 1, got ${result.status}\nstdout: ${result.stdout}`);
+      assert.match(result.stderr, /unsupported channel "bogus"/);
+    });
+  }
+
+  // --session goes through the same bridge; an invalid name proves the value
+  // now lands there instead of being read as empty.
+  test('sleep rejects an invalid --session name', () => {
+    const result = run(['sleep', '100', '--session', 'bad/name']);
+    assert.strictEqual(result.status, 1, `expected exit 1, got ${result.status}\nstdout: ${result.stdout}`);
+    assert.match(result.stderr, /invalid session name/);
+  });
+
+  test('fill rejects an invalid --session name given before the command', () => {
+    const result = run(['--session', 'bad/name', 'fill', '#a', 'x']);
+    assert.strictEqual(result.status, 1, `expected exit 1, got ${result.status}\nstdout: ${result.stdout}`);
+    assert.match(result.stderr, /invalid session name/);
+  });
+
+  // Guardrail: a validation failure must not report the arity error instead,
+  // which would mean the parse itself broke.
+  test('geolocation with a negative positional still reaches channel validation', () => {
+    const result = run(['geolocation', '37.8', '-122.4', '--channel', 'bogus']);
+    assert.doesNotMatch(result.stderr, /accepts 2 arg\(s\)/);
+    assert.match(result.stderr, /unsupported channel "bogus"/);
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#482

fill, type, geolocation and sleep set DisableFlagParsing and parse their flags inside Run via parseFlagsAllowNegative. The parse itself is fine, but everything that gives the global flags effect lives in the root's PersistentPreRunE, which ran before Run with the flags still unset. So --session was accepted and the command silently targeted the default session, the documented flag-over-env precedence was inverted, and --channel validation (#314) never ran on these four commands.

The fix extracts the PersistentPreRunE body into applyGlobalFlags and runs it again from parseFlagsAllowNegative once the flags hold what the user passed. The ready early-return stays in PersistentPreRunE; the pipe --no-browser early return moves with the body and behaves identically since it keys off the command name.

Root cause analysis and the fix shape come from lana-20's report on #482, adapted to main, which has since grown the ready and pipe early-returns in PersistentPreRunE.

Verified:
- tests/cli/global-flags.test.js fails on main: `sleep 100 --channel bogus` and `sleep 100 --session bad/name` both exit 0 there, exit 1 with the fix
- new suite passes (7 tests), no daemon or browser needed: validation short-circuits before daemonCall
- tests/cli/help-flags.test.js still passes (19 tests), so the #422/#423 help interception and negative-positional behavior survive
- go build, go vet, go test ./cmd/clicker green