### PR TITLE
Shard the Check and Run suites onto their own CI runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,13 +175,88 @@ jobs:
       # The NODE_TEST_TIMEOUT override is gone with Node 20: --test-timeout is
       # per test now, not per file, so the Makefile's 30s default applies and a
       # hung ordinary test surfaces in 30s.
+      #
+      # test-core is everything except the Check and Run suites, which run on
+      # their own runner in chrome-checks (#513). Locally `make test` is
+      # still the whole suite.
       - name: Test
-        run: xvfb-run --auto-servernum make test SUITE_PARALLEL=4
+        run: xvfb-run --auto-servernum make test-core SUITE_PARALLEL=4
 
       - name: Audit capability selection
         run: make test-capability-audit
 
       # In case the job is interrupted before make test's own cleanup runs.
+      - name: Clean up zombie processes
+        if: always()
+        run: make double-tap
+
+  # The Check and Run suites on the default engine, split from the chrome
+  # job so its wall time stays near the pre-#484 suite's (#513). Not a
+  # required check by name: the test gate below fails unless this passes.
+  chrome-checks:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: clicker/go.mod
+          cache-dependency-path: clicker/go.sum
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.9'
+          cache: pip
+          cache-dependency-path: |
+            clients/python/pyproject.toml
+            packages/python/vibium_linux_x64/pyproject.toml
+
+      - name: Set up Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: gradle
+
+      # Chrome's sandbox needs this on Ubuntu 24.04, same as the chrome job.
+      - name: Configure kernel for Chrome sandbox
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
+      # Same key as the chrome job, so this restores what that job saved
+      # rather than downloading Chrome again.
+      - name: Cache Chrome for Testing
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/vibium/chrome-for-testing
+          key: ${{ runner.os }}-chrome-${{ hashFiles('clicker/internal/browser/installer.go') }}
+          restore-keys: |
+            ${{ runner.os }}-chrome-
+
+      - name: Install npm dependencies
+        run: |
+          npm ci
+          npm install --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('rollup/package.json').version")
+
+      - name: Build
+        run: make
+
+      - name: Test Check and Run
+        run: xvfb-run --auto-servernum make test-checkrun
+
       - name: Clean up zombie processes
         if: always()
         run: make double-tap
@@ -235,9 +310,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-firefox-
 
-      # The Check and Run suites below drive Chrome for their non-Firefox
-      # cases. Same key as the chrome job, so this restores what that job
-      # saved rather than downloading Chrome again.
+      # install-browser below still fetches Chrome. Same key as the chrome
+      # job, so this restores what that job saved rather than downloading
+      # Chrome again.
       - name: Cache Chrome for Testing
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -267,10 +342,89 @@ jobs:
       - name: Test focused Firefox behavior
         run: xvfb-run --auto-servernum make test-firefox
 
-      # Same suites the chrome job runs, with the engine parameter pointed at
-      # Firefox — the shape every other engine-parity target already uses. A
-      # handful of cases used to name Firefox inside the default suite instead,
-      # so the chrome job ran them against a browser it never installs.
+      - name: Clean up zombie processes
+        if: always()
+        run: make double-tap
+
+  # Same suites chrome-checks runs, with the engine parameter pointed at
+  # Firefox — the shape every other engine-parity target already uses (#494).
+  # Split from the firefox job for the same reason chrome-checks exists:
+  # these suites stand alone and were the firefox job's longest step (#513).
+  firefox-checks:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    timeout-minutes: 30
+    env:
+      VIBIUM_REQUIRE_FIREFOX: 1
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: clicker/go.mod
+          cache-dependency-path: clicker/go.sum
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.9'
+          cache: pip
+          cache-dependency-path: |
+            clients/python/pyproject.toml
+            packages/python/vibium_linux_x64/pyproject.toml
+
+      - name: Set up Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: gradle
+
+      - name: Cache Firefox
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/vibium/firefox
+          key: ${{ runner.os }}-firefox-${{ hashFiles('clicker/internal/browser/installer_firefox.go') }}
+          restore-keys: |
+            ${{ runner.os }}-firefox-
+
+      # These suites drive Chrome for their non-Firefox cases. Same key as
+      # the chrome job, so this restores what that job saved rather than
+      # downloading Chrome again.
+      - name: Cache Chrome for Testing
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/vibium/chrome-for-testing
+          key: ${{ runner.os }}-chrome-${{ hashFiles('clicker/internal/browser/installer.go') }}
+          restore-keys: |
+            ${{ runner.os }}-chrome-
+
+      # Chrome's sandbox needs this on Ubuntu 24.04, same as the chrome job.
+      - name: Configure kernel for Chrome sandbox
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm install --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('rollup/package.json').version")
+
+      - name: Build and install browsers
+        run: |
+          make
+          make install-firefox
+          make install-browser
+
       - name: Test Check and Run on Firefox
         run: xvfb-run --auto-servernum make test-check test-run ENGINE=firefox
 
@@ -279,12 +433,14 @@ jobs:
         run: make double-tap
 
   # Branch protection requires a check named "test" (the pre-split job).
-  # This gate reports it, green only when both engine jobs pass. if: always()
-  # keeps it from being skipped on failure, which protection would treat as
-  # satisfied.
+  # This gate reports it, green only when every suite job passes. The check
+  # and run shards are not required by name, so this is the only thing that
+  # enforces them — a new suite job must be added here or it is decorative.
+  # if: always() keeps the gate from being skipped on failure, which
+  # protection would treat as satisfied.
   test:
     runs-on: ubuntu-latest
-    needs: [changes, chrome, firefox]
+    needs: [changes, chrome, chrome-checks, firefox, firefox-checks]
     if: always()
     steps:
       - name: All suites green
@@ -300,4 +456,6 @@ jobs:
           fi
 
           test "${{ needs.chrome.result }}" = "success"
+          test "${{ needs['chrome-checks'].result }}" = "success"
           test "${{ needs.firefox.result }}" = "success"
+          test "${{ needs['firefox-checks'].result }}" = "success"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
   endif
 endif
 
-.PHONY: all build build-go build-js build-go-all package package-js package-python install-browser install-firefox install-engine deps clean clean-go clean-js clean-npm-packages clean-python-packages clean-packages clean-cache clean-all serve test test-go test-cli test-cli-shared test-js test-js-async test-js-sync test-js-process test-js-engine test-mcp test-daemon test-python test-python-engine python-venv test-browser-modes test-firefox test-firefox-core test-firefox-capabilities test-engine test-java test-java-engine check-api-drift test-capability-audit test-check test-run test-cleanup mtlshim double-tap get-version set-version build-java package-java verify-staged-java clean-java jshell help
+.PHONY: all build build-go build-js build-go-all package package-js package-python install-browser install-firefox install-engine deps clean clean-go clean-js clean-npm-packages clean-python-packages clean-packages clean-cache clean-all serve test test-core test-checkrun test-core-suites test-checkrun-suites test-go test-cli test-cli-shared test-js test-js-async test-js-sync test-js-process test-js-engine test-mcp test-daemon test-python test-python-engine python-venv test-browser-modes test-firefox test-firefox-core test-firefox-capabilities test-engine test-java test-java-engine check-api-drift test-capability-audit test-check test-run test-cleanup mtlshim double-tap get-version set-version build-java package-java verify-staged-java clean-java jshell help
 
 # Version from VERSION file
 # Note: GnuWin32 Make 3.81 runs $(shell) via CreateProcess, not SHELL,
@@ -273,20 +273,12 @@ mtlshim:
 	clang -fno-objc-arc -dynamiclib -framework Metal -framework Foundation \
 		-o $(MTLSHIM) scripts/mtlshim.m
 
+# The full suite. CI runs the two halves below on separate runners to keep
+# wall time down (#513); locally this is still everything.
 test: build install-browser $(FAST_LAUNCH_DEP)
 	@START_TIME=$$(date +%s); \
-	"$(MAKE)" check-api-drift && \
-	"$(MAKE)" test-go && \
-	"$(MAKE)" test-cli test-cleanup && \
-	"$(MAKE)" test-js-process test-cleanup && \
-	"$(MAKE)" -j $(SUITE_PARALLEL) test-js-async test-mcp test-python test-java && \
-	"$(MAKE)" test-cleanup && \
-	"$(MAKE)" test-browser-modes test-cleanup && \
-	"$(MAKE)" test-firefox test-cleanup && \
-	"$(MAKE)" test-daemon test-cleanup && \
-	"$(MAKE)" test-js-sync && \
-	"$(MAKE)" test-check && \
-	"$(MAKE)" test-run; \
+	"$(MAKE)" test-core-suites && \
+	"$(MAKE)" test-checkrun-suites; \
 	EXIT=$$?; \
 	"$(MAKE)" test-cleanup; \
 	END_TIME=$$(date +%s); \
@@ -300,6 +292,39 @@ test: build install-browser $(FAST_LAUNCH_DEP)
 		echo "--- Tests failed after $${MINS}m$${SECS}s ---"; \
 		exit $$EXIT; \
 	fi
+
+# CI shard entry points (#513). Each carries the same build prerequisites as
+# `test`, so a shard runs standalone on a fresh runner.
+test-core: build install-browser $(FAST_LAUNCH_DEP)
+	@"$(MAKE)" test-core-suites; \
+	EXIT=$$?; \
+	"$(MAKE)" test-cleanup; \
+	exit $$EXIT
+
+test-checkrun: build install-browser $(FAST_LAUNCH_DEP)
+	@"$(MAKE)" test-checkrun-suites; \
+	EXIT=$$?; \
+	"$(MAKE)" test-cleanup; \
+	exit $$EXIT
+
+# The suite chains. Internal: `test`, `test-core` and `test-checkrun` wrap
+# these with build deps and cleanup; the split exists so the Check and Run
+# suites, which stand alone, can shard to their own runner.
+test-core-suites:
+	@"$(MAKE)" check-api-drift && \
+	"$(MAKE)" test-go && \
+	"$(MAKE)" test-cli test-cleanup && \
+	"$(MAKE)" test-js-process test-cleanup && \
+	"$(MAKE)" -j $(SUITE_PARALLEL) test-js-async test-mcp test-python test-java && \
+	"$(MAKE)" test-cleanup && \
+	"$(MAKE)" test-browser-modes test-cleanup && \
+	"$(MAKE)" test-firefox test-cleanup && \
+	"$(MAKE)" test-daemon test-cleanup && \
+	"$(MAKE)" test-js-sync
+
+test-checkrun-suites:
+	@"$(MAKE)" test-check && \
+	"$(MAKE)" test-run
 
 # Kill any browser/driver processes left over from tests.
 # The bracketed characters stop Linux pkill from SIGKILLing the recipe's


### PR DESCRIPTION
Fixes VibiumDev/vibium#513

Wall time grew from ~8 min (Sep 4) to ~14 min after #484 added the Check and Run suites and #494 correctly re-ran them per engine. Job breakdown of a current green run: chrome 13m33s (11m33s in one sequential make test step, of which roughly 3 minutes is Check+Run), firefox 11m53s (4m22s of it the Check/Run re-run). Both jobs end in suites that stand alone, so they shard cleanly.

## What changed

Makefile: the `test` recipe's chain splits into `test-core-suites` (everything through test-js-sync) and `test-checkrun-suites` (test-check, test-run), with `test-core` and `test-checkrun` as standalone entry points carrying the same build prerequisites and cleanup. Local `make test` composes both halves and behaves exactly as before, including the timing summary, so the run-tests-before-committing rule is unaffected.

Workflow: two new jobs. `chrome-checks` is the chrome job minus the drift/audit steps, running `make test-checkrun`; `firefox-checks` is the firefox job's former "Test Check and Run on Firefox" step with the same setup, caches and installs. The `test` gate now requires all four suite jobs plus the classifier.

## Constraints from #513, kept

- Check names and count reported to branch protection are unchanged: `chrome`, `firefox`, `test` still exist under their old names. The new shards are not required by name; the gate enforces them, and the gate comment now says so explicitly.
- #486's gate semantics survive untouched: docs-only PRs skip all four suite jobs and pass via the gate, and a failed classifier fails the gate rather than reading skips as success.
- No test removed or demoted; coverage per engine is exactly what #484/#494 established.

## Expected effect

Longest remaining job is chrome at roughly 8.5 min (setup plus core suites); firefox drops to ~7.5 min, and both check shards land around 7 min. The four run concurrently (public repo, so the extra runners are free). Further rebalancing (the parallel client block or the capabilities suite) is possible once the shard timings are visible in CI, but this PR takes only the clean seam.

Verified:
- make -n test, test-core, test-checkrun all resolve; local make test still runs the full chain (structure unchanged, one wrapper level added)
- workflow YAML parses; gate needs all four suite jobs; hyphenated job results use the bracket expression syntax
- this PR's own CI run is the live demonstration; the shard timings on it are the numbers to look at
