### PR TITLE
Classify Java client errors by specific phrases, not bare substrings

### DIFF
--- a/clients/java/src/main/java/com/vibium/internal/BiDiClient.java
+++ b/clients/java/src/main/java/com/vibium/internal/BiDiClient.java
@@ -251,7 +251,7 @@ public class BiDiClient {
     /**
      * Map wire error strings to Java exceptions.
      */
-    private static VibiumException mapError(String error, String message) {
+    static VibiumException mapError(String error, String message) {
         if ("not_found".equals(error) || "no_such_element".equals(error)) {
             return new ElementNotFoundException(message);
         }
@@ -265,8 +265,13 @@ public class BiDiClient {
             return new VibiumTimeoutException(message);
         }
 
+        // Match the same specific phrases the timeout branch uses. A bare
+        // "not found" also matches text the client does not own, like a
+        // page's own Error(...) string or an engine diagnostic, so an
+        // unrelated failure whose wording happened to contain it was
+        // reported as a missing element. This mirrors the Python client.
         String lower = message.toLowerCase();
-        if (lower.contains("not found") || lower.contains("no elements")) {
+        if (lower.contains("element not found") || lower.contains("no elements found")) {
             return new ElementNotFoundException(message);
         }
 

--- a/clients/java/src/test/java/com/vibium/internal/BiDiClientTest.java
+++ b/clients/java/src/test/java/com/vibium/internal/BiDiClientTest.java
@@ -1,6 +1,8 @@
 package com.vibium.internal;
 
 import com.vibium.errors.ElementNotFoundException;
+import com.vibium.errors.VibiumException;
+import com.vibium.errors.VibiumTimeoutException;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -27,5 +29,44 @@ class BiDiClientTest {
     private void attachFromUserCall(ElementNotFoundException error) {
         StackTraceElement[] callerStack = BiDiClient.captureCallerStack();
         BiDiClient.attachCallerStack(error, callerStack);
+    }
+
+    // #483: classification must not depend on wording the client does not
+    // own. A page's own error text containing "not found" is not an element
+    // lookup failure.
+
+    @Test
+    void scriptErrorMentioningNotFoundIsNotAnElementError() {
+        VibiumException e = BiDiClient.mapError("error",
+            "eval failed: script exception: Error: widget not found in registry");
+        assertEquals(VibiumException.class, e.getClass());
+    }
+
+    @Test
+    void scriptErrorMentioningNoElementsIsNotAnElementError() {
+        VibiumException e = BiDiClient.mapError("error",
+            "eval failed: script exception: Error: no elements match the filter");
+        assertEquals(VibiumException.class, e.getClass());
+    }
+
+    @Test
+    void realElementFailureStillMapsThroughTheTimeoutBranch() {
+        VibiumException e = BiDiClient.mapError("timeout",
+            "timeout after 30s waiting for '#gone': element not found");
+        assertEquals(ElementNotFoundException.class, e.getClass());
+    }
+
+    @Test
+    void elementNotFoundPhraseOutsideTimeoutStillMaps() {
+        VibiumException e = BiDiClient.mapError("error",
+            "element not found");
+        assertEquals(ElementNotFoundException.class, e.getClass());
+    }
+
+    @Test
+    void plainTimeoutStaysATimeout() {
+        VibiumException e = BiDiClient.mapError("timeout",
+            "timeout after 30s waiting for network idle");
+        assertEquals(VibiumTimeoutException.class, e.getClass());
     }
 }


### PR DESCRIPTION
Fixes VibiumDev/vibium#483

BiDiClient.mapError falls back to searching the error message for "not found" and "no elements", so any failure whose text contains those words becomes ElementNotFoundException. The text can be a page's own Error(...) string or an engine diagnostic, wording nobody in vibium controls, so catch blocks and retry loops keyed on that exception fire on failures that are not element lookups. lana-20's report demonstrates it with a script exception reading "widget not found in registry".

The fix narrows the fallback to the same two phrases the timeout branch above it already matches, "element not found" and "no elements found". That is what the Python client matches too, so Java moves toward the Python contract rather than inventing a new one. The report measured that every reproducible element failure arrives as wire code timeout with "element not found" in the message, so genuine misses keep their type through the branch that already handles them.

mapError goes from private to package-private so the test can call it, following captureCallerStack and attachCallerStack in the same class.

The report also offered a stricter shape that drops the message heuristic entirely. This PR takes the narrow one: same measured behavior, smaller behavioral bet, and it keeps a real "element not found" arriving under wire code "error" correctly typed.

Verified:
- two new tests fail against main's classification (script errors mentioning "not found" / "no elements" came back as ElementNotFoundException; 6 tests, 2 failed with only the fallback line reverted)
- BiDiClientTest passes with the fix: 6 tests, 0 failures
- classification of real element misses, the "element not found" phrase under a non-timeout code, and plain timeouts are covered and unchanged