### PR TITLE
Fence the fixture provider's Anthropic verdicts like real Claude

### DIFF
--- a/tests/run/fixture.cjs
+++ b/tests/run/fixture.cjs
@@ -28,11 +28,16 @@ function decode(body, url) {
 }
 function answer(res, family, step, result, index) {
   const text = JSON.stringify(result);
+  // Real Claude wraps the final verdict in a markdown fence behind a line of
+  // prose despite being told to return only JSON; the openai family answers
+  // bare. Each emulation matches its provider's observed behavior so parser
+  // regressions fail here instead of on the first live call (#506, #514).
+  const fenced = 'The evidence is clear. Here is the result:\n\n```json\n' + text + '\n```';
   res.setHeader('Content-Type', 'application/json');
   if (family === 'anthropic') {
     res.end(JSON.stringify({ stop_reason: step ? 'tool_use' : 'end_turn', content: step ? [
       { type: 'text', text: 'PRIVATE-REASONING' }, { type: 'tool_use', id: `tool-${index}`, name: step[0], input: step[1] },
-    ] : [{ type: 'text', text }] }));
+    ] : [{ type: 'text', text: fenced }] }));
   } else if (family === 'google') {
     res.end(JSON.stringify({ candidates: [{ finishReason: 'STOP', content: { role: 'model', parts: step ? [
       { thought: true, text: 'PRIVATE-REASONING' }, { functionCall: { name: step[0], args: step[1], id: `tool-${index}` }, thoughtSignature: `opaque-${index}` },


### PR DESCRIPTION
Follow-up to #514, closing the coverage gap behind #506.

The fixture provider emulates three wire families, but its Anthropic emulation returned the final verdict as bare JSON text. Real Claude wraps the verdict in a ```json fence behind a line of prose, which is exactly the shape the parser rejected before #514 — so CI was green on the anthropic family while every live Anthropic check failed. The fixture validated the plumbing but not the provider's observed behavior.

The Anthropic emulation now answers with the fenced, prose-prefixed shape captured from live claude-sonnet-4-6 runs (the same shape pinned in verifier/fence_test.go). The openai family keeps answering bare JSON, since that is what those models do; the point is for each emulation to match its provider, not for all of them to exercise the same branch.

Verified:
- tests/run/overrides.test.js and tests/run/cli.test.js pass with the fenced fixture: 14 tests, 0 failures
- the regression it exists to catch, caught: with StripJSONFence removed from parseResult (a simulated revert of #514), the overrides suite fails instead of staying green, then passes again with the parser restored
