### PR TITLE
Move the caret to the end before typing or pressing

### DIFF
--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -127,6 +127,10 @@ func (r *Router) handleVibiumType(session *BrowserSession, cmd bidiCommand) {
 		r.sendError(session, cmd.ID, err)
 		return
 	}
+	if err := caretToEnd(s, context, ep); err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
 	if err := TypeText(s, context, text); err != nil {
 		r.sendError(session, cmd.ID, err)
 		return
@@ -155,6 +159,10 @@ func (r *Router) handleVibiumPress(session *BrowserSession, cmd bidiCommand) {
 	}
 	r.captureBeforeSnapshotAfterScroll(session, cmd.Params)
 	if err := ClickAtCenter(s, context, info); err != nil {
+		r.sendError(session, cmd.ID, err)
+		return
+	}
+	if err := caretToEnd(s, context, ep); err != nil {
 		r.sendError(session, cmd.ID, err)
 		return
 	}
@@ -848,6 +856,39 @@ func Fill(s Session, context string, ep ElementParams, value string) error {
 	return nil
 }
 
+// caretToEnd moves the caret past the element's existing content, ignoring
+// elements that cannot carry one.
+//
+// TypeInto, PressOn and their router twins focus by clicking the element's
+// center, and a click in a text field puts the caret at the character nearest
+// that x-coordinate — a fixed fraction of the field's width, independent of
+// how much text is there. A value long enough to reach that point got new
+// text spliced into its middle, and which character a press acted on
+// depended on CSS width, font metrics and engine (#488). Collapsing the
+// caret to the end afterwards restores the documented "appends to existing
+// content" contract.
+func caretToEnd(s Session, context string, ep ElementParams) error {
+	script, args := buildElActionScript(ep, nil, nil, `
+			const n = el.value !== undefined && el.value !== null ? String(el.value).length : null;
+			if (n !== null && typeof el.setSelectionRange === 'function') {
+				// setSelectionRange throws on input types that do not support
+				// selection (number, email, date). Those cannot hold a caret
+				// mid-value anyway, so leaving them alone is correct.
+				try { el.setSelectionRange(n, n); } catch (e) {}
+			} else if (el.isContentEditable) {
+				const r = document.createRange();
+				r.selectNodeContents(el);
+				r.collapse(false);
+				const sel = window.getSelection();
+				sel.removeAllRanges();
+				sel.addRange(r);
+			}
+			return 'ok';
+		`)
+	_, err := CallScript(s, context, script, args)
+	return err
+}
+
 // TypeInto resolves an element with actionability checks, clicks to focus, and types text.
 func TypeInto(s Session, context string, ep ElementParams, text string) error {
 	info, err := resolveWithActionability(s, context, ep, ClickChecks)
@@ -855,6 +896,9 @@ func TypeInto(s Session, context string, ep ElementParams, text string) error {
 		return err
 	}
 	if err := ClickAtCenter(s, context, info); err != nil {
+		return err
+	}
+	if err := caretToEnd(s, context, ep); err != nil {
 		return err
 	}
 	return TypeText(s, context, text)
@@ -867,6 +911,9 @@ func PressOn(s Session, context string, ep ElementParams, key string) error {
 		return err
 	}
 	if err := ClickAtCenter(s, context, info); err != nil {
+		return err
+	}
+	if err := caretToEnd(s, context, ep); err != nil {
 		return err
 	}
 	return PressKey(s, context, key)

--- a/tests/cli/engine/type-append.test.js
+++ b/tests/cli/engine/type-append.test.js
@@ -1,0 +1,39 @@
+/**
+ * CLI Tests: type and press act at the end of the value
+ *
+ * Same regression as the JS suite of the same name (#488), through the CLI,
+ * which reaches the separate TypeInto/PressOn implementation rather than
+ * the router handlers the language clients use.
+ */
+
+const { test, describe, after } = require("../../helpers/capabilities").suite("core");
+const assert = require('node:assert');
+const { execSync } = require('node:child_process');
+const { VIBIUM } = require("../../helpers");
+
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+const PAGE = 'data:text/html,<input id="n" type="text" style="width:100px">';
+
+function cli(args) {
+  return execSync(`${VIBIUM} --headless ${args}`, { encoding: 'utf-8', timeout: 30000 });
+}
+
+after(() => {
+  try { cli('stop'); } catch { /* no session left behind either way */ }
+});
+
+describe('CLI: type/press caret moves to the end of the value (#488)', () => {
+  test('type appends when the value is wider than the field', () => {
+    cli(`go '${PAGE}'`);
+    cli(`fill "#n" "${ALPHABET}"`);
+    cli(`type "#n" "XX"`);
+    assert.strictEqual(cli(`value "#n"`).trim(), ALPHABET + 'XX');
+  });
+
+  test('press acts on the last character, whatever the field width', () => {
+    cli(`go '${PAGE}'`);
+    cli(`fill "#n" "${ALPHABET}"`);
+    cli(`press "Backspace" "#n"`);
+    assert.strictEqual(cli(`value "#n"`).trim(), ALPHABET.slice(0, -1));
+  });
+});

--- a/tests/js/async/engine/type-append.test.js
+++ b/tests/js/async/engine/type-append.test.js
@@ -1,0 +1,72 @@
+/**
+ * JS Library Tests: type and press act at the end of the value
+ *
+ * Regression tests for #488: type and press focus by clicking the element's
+ * center, and a click in a text field puts the caret at the character
+ * nearest that x-coordinate. In a field narrower than its value the new
+ * text was spliced into the middle at a width- and engine-dependent index,
+ * and press Backspace deleted a different character per engine.
+ *
+ * The fixture is the report's: a 100px field holding a 26-character value,
+ * so the focusing click always lands inside the text.
+ */
+
+const { test, describe, before, after } = require("../../../helpers/capabilities").suite("core");
+const assert = require('node:assert');
+
+const { browser } = require('../../../../clients/javascript/dist');
+
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+
+let bro;
+
+before(async () => {
+  bro = await browser.start({ headless: true });
+});
+
+after(async () => {
+  await bro.stop();
+});
+
+async function narrowFieldPage() {
+  const vibe = await bro.page();
+  await vibe.go('about:blank');
+  await vibe.setContent(
+    '<input id="n" type="text" style="width:100px">' +
+    '<div id="ce" contenteditable style="width:100px"></div>'
+  );
+  return vibe;
+}
+
+describe('Type/press: caret moves to the end of the value (#488)', () => {
+  test('type appends when the value is wider than the field', async () => {
+    const vibe = await narrowFieldPage();
+    const input = await vibe.find('#n');
+    await input.fill(ALPHABET);
+    await input.type('XX');
+    assert.strictEqual(await input.value(), ALPHABET + 'XX');
+  });
+
+  test('press acts on the last character, whatever the field width', async () => {
+    const vibe = await narrowFieldPage();
+    const input = await vibe.find('#n');
+    await input.fill(ALPHABET);
+    await input.press('Backspace');
+    assert.strictEqual(await input.value(), ALPHABET.slice(0, -1));
+  });
+
+  test('type appends in contenteditable', async () => {
+    const vibe = await narrowFieldPage();
+    const ce = await vibe.find('#ce');
+    await ce.type(ALPHABET);
+    await ce.type('XX');
+    assert.strictEqual(await ce.text(), ALPHABET + 'XX');
+  });
+
+  test('type into an empty field is unchanged', async () => {
+    const vibe = await narrowFieldPage();
+    const input = await vibe.find('#n');
+    await input.type('hello');
+    assert.strictEqual(await input.value(), 'hello');
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#488

type is documented as appending ("appends to existing content", clients/javascript/src/element.ts), but it appends only by accident: it focuses the element by clicking its geometric center, and a click in a text field puts the caret at the character nearest that pixel. So the insertion index tracked the field's width, not its text: a 26-character value in a 100px field got new text spliced in after character 7 on Chrome and elsewhere on Firefox, silently, exit 0. press was worse, since Backspace deleted a different character per engine.

lana-20's report on #488 has the full measurements and proposed this fix shape (option 1, caret to end after the focusing click). Her diff covered TypeInto/PressOn only; as her report notes, type and press are implemented twice, and the language clients reach the other copy. This PR applies the step to both: a shared caretToEnd helper called from TypeInto and PressOn (CLI/MCP path) and from the router's handleVibiumType and handleVibiumPress (JavaScript, Python, Java path). Collapsing the two copies entirely would mean threading the recorder's before-snapshot hook through the shared functions, so that stays as-is.

Not covered, deliberately, matching the report: input[type=number] has no selection API and stays corrupted by the same defect on stock and patched alike; whether to refuse type on it is a separate call. And press now deterministically acts at the end of the value rather than preserving the caret, which is new semantics for non-printable keys, the defensible default but worth a maintainer's eye.

Verified:
- both new suites fail on main: 5 of 6 cases (splice instead of append, wrong character deleted, contenteditable splice); only the empty-field guardrail passes there
- with the fix, all 6 pass on the default engine and on VIBIUM_ENGINE=firefox, through both the JS client (router path) and the CLI (TypeInto/PressOn path)
- go build, go vet green; the fixture is the report's (100px field, 26-char value)