### PR TITLE
Pin the channel env in the is-installed fake-cache tests

### DIFF
--- a/tests/cli/is-installed.test.js
+++ b/tests/cli/is-installed.test.js
@@ -19,7 +19,11 @@ function runIsInstalled(cacheDir) {
   try {
     execFileSync(VIBIUM, ['is-installed'], {
       timeout: 10000,
-      env: { ...process.env, VIBIUM_CACHE_DIR: cacheDir },
+      // Pin the channel: the fake cache seeds the default-channel layout,
+      // and the Beta Watch workflow exports VIBIUM_ENGINE_CHANNEL=beta
+      // job-wide, which sent resolution into a beta/ subdirectory nobody
+      // created. Same class as #479.
+      env: { ...process.env, VIBIUM_CACHE_DIR: cacheDir, VIBIUM_ENGINE_CHANNEL: '' },
     });
     return 0;
   } catch (err) {


### PR DESCRIPTION
Follow-up to #504, same class as #479: one more test that seeds the default-channel cache layout while spreading the ambient environment into the binary it runs.

With #504 merged, a suite run under VIBIUM_ENGINE_CHANNEL=beta gets past test-go and now dies 13 seconds into test-cli: is-installed's fake-cache helper passes `...process.env` through, so the binary resolves into a beta/ subdirectory the fake cache never created and the exits-0 case fails. The two real-install cases at the top of the file are left unpinned on purpose; they test the ambient installation and pass either way on the Beta Watch runner, which installs the beta.

Verified:
- fails on main: `VIBIUM_ENGINE_CHANNEL=beta node --test tests/cli/is-installed.test.js` fails the exits-0 fake-cache case (this is exactly how the full-suite run died)
- with the fix, 6/6 pass with and without the ambient beta env
- with this plus #504, the entire suite is green under VIBIUM_ENGINE_CHANNEL=beta against Chrome beta 154.0.8037.0 locally (macOS arm64): core suites, check 29/29, run 28/28

That last bullet answers #479's actual question: Chrome beta 154 does not break vibium. Both failures the bot reported trace to the channel env leaking into tests that assume the default channel — the browser was never implicated. The next scheduled Beta Watch run with both fixes should be the first green one, and if it is not, whatever it reports will finally be a real browser regression.
