### PR TITLE
Validate upload paths in the daemon and surface setFiles rejections

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -4155,7 +4155,7 @@ func (h *Handlers) browserUpload(args map[string]interface{}) (*ToolsCallResult,
 	if err != nil {
 		return nil, err
 	}
-	if err := api.Upload(s, ctx, elementParamsWithTimeout(selector, args), files); err != nil {
+	if err := api.Upload(s, ctx, elementParamsWithTimeout(selector, args), files, h.connectURL != ""); err != nil {
 		return nil, fmt.Errorf("failed to set files: %w", err)
 	}
 

--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -553,27 +553,10 @@ func (r *Router) handleVibiumElSetFiles(session *BrowserSession, cmd bidiCommand
 		files[i] = s
 	}
 
-	if err := RequireFileInput(NewAPISession(r, session, context), context, ep); err != nil {
-		r.sendError(session, cmd.ID, err)
-		return
-	}
-
-	// Resolve the element to get its BiDi sharedId
-	sharedID, err := r.resolveElementRef(session, context, ep)
-	if err != nil {
-		r.sendError(session, cmd.ID, err)
-		return
-	}
-
-	// Call input.setFiles
-	_, err = r.sendInternalCommand(session, "input.setFiles", map[string]interface{}{
-		"context": context,
-		"element": map[string]interface{}{
-			"sharedId": sharedID,
-		},
-		"files": files,
-	})
-	if err != nil {
+	// Upload does the file-input check, path validation and the setFiles
+	// call; going through it keeps this path and the CLI/MCP path one
+	// implementation.
+	if err := Upload(NewAPISession(r, session, context), context, ep, files, r.connectURL != ""); err != nil {
 		r.sendError(session, cmd.ID, err)
 		return
 	}

--- a/clicker/internal/api/handlers_lifecycle.go
+++ b/clicker/internal/api/handlers_lifecycle.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 )
 
 // handleBrowserPage handles vibium:browser.page — returns the first (default) browsing context.
@@ -384,8 +385,46 @@ func RequireFileInput(s Session, context string, ep ElementParams) error {
 	return nil
 }
 
+// validateUploadFiles rejects paths the engine cannot deliver. Without it,
+// what a bad path means depends on the engine: Chrome attaches a zero-byte
+// file named after a typo and reports success, Firefox rejects it (#480).
+//
+// Stat alone is not enough: it succeeds on a directory and on a file the
+// process cannot read, and both reach the page as bogus entries. Opening the
+// file is what answers "can this be uploaded".
+func validateUploadFiles(files []string) error {
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("upload: file does not exist: %s", f)
+			}
+			return fmt.Errorf("upload: cannot read %s: %v", f, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("upload: not a file: %s is a directory", f)
+		}
+		handle, err := os.Open(f)
+		if err != nil {
+			return fmt.Errorf("upload: cannot read %s: %v", f, err)
+		}
+		handle.Close()
+	}
+	return nil
+}
+
 // Upload sets files on an <input type="file"> element.
-func Upload(s Session, context string, ep ElementParams, files []string) error {
+//
+// remote reports whether the browser runs on another host, in which case the
+// local filesystem says nothing about the paths and validation is left to
+// the engine.
+func Upload(s Session, context string, ep ElementParams, files []string, remote bool) error {
+	if !remote {
+		if err := validateUploadFiles(files); err != nil {
+			return err
+		}
+	}
+
 	if err := RequireFileInput(s, context, ep); err != nil {
 		return err
 	}
@@ -395,14 +434,22 @@ func Upload(s Session, context string, ep ElementParams, files []string) error {
 		return err
 	}
 
-	_, err = s.SendBidiCommand("input.setFiles", map[string]interface{}{
+	resp, err := s.SendBidiCommand("input.setFiles", map[string]interface{}{
 		"context": context,
 		"element": map[string]interface{}{
 			"sharedId": sharedID,
 		},
 		"files": files,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	// Through APISession, SendBidiCommand reports transport failures only:
+	// an engine-level rejection arrives as a normal response whose payload
+	// is an error, so without this the proxy answered "set": true for a
+	// file the browser refused and every client built on it reported
+	// success (#481). Through AgentSession this is a safe no-op.
+	return checkBidiError(resp)
 }
 
 // MouseMove moves the mouse to the given coordinates.

--- a/clicker/internal/api/upload_validate_test.go
+++ b/clicker/internal/api/upload_validate_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Regression tests for #480: a bad upload path used to go straight to the
+// engine, and what it meant depended on which engine answered.
+func TestValidateUploadFiles(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.txt")
+	if err := os.WriteFile(good, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("existing file passes", func(t *testing.T) {
+		if err := validateUploadFiles([]string{good}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty list passes", func(t *testing.T) {
+		if err := validateUploadFiles(nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing file is rejected", func(t *testing.T) {
+		err := validateUploadFiles([]string{filepath.Join(dir, "nope.txt")})
+		if err == nil || !strings.Contains(err.Error(), "does not exist") {
+			t.Fatalf("want does-not-exist error, got: %v", err)
+		}
+	})
+
+	t.Run("directory is rejected", func(t *testing.T) {
+		err := validateUploadFiles([]string{dir})
+		if err == nil || !strings.Contains(err.Error(), "is a directory") {
+			t.Fatalf("want directory error, got: %v", err)
+		}
+	})
+
+	t.Run("unreadable file is rejected", func(t *testing.T) {
+		if runtime.GOOS == "windows" || os.Getuid() == 0 {
+			t.Skip("permission bits are not enforced here")
+		}
+		locked := filepath.Join(dir, "locked.txt")
+		if err := os.WriteFile(locked, []byte("secret"), 0o000); err != nil {
+			t.Fatal(err)
+		}
+		err := validateUploadFiles([]string{locked})
+		if err == nil || !strings.Contains(err.Error(), "cannot read") {
+			t.Fatalf("want cannot-read error, got: %v", err)
+		}
+	})
+
+	t.Run("second file missing rejects the whole call", func(t *testing.T) {
+		err := validateUploadFiles([]string{good, filepath.Join(dir, "nope.txt")})
+		if err == nil {
+			t.Fatal("want error, got nil")
+		}
+	})
+}

--- a/tests/js/async/engine/upload.test.js
+++ b/tests/js/async/engine/upload.test.js
@@ -1,0 +1,84 @@
+/**
+ * JS Library Tests: setFiles path validation and error delivery
+ *
+ * Regression tests for #480 (a nonexistent path was accepted and Chrome
+ * attached a zero-byte file named after it) and #481 (an engine rejection
+ * of setFiles never reached callers of the language clients).
+ */
+
+const { test, describe, before, after } = require("../../../helpers/capabilities").suite("core");
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { browser } = require('../../../../clients/javascript/dist');
+
+let bro, tmpdir;
+
+before(async () => {
+  tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-upload-'));
+  bro = await browser.start({ headless: true });
+});
+
+after(async () => {
+  await bro.stop();
+  fs.rmSync(tmpdir, { recursive: true, force: true });
+});
+
+async function fileInputPage() {
+  const vibe = await bro.page();
+  await vibe.go('about:blank');
+  await vibe.setContent('<input id="f" type="file"><input id="m" type="file" multiple>');
+  return vibe;
+}
+
+describe('Upload: setFiles path validation', () => {
+  test('a nonexistent path rejects instead of attaching a zero-byte file', async () => {
+    const vibe = await fileInputPage();
+    const input = await vibe.find('#f');
+
+    await assert.rejects(
+      input.setFiles([path.join(tmpdir, 'definitely-not-here.pdf')]),
+      /does not exist/
+    );
+
+    const count = await vibe.evaluate('document.querySelector("#f").files.length');
+    assert.strictEqual(Number(count), 0, 'nothing may be attached on a rejected call');
+  });
+
+  test('a directory rejects', async () => {
+    const vibe = await fileInputPage();
+    const input = await vibe.find('#f');
+    await assert.rejects(input.setFiles([tmpdir]), /is a directory/);
+  });
+
+  test('one bad path in a multi-file call rejects the whole call', async () => {
+    const real = path.join(tmpdir, 'real.txt');
+    fs.writeFileSync(real, 'content');
+
+    const vibe = await fileInputPage();
+    const input = await vibe.find('#m');
+    await assert.rejects(
+      input.setFiles([real, path.join(tmpdir, 'missing.txt')]),
+      /does not exist/
+    );
+
+    const count = await vibe.evaluate('document.querySelector("#m").files.length');
+    assert.strictEqual(Number(count), 0, 'a half-filled input hides the failure');
+  });
+
+  test('a real file still uploads with its content', async () => {
+    const real = path.join(tmpdir, 'attachment.txt');
+    fs.writeFileSync(real, 'seven b');
+
+    const vibe = await fileInputPage();
+    const input = await vibe.find('#f');
+    await input.setFiles([real]);
+
+    const got = await vibe.evaluate(
+      'JSON.stringify([...document.querySelector("#f").files].map(f => ({name: f.name, size: f.size})))'
+    );
+    assert.deepStrictEqual(JSON.parse(got), [{ name: 'attachment.txt', size: 7 }]);
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#480
Fixes VibiumDev/vibium#481

Two halves of the same failure, reported separately by lana-20 and fixed together because they meet in one function.

Nothing between the upload argument and the browser checked that the path exists (#480). The CLI resolves it with filepath.Abs, which never touches the filesystem, and the daemon passed it straight to BiDi input.setFiles, so the engine decided what a bad path means: Chrome attaches a real zero-byte File named after the typo and reports success, surviving into form submission; Firefox rejects the call. And when the engine did reject, the router's setFiles handler never inspected the response (#481), so the proxy answered "set": true and the JavaScript, Python and Java clients reported success while the input stayed empty. The CLI and MCP go through bidi.Client, which already turns error responses into Go errors, which is why only the language clients were blind.

The fix puts both checks in api.Upload, the shared implementation the CLI/MCP path already uses:

- validate each path before sending: stat, reject directories, and open the file, since stat succeeds on a directory and on a file the process cannot read, and both reach the page as bogus entries
- validation is skipped against a remote browser (connect URL set), where the local filesystem says nothing about the paths; there the engine's own rejection now propagates via the response check
- check the BiDi response with checkBidiError, which is load-bearing through APISession and a documented no-op through AgentSession

The router's handleVibiumElSetFiles was a second copy of Upload minus these checks; it now parses params and calls Upload, so all five entry points share one behavior on both engines. Per #480's report the check placement follows the #197 precedent (RequireFileInput went daemon-side for the same reason) and #446's keep-logic-in-the-binary rule.

Verified:
- new tests/js/async/engine/upload.test.js fails on main: all three rejection cases return success there (observed against a main-built binary before rebuilding), pass with the fix; the positive upload case passes on both
- suite passes on both engines locally: 4/4 with default engine and with VIBIUM_ENGINE=firefox
- new Go unit test covers missing file, directory, unreadable file, multi-file with one bad path, and the passing cases
- go build, go vet, go test ./internal/api ./internal/agent green