### PR TITLE
Activate pages the router creates, matching the CLI and MCP

### DIFF
--- a/clicker/internal/api/handlers_lifecycle.go
+++ b/clicker/internal/api/handlers_lifecycle.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 )
 
 // handleBrowserPage handles vibium:browser.page — returns the first (default) browsing context.
@@ -62,10 +63,38 @@ func (r *Router) handleBrowserNewPage(session *BrowserSession, cmd bidiCommand) 
 		return
 	}
 
+	r.activateNewPage(session, context)
+
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{
 		"context":     context,
 		"userContext": userContext,
 	})
+}
+
+// activateNewPage raises a freshly created tab, best effort.
+//
+// The CLI and MCP activate the tabs they create, and the router path did
+// not, so the same two lines of user code left a different tab in the
+// foreground depending on the surface — and a background tab is a different
+// execution environment: visibilityState is hidden, rAF is throttled, and
+// headless Chrome composites no frame for it at all (#495, the mechanism
+// behind #491). Activating here makes newPage mean "open a tab and show it"
+// everywhere, which is also what the visible-browser default promises a
+// watching human.
+//
+// Best effort because a page that exists but stayed behind beats a failed
+// creation: some Firefox configurations reject browsingContext.activate as
+// privileged (see launcher_firefox.go).
+func (r *Router) activateNewPage(session *BrowserSession, context string) {
+	resp, err := r.sendInternalCommand(session, "browsingContext.activate", map[string]interface{}{
+		"context": context,
+	})
+	if err == nil {
+		err = checkBidiError(resp)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[router] newPage: created %s but could not raise it: %v\n", context, err)
+	}
 }
 
 // handleBrowserNewContext handles vibium:browser.newContext — creates a new user context (incognito-like).
@@ -113,6 +142,8 @@ func (r *Router) handleContextNewPage(session *BrowserSession, cmd bidiCommand) 
 		r.sendError(session, cmd.ID, err)
 		return
 	}
+
+	r.activateNewPage(session, context)
 
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{
 		"context":     context,

--- a/tests/js/async/engine/newpage-foreground.test.js
+++ b/tests/js/async/engine/newpage-foreground.test.js
@@ -1,0 +1,62 @@
+/**
+ * JS Library Tests: newPage foregrounds the tab it creates
+ *
+ * Regression tests for #495: the CLI and MCP activate the tabs they create
+ * and the client path did not, so page scripts saw a different
+ * visibilityState depending on which surface drove the browser. A
+ * background tab is a different execution environment (visibilityState
+ * hidden, rAF throttled, no composited frame in headless Chrome), which is
+ * the mechanism behind the #491 screenshot hang.
+ */
+
+const { test, describe, before, after } = require("../../../helpers/capabilities").suite("core");
+const assert = require('node:assert');
+
+const { browser } = require('../../../../clients/javascript/dist');
+
+let bro;
+
+before(async () => {
+  bro = await browser.start({ headless: true });
+});
+
+after(async () => {
+  await bro.stop();
+});
+
+describe('Lifecycle: newPage foregrounds the new tab (#495)', () => {
+  test('the newest page is visible, like the CLI and MCP', async () => {
+    const a = await bro.newPage();
+    const b = await bro.newPage();
+    try {
+      assert.strictEqual(await b.evaluate('document.visibilityState'), 'visible');
+      assert.strictEqual(await a.evaluate('document.visibilityState'), 'hidden');
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+
+  test('bringToFront still moves the foreground back', async () => {
+    const a = await bro.newPage();
+    const b = await bro.newPage();
+    try {
+      await a.bringToFront();
+      assert.strictEqual(await a.evaluate('document.visibilityState'), 'visible');
+      assert.strictEqual(await b.evaluate('document.visibilityState'), 'hidden');
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+
+  test('a page created inside a user context is visible too', async () => {
+    const ctx = await bro.newContext();
+    try {
+      const p = await ctx.newPage();
+      assert.strictEqual(await p.evaluate('document.visibilityState'), 'visible');
+    } finally {
+      await ctx.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#495

The issue asks for a decision: activate everywhere, or nowhere. This PR takes activate everywhere, for three reasons. It matches the visible-browser default, where newPage in headed mode should show the watching human the tab. It matches what the CLI and MCP already do, and #487 explicitly kept their activate. And it turns out to be what the BiDi spec prescribes anyway: browsingContext.create takes background defaulting to false, and a non-background create gets the focusing steps (docs/reference/WebDriver-Bidi-Spec.md:4232,4306), so activate-nowhere would be fighting the protocol.

The change adds an explicit best-effort activate to handleBrowserNewPage and handleContextNewPage. Best effort because a page that exists but stayed behind beats a failed creation: some Firefox configurations reject browsingContext.activate as privileged (launcher_firefox.go:105, same tolerance as #487). A refused activate is logged to stderr rather than swallowed.

One measurement to be upfront about: the issue's client repro does not reproduce on my machine. On a main-built binary, macOS arm64, both Chrome for Testing 152.0.7977.54 and Firefox 154 already foreground a client-created tab, exactly as the spec default says. But CI disagrees: #491's pinned-screenshot hang existed precisely because a client-path-created second tab left the pinned page composited and the MCP-created one did not, on Linux headless Chrome. So the foreground after newPage is currently an engine and platform accident; this PR makes it deterministic. Consequence: the new test passes on main locally and should fail on main in the CI environment, so the fails-on-main evidence for this one has to come from the CI run rather than my machine.

Verified:
- new tests/js/async/engine/newpage-foreground.test.js passes with the fix on both engines locally (newest page visible, previous hidden, bringToFront still wins afterwards, user-context pages covered)
- tests/js/async/engine/lifecycle.test.js still passes, 12/12, both engines
- go build, go vet green