### PR TITLE
Pin the channel env in default-channel paths tests

### DIFF
--- a/clicker/internal/paths/paths_chrome_channel_test.go
+++ b/clicker/internal/paths/paths_chrome_channel_test.go
@@ -24,6 +24,10 @@ func installFakeChrome(t *testing.T, cacheDir string, segments ...string) {
 func TestResolveVersionDirHonorsPin(t *testing.T) {
 	cache := t.TempDir()
 	t.Setenv("VIBIUM_CACHE_DIR", cache)
+	// Pin the channel: the ambient environment may carry
+	// VIBIUM_ENGINE_CHANNEL=beta (the Beta Watch workflow does), and this
+	// test seeds the default-channel layout (#479).
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "")
 	installFakeChrome(t, cache, "140.0.7000.10")
 	installFakeChrome(t, cache, "141.0.7100.20")
 
@@ -57,6 +61,10 @@ func TestResolveVersionDirHonorsPin(t *testing.T) {
 func TestChromeChannelDirsAreSeparate(t *testing.T) {
 	cache := t.TempDir()
 	t.Setenv("VIBIUM_CACHE_DIR", cache)
+	// Pin the channel: the ambient environment may carry
+	// VIBIUM_ENGINE_CHANNEL=beta (the Beta Watch workflow does), and this
+	// test seeds the default-channel layout (#479).
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "")
 	installFakeChrome(t, cache, "141.0.7100.20")
 	// A beta with a higher version number than stable.
 	installFakeChrome(t, cache, "beta", "142.0.7200.5")

--- a/clicker/internal/paths/paths_test.go
+++ b/clicker/internal/paths/paths_test.go
@@ -132,6 +132,11 @@ func withCache(t *testing.T) string {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	// These tests seed the default-channel layout, so the ambient channel
+	// must not redirect resolution to a channel subdirectory. The Beta
+	// Watch workflow exports VIBIUM_ENGINE_CHANNEL=beta job-wide, which
+	// failed every one of them regardless of the browser (#479).
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "")
 	dir, err := GetChromeForTestingDir()
 	if err != nil {
 		t.Fatalf("GetChromeForTestingDir: %v", err)


### PR DESCRIPTION
Fixes VibiumDev/vibium#479

The Beta Watch failure the bot attributes to Chrome beta 154.0.8037.0 happens before any browser launches. The job log shows make test-go failing four internal/paths unit tests:

    paths_chrome_channel_test.go:33: resolveVersionDir() error =
      open .../chrome-for-testing/beta: no such file or directory

beta-watch.yml exports VIBIUM_ENGINE_CHANNEL=beta job-wide, resolution honors the ambient channel, and these tests seed the default-channel cache layout, so they look for a beta/ subdirectory nobody created. Chrome 154 itself is not implicated: every beta-watch run fails these tests the same way whatever the browser does. (Whether 154 also breaks something real will only be visible once the job gets past this.)

The fix pins the channel to empty via t.Setenv in withCache (covering TestResolvesChromeAndDriverAsAPair, TestPrefersNewestCompleteVersion, TestNoCompleteVersionIsNotFound) and at the top of the two channel tests that begin on the default channel. TestChromeChannelDefaultsToStable already did exactly this.

Verified:
- fails on main: VIBIUM_ENGINE_CHANNEL=beta go test ./internal/paths/ reproduces all four CI failures locally
- with the fix, ./internal/paths passes with and without the ambient beta env, and VIBIUM_ENGINE_CHANNEL=beta go test ./... is green across the module