### PR TITLE
Honor --json on the eight commands outside the envelope contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ test-go:
 # Process tests run separately with --test-concurrency=1 to avoid interference
 test-cli: build-go
 	@echo "--- CLI Tests (no daemon) ---"
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/help-flags.test.js tests/cli/ready.test.js tests/cli/is-installed.test.js tests/cli/packaging.test.js tests/cli/release-versioning.test.js tests/cli/wrapper.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/help-flags.test.js tests/cli/ready.test.js tests/cli/is-installed.test.js tests/cli/json-output.test.js tests/cli/packaging.test.js tests/cli/release-versioning.test.js tests/cli/wrapper.test.js
 	@"$(MAKE)" test-cli-shared ENGINE=$(ENGINE)
 	@echo "--- CLI Process Tests (sequential) ---"
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js tests/cli/dead-browser.test.js tests/cli/start-json.test.js

--- a/clicker/cmd/clicker/config_cmd.go
+++ b/clicker/cmd/clicker/config_cmd.go
@@ -97,10 +97,19 @@ you want in the shell that runs vibium.`,
 				}
 				return nil
 			}
+			var written []string
 			for _, t := range chosen {
-				if err := writeConfigTemplate(cmd, t, force); err != nil {
+				path, err := writeConfigTemplate(cmd, t, force)
+				if err != nil {
 					return err
 				}
+				written = append(written, path)
+			}
+			if jsonOutput {
+				printJSON(jsonEnvelope{OK: true, Result: map[string]interface{}{
+					"written": written,
+					"mode":    "0600",
+				}})
 			}
 			return nil
 		},
@@ -113,38 +122,46 @@ you want in the shell that runs vibium.`,
 // writeConfigTemplate lays down one template at 0600. These files hold API
 // keys, so the mode is the point: a world-readable copy is how a key leaks to
 // anything else running as another user on the machine.
-func writeConfigTemplate(cmd *cobra.Command, t configTemplate, force bool) error {
+func writeConfigTemplate(cmd *cobra.Command, t configTemplate, force bool) (string, error) {
 	dir, err := paths.GetConfigDir()
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := os.MkdirAll(dir, 0700); err != nil {
-		return fmt.Errorf("could not create %s: %w", dir, err)
+		return "", fmt.Errorf("could not create %s: %w", dir, err)
 	}
 	path := filepath.Join(dir, t.file)
 
 	if _, err := os.Stat(path); err == nil {
 		if !force {
 			// Never clobber real credentials on a bare `config init`.
-			return fmt.Errorf("%s already exists; edit it, or pass --force to replace it (a .bak is kept)", path)
+			return "", fmt.Errorf("%s already exists; edit it, or pass --force to replace it (a .bak is kept)", path)
 		}
 		if err := os.Rename(path, path+".bak"); err != nil {
-			return fmt.Errorf("could not back up %s: %w", path, err)
+			return "", fmt.Errorf("could not back up %s: %w", path, err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Kept the previous file as %s.bak\n", tildePath(path))
+		if !jsonOutput {
+			fmt.Fprintf(cmd.OutOrStdout(), "Kept the previous file as %s.bak\n", tildePath(path))
+		}
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("could not check %s: %w", path, err)
+		return "", fmt.Errorf("could not check %s: %w", path, err)
 	}
 
 	if err := os.WriteFile(path, []byte(*t.content), 0600); err != nil {
-		return fmt.Errorf("could not write %s: %w", path, err)
+		return "", fmt.Errorf("could not write %s: %w", path, err)
 	}
 	// WriteFile respects umask, so an inherited one can widen the mode.
 	if err := os.Chmod(path, 0600); err != nil {
-		return fmt.Errorf("could not set permissions on %s: %w", path, err)
+		return "", fmt.Errorf("could not set permissions on %s: %w", path, err)
+	}
+
+	// Under --json the caller reports every file in one envelope, so the
+	// per-file lines stay quiet.
+	if jsonOutput {
+		return path, nil
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s (0600) — %s\n", tildePath(path), t.what)
 	fmt.Fprintf(cmd.OutOrStdout(), "Edit it, then: source %s\n", tildePath(path))
-	return nil
+	return path, nil
 }

--- a/clicker/cmd/clicker/config_cmd_test.go
+++ b/clicker/cmd/clicker/config_cmd_test.go
@@ -22,7 +22,7 @@ func TestConfigInitWritesOwnerOnly(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	for _, tmpl := range configTemplates {
-		if err := writeConfigTemplate(cmd, tmpl, false); err != nil {
+		if _, err := writeConfigTemplate(cmd, tmpl, false); err != nil {
 			t.Fatalf("%s: %v", tmpl.name, err)
 		}
 		path := filepath.Join(dir, "vibium", tmpl.file)
@@ -46,7 +46,7 @@ func TestConfigInitRefusesToClobber(t *testing.T) {
 	}
 
 	cmd := &cobra.Command{}
-	err := writeConfigTemplate(cmd, configTemplates[0], false)
+	_, err := writeConfigTemplate(cmd, configTemplates[0], false)
 	if err == nil {
 		t.Fatal("expected a refusal, got nil")
 	}
@@ -69,7 +69,7 @@ func TestConfigInitForceKeepsBackup(t *testing.T) {
 	}
 
 	cmd := &cobra.Command{}
-	if err := writeConfigTemplate(cmd, configTemplates[0], true); err != nil {
+	if _, err := writeConfigTemplate(cmd, configTemplates[0], true); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(path + ".bak")

--- a/clicker/cmd/clicker/daemon_cmd.go
+++ b/clicker/cmd/clicker/daemon_cmd.go
@@ -66,7 +66,10 @@ func newDaemonStartCmd() *cobra.Command {
 
   vibium --session projA daemon start
   # Isolated session "projA": own daemon, own browser, socket
-  # vibium-projA.sock; VIBIUM_SESSION=projA does the same`,
+  # vibium-projA.sock; VIBIUM_SESSION=projA does the same
+
+  vibium daemon start --json
+  # {"ok":true,"result":{"pid":79311,"running":true,"started":true}}`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if !foreground && !internal {
 				// Daemonize: re-exec as detached child
@@ -96,8 +99,20 @@ func newDaemonStopCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "stop",
 		Short: "Stop the vibium daemon",
+		Example: `  vibium daemon stop
+  # Daemon stopped.
+
+  vibium daemon stop --json
+  # {"ok":true,"result":{"running":false,"stopped":true}}`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if !daemon.IsRunning() {
+				if jsonOutput {
+					printJSON(jsonEnvelope{OK: true, Result: map[string]interface{}{
+						"running": false,
+						"stopped": false,
+					}})
+					return
+				}
 				fmt.Println("Daemon is not running.")
 				return
 			}
@@ -107,6 +122,13 @@ func newDaemonStopCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
+			if jsonOutput {
+				printJSON(jsonEnvelope{OK: true, Result: map[string]interface{}{
+					"running": false,
+					"stopped": true,
+				}})
+				return
+			}
 			fmt.Println("Daemon stopped.")
 		},
 	}
@@ -121,7 +143,11 @@ func newDaemonStatusCmd() *cobra.Command {
 				// Exit non-zero so `vibium daemon status` is usable in a
 				// conditional, and keep the human line out of --json output.
 				if jsonOutput {
+					// ok is true because the check ran; running says what it
+					// found. The keys stay top-level rather than moving under
+					// result so existing parsers of .running keep working.
 					printJSON(map[string]interface{}{
+						"ok":      true,
 						"running": false,
 					})
 				} else {
@@ -138,6 +164,7 @@ func newDaemonStatusCmd() *cobra.Command {
 
 			if jsonOutput {
 				printJSON(map[string]interface{}{
+					"ok":      true,
 					"running": true,
 					"version": status.Version,
 					"pid":     status.PID,
@@ -289,6 +316,13 @@ func daemonize(idleTimeout time.Duration, connectFlag string, headerFlags []stri
 	daemon.CleanStale()
 
 	if daemon.IsRunning() {
+		if jsonOutput {
+			printJSON(jsonEnvelope{OK: true, Result: map[string]interface{}{
+				"running": true,
+				"started": false,
+			}})
+			return
+		}
 		fmt.Println("Daemon is already running.")
 		return
 	}
@@ -338,6 +372,14 @@ func daemonize(idleTimeout time.Duration, connectFlag string, headerFlags []stri
 		os.Exit(1)
 	}
 
+	if jsonOutput {
+		printJSON(jsonEnvelope{OK: true, Result: map[string]interface{}{
+			"running": true,
+			"started": true,
+			"pid":     cmd.Process.Pid,
+		}})
+		return
+	}
 	fmt.Printf("Daemon started (pid %d)\n", cmd.Process.Pid)
 }
 

--- a/clicker/cmd/clicker/diagnostics.go
+++ b/clicker/cmd/clicker/diagnostics.go
@@ -18,7 +18,19 @@ func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number",
+		Example: `  vibium version
+  # vibium v26.8.21
+
+  vibium version --json
+  # {"ok":true,"result":{"name":"vibium","version":"26.8.21"}}`,
 		Run: func(cmd *cobra.Command, args []string) {
+			if jsonOutput {
+				printJSON(jsonEnvelope{OK: true, Result: map[string]string{
+					"name":    filepath.Base(os.Args[0]),
+					"version": version,
+				}})
+				return
+			}
 			fmt.Printf("%s v%s\n", filepath.Base(os.Args[0]), version)
 		},
 	}
@@ -100,14 +112,29 @@ func newIsInstalledCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "is-installed",
 		Short: "Check if the selected browser is installed (exit 0 = yes, exit 1 = no)",
+		Example: `  vibium is-installed && echo yes
+  # yes
+
+  vibium is-installed --json
+  # {"ok":true,"result":{"engine":"chrome","installed":true}}`,
 		Run: func(cmd *cobra.Command, args []string) {
+			var installed bool
 			if engineName == "firefox" {
-				if !browser.IsFirefoxInstalled() {
-					os.Exit(1)
-				}
-				return
+				installed = browser.IsFirefoxInstalled()
+			} else {
+				installed = browser.IsInstalled()
 			}
-			if !browser.IsInstalled() {
+			// The exit code stays the contract: 1 means not installed even
+			// though the check itself ran fine, which is why ok is true in
+			// that case. --json adds an answer for callers that capture
+			// output instead of branching on the exit status.
+			if jsonOutput {
+				printJSON(jsonEnvelope{OK: true, Result: map[string]interface{}{
+					"engine":    engineName,
+					"installed": installed,
+				}})
+			}
+			if !installed {
 				os.Exit(1)
 			}
 		},
@@ -133,6 +160,13 @@ func newInstallCmd() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					os.Exit(1)
 				}
+				if jsonOutput {
+					printJSON(jsonEnvelope{OK: true, Result: map[string]string{
+						"engine":  "firefox",
+						"firefox": exePath,
+					}})
+					return
+				}
 				fmt.Println("Installation complete!")
 				fmt.Printf("Firefox: %s\n", exePath)
 				return
@@ -144,6 +178,15 @@ func newInstallCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
+			if jsonOutput {
+				printJSON(jsonEnvelope{OK: true, Result: map[string]string{
+					"engine":       "chrome",
+					"chrome":       result.ChromePath,
+					"chromedriver": result.ChromedriverPath,
+					"version":      result.Version,
+				}})
+				return
+			}
 			fmt.Println("Installation complete!")
 			fmt.Printf("Chrome: %s\n", result.ChromePath)
 			fmt.Printf("Chromedriver: %s\n", result.ChromedriverPath)

--- a/clicker/cmd/clicker/main.go
+++ b/clicker/cmd/clicker/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/vibium/clicker/internal/browser"
 	"github.com/vibium/clicker/internal/log"
 	"github.com/vibium/clicker/internal/paths"
 )
@@ -91,6 +92,12 @@ func applyGlobalFlags(cmd *cobra.Command) error {
 	// Enable logging only if --verbose is used
 	if verbose {
 		log.Setup(log.LevelVerbose)
+	}
+	// The installer's commentary is progress, not result. Under --json it
+	// has to leave stdout, or `install --json` prints plain text on the
+	// lines before the envelope and nothing can parse the stream.
+	if jsonOutput {
+		browser.Progress = os.Stderr
 	}
 	// Bridge the flag to the env var so the paths package and any
 	// auto-started daemon child process resolve the same session.

--- a/clicker/cmd/clicker/skill.go
+++ b/clicker/cmd/clicker/skill.go
@@ -73,6 +73,15 @@ func installSkill(name, content string) error {
 		return fmt.Errorf("could not write SKILL.md: %w", err)
 	}
 
+	if jsonOutput {
+		printJSON(jsonEnvelope{OK: true, Result: map[string]interface{}{
+			"skill": name,
+			"dir":   skillDir,
+			"files": []string{skillPath},
+		}})
+		return nil
+	}
+
 	fmt.Printf("Installed Vibium skill to %s\n", skillDir)
 	fmt.Println("Files:")
 	fmt.Printf("  %s\n", skillPath)

--- a/clicker/internal/browser/installer.go
+++ b/clicker/internal/browser/installer.go
@@ -66,7 +66,7 @@ func Install() (*InstallResult, error) {
 		chromedriverPath, _ := paths.GetChromedriverPath()
 		// Extract version from path (e.g., .../chrome-for-testing/143.0.7499.192/...)
 		version := extractVersionFromPath(chromePath)
-		fmt.Printf("Chrome for Testing v%s already installed.\n", version)
+		progressf("Chrome for Testing v%s already installed.\n", version)
 		return &InstallResult{
 			ChromePath:       chromePath,
 			ChromedriverPath: chromedriverPath,
@@ -83,9 +83,9 @@ func Install() (*InstallResult, error) {
 
 	channel := paths.ChromeChannel()
 	if channel == "stable" {
-		fmt.Printf("Installing Chrome for Testing v%s...\n", versionInfo.Version)
+		progressf("Installing Chrome for Testing v%s...\n", versionInfo.Version)
 	} else {
-		fmt.Printf("Installing Chrome for Testing v%s (%s channel)...\n", versionInfo.Version, channel)
+		progressf("Installing Chrome for Testing v%s (%s channel)...\n", versionInfo.Version, channel)
 	}
 
 	// Create version directory
@@ -105,7 +105,7 @@ func Install() (*InstallResult, error) {
 		return nil, fmt.Errorf("no Chrome download available for platform %s", platform)
 	}
 
-	fmt.Printf("Downloading Chrome from %s...\n", chromeURL)
+	progressf("Downloading Chrome from %s...\n", chromeURL)
 	if err := downloadAndExtract(chromeURL, versionDir); err != nil {
 		return nil, fmt.Errorf("failed to install Chrome: %w", err)
 	}
@@ -116,7 +116,7 @@ func Install() (*InstallResult, error) {
 		return nil, fmt.Errorf("no chromedriver download available for platform %s", platform)
 	}
 
-	fmt.Printf("Downloading chromedriver from %s...\n", chromedriverURL)
+	progressf("Downloading chromedriver from %s...\n", chromedriverURL)
 	if err := downloadAndExtract(chromedriverURL, versionDir); err != nil {
 		return nil, fmt.Errorf("failed to install chromedriver: %w", err)
 	}
@@ -287,7 +287,7 @@ func downloadAndExtract(url, destDir string) error {
 	tmpPath := tmpFile.Name()
 	defer os.Remove(tmpPath)
 
-	pw := &progressWriter{dst: tmpFile, total: resp.ContentLength, out: os.Stdout}
+	pw := &progressWriter{dst: tmpFile, total: resp.ContentLength, out: progressOut()}
 	if _, err := io.Copy(pw, resp.Body); err != nil {
 		tmpFile.Close()
 		return err
@@ -301,8 +301,9 @@ func downloadAndExtract(url, destDir string) error {
 // progressWriter wraps a download destination and prints coarse progress
 // lines while bytes flow: one line per 10% step when the total is known, one
 // line per 25 MB when the server sends no Content-Length. Progress goes to
-// out (os.Stdout for the install command; pipe mode redirects that to stderr
-// so the protocol stream stays clean and clients see download liveness).
+// out (progressOut(): stdout for the install command, stderr under --json so
+// the envelope has the stream to itself, and stderr in pipe mode so the
+// protocol stream stays clean and clients still see download liveness).
 type progressWriter struct {
 	dst     io.Writer
 	out     io.Writer

--- a/clicker/internal/browser/installer_firefox.go
+++ b/clicker/internal/browser/installer_firefox.go
@@ -75,14 +75,14 @@ func InstallFirefoxForChannel(channel string) (string, error) {
 	exePath := paths.FirefoxPathInVersion(versionDir)
 
 	if _, err := os.Stat(exePath); err == nil {
-		fmt.Printf("Firefox v%s already installed.\n", version)
+		progressf("Firefox v%s already installed.\n", version)
 		return exePath, nil
 	}
 
-	fmt.Printf("Installing Firefox v%s (%s channel)...\n", version, channel)
+	progressf("Installing Firefox v%s (%s channel)...\n", version, channel)
 
 	downloadURL := firefoxDownloadURL(version)
-	fmt.Printf("Downloading Firefox from %s...\n", downloadURL)
+	progressf("Downloading Firefox from %s...\n", downloadURL)
 
 	pattern := "firefox-*.tar.xz"
 	if runtime.GOOS == "darwin" {
@@ -239,7 +239,7 @@ func verifyFirefoxArchive(archivePath, version string) error {
 	if err := verifyArchiveAgainstSums(archivePath, sums, relPath); err != nil {
 		return err
 	}
-	fmt.Printf("Verified Firefox archive against Mozilla's SHA256SUMS.\n")
+	progressf("Verified Firefox archive against Mozilla's SHA256SUMS.\n")
 	return nil
 }
 
@@ -321,7 +321,7 @@ func downloadToTemp(downloadURL, pattern string) (string, error) {
 	}
 	tmpPath := tmpFile.Name()
 
-	pw := &progressWriter{dst: tmpFile, total: resp.ContentLength, out: os.Stdout}
+	pw := &progressWriter{dst: tmpFile, total: resp.ContentLength, out: progressOut()}
 	if _, err := io.Copy(pw, resp.Body); err != nil {
 		tmpFile.Close()
 		os.Remove(tmpPath)

--- a/clicker/internal/browser/progress.go
+++ b/clicker/internal/browser/progress.go
@@ -1,0 +1,30 @@
+package browser
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Progress receives the installer's running commentary: "already installed",
+// "Downloading ...", the percentage lines. It is progress, not a result, so
+// the CLI points it at stderr under --json; otherwise the JSON envelope
+// shares stdout with plain text and neither can be parsed.
+//
+// Nil means "whatever os.Stdout is at the time". The lookup must stay
+// per-call: pipe and mcp reassign os.Stdout to os.Stderr inside their own
+// Run, long after this package is initialized, and a writer captured at init
+// would pin progress to the real stdout and corrupt the protocol stream pipe
+// writes there.
+var Progress io.Writer
+
+func progressOut() io.Writer {
+	if Progress != nil {
+		return Progress
+	}
+	return os.Stdout
+}
+
+func progressf(format string, a ...interface{}) {
+	fmt.Fprintf(progressOut(), format, a...)
+}

--- a/clicker/internal/browser/progress_test.go
+++ b/clicker/internal/browser/progress_test.go
@@ -1,0 +1,49 @@
+package browser
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// Progress must stay late-bound: pipe and mcp reassign os.Stdout to os.Stderr
+// inside their own Run, long after this package is initialized. A writer
+// captured at init would pin download progress to the real stdout and corrupt
+// the BiDi protocol stream pipe writes there.
+func TestProgressFollowsStdoutReassignment(t *testing.T) {
+	origProgress, origStdout := Progress, os.Stdout
+	defer func() { Progress, os.Stdout = origProgress, origStdout }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	Progress = nil // the default: follow whatever os.Stdout is now
+	os.Stdout = w  // what pipe.go does
+	progressf("downloading %d%%\n", 40)
+	w.Close()
+
+	var got bytes.Buffer
+	if _, err := got.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if got.String() != "downloading 40%\n" {
+		t.Errorf("progress did not follow the reassignment: got %q", got.String())
+	}
+}
+
+// With Progress set explicitly, which is what the CLI does under --json, it
+// wins over os.Stdout so the envelope has stdout to itself.
+func TestProgressHonorsExplicitWriter(t *testing.T) {
+	origProgress := Progress
+	defer func() { Progress = origProgress }()
+
+	var buf bytes.Buffer
+	Progress = &buf
+	progressf("installing %s\n", "chrome")
+	if buf.String() != "installing chrome\n" {
+		t.Errorf("explicit writer ignored: got %q", buf.String())
+	}
+}

--- a/tests/cli/json-output.test.js
+++ b/tests/cli/json-output.test.js
@@ -1,0 +1,210 @@
+/**
+ * CLI Tests: --json envelope on commands that answer without a browser
+ *
+ * Regression tests for #517: version, install, add-skill, daemon start,
+ * daemon stop and config init ignored --json entirely, daemon status emitted
+ * JSON without ok, and is-installed printed nothing at all. Every command
+ * here must put exactly one parseable JSON object with an "ok" key on
+ * stdout, and nothing else.
+ *
+ * All state is sandboxed: a temp HOME and config dir for the file-writing
+ * commands, a temp cache dir for the install ones, and a private session so
+ * the daemon cases never touch a real daemon. No browser is launched; the
+ * install case hits the already-installed path of a seeded fake cache.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { VIBIUM } = require('../helpers');
+
+// Short on purpose: the daemon socket lands under the cache dir, and unix
+// socket paths are capped at 103 bytes on macOS.
+const SESSION = `j${process.pid}`;
+let tmpHome;
+let shortCache;
+
+function run(args, extraEnv = {}) {
+  const result = spawnSync(VIBIUM, args, {
+    encoding: 'utf-8',
+    timeout: 30000,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      VIBIUM_CONFIG_DIR: path.join(tmpHome, 'config'),
+      VIBIUM_CACHE_DIR: shortCache,
+      VIBIUM_SESSION: SESSION,
+      VIBIUM_ENGINE_CHANNEL: '',
+      ...extraEnv,
+    },
+  });
+  assert.strictEqual(result.error, undefined, `spawn failed: ${result.error}`);
+  return result;
+}
+
+// Asserts stdout is exactly one JSON object with ok, and returns it parsed.
+function parseEnvelope(result) {
+  const lines = result.stdout.trim().split('\n');
+  assert.strictEqual(lines.length, 1,
+    `expected a single JSON line on stdout, got:\n${result.stdout}`);
+  let parsed;
+  assert.doesNotThrow(() => { parsed = JSON.parse(lines[0]); },
+    `stdout is not JSON:\n${result.stdout}`);
+  assert.strictEqual(typeof parsed.ok, 'boolean',
+    `envelope has no boolean ok:\n${result.stdout}`);
+  return parsed;
+}
+
+// Chrome fake cache in the platform layout paths.GetChromeExecutable expects,
+// same shape as is-installed.test.js.
+function seedFakeChromeCache(cacheDir) {
+  const versionDir = path.join(cacheDir, 'chrome-for-testing', '999.0.0.0');
+  let chromePath;
+  if (process.platform === 'darwin') {
+    chromePath = path.join(versionDir, 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing');
+  } else if (process.platform === 'win32') {
+    chromePath = path.join(versionDir, 'chrome.exe');
+  } else {
+    chromePath = path.join(versionDir, 'chrome');
+  }
+  fs.mkdirSync(path.dirname(chromePath), { recursive: true });
+  fs.writeFileSync(chromePath, 'fake', { mode: 0o755 });
+  const driverName = process.platform === 'win32' ? 'chromedriver.exe' : 'chromedriver';
+  fs.writeFileSync(path.join(versionDir, driverName), 'fake', { mode: 0o755 });
+}
+
+describe('CLI: --json envelope on no-browser commands (#517)', () => {
+  before(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-json-test-'));
+    shortCache = fs.mkdtempSync(path.join(os.tmpdir(), 'vjt-'));
+  });
+
+  after(() => {
+    // The daemon cases stop their own daemon, but a failed assertion can
+    // leave one behind on the private session; sweep it before cleanup.
+    run(['daemon', 'stop']);
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(shortCache, { recursive: true, force: true });
+  });
+
+  test('version --json wraps name and version', () => {
+    const result = run(['--json', 'version']);
+    assert.strictEqual(result.status, 0);
+    const env = parseEnvelope(result);
+    assert.strictEqual(env.ok, true);
+    assert.strictEqual(typeof env.result.version, 'string');
+    assert.strictEqual(typeof env.result.name, 'string');
+  });
+
+  test('version without --json is unchanged', () => {
+    const result = run(['version']);
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /^\S+ v\S+\n$/);
+  });
+
+  test('is-installed --json answers installed:true from a seeded cache', () => {
+    const cacheDir = path.join(tmpHome, 'cache-full');
+    seedFakeChromeCache(cacheDir);
+    const result = run(['--json', 'is-installed'], { VIBIUM_CACHE_DIR: cacheDir });
+    assert.strictEqual(result.status, 0);
+    const env = parseEnvelope(result);
+    assert.strictEqual(env.ok, true);
+    assert.deepStrictEqual(env.result, { engine: 'chrome', installed: true });
+  });
+
+  test('is-installed --json answers installed:false and still exits 1', () => {
+    const cacheDir = path.join(tmpHome, 'cache-empty');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    const result = run(['--json', 'is-installed'], { VIBIUM_CACHE_DIR: cacheDir });
+    // ok means the check ran; the answer and the exit code both say no.
+    assert.strictEqual(result.status, 1);
+    const env = parseEnvelope(result);
+    assert.strictEqual(env.ok, true);
+    assert.deepStrictEqual(env.result, { engine: 'chrome', installed: false });
+  });
+
+  test('install --json emits only the envelope when already installed', () => {
+    const cacheDir = path.join(tmpHome, 'cache-full-install');
+    seedFakeChromeCache(cacheDir);
+    const result = run(['--json', 'install'], { VIBIUM_CACHE_DIR: cacheDir });
+    assert.strictEqual(result.status, 0);
+    const env = parseEnvelope(result);
+    assert.strictEqual(env.ok, true);
+    assert.strictEqual(env.result.engine, 'chrome');
+    assert.ok(env.result.chrome, 'result should carry the chrome path');
+    // The "already installed" line is progress, not result: stderr only.
+    assert.match(result.stderr, /already installed/);
+  });
+
+  test('install without --json keeps its human transcript on stdout', () => {
+    const cacheDir = path.join(tmpHome, 'cache-full-install2');
+    seedFakeChromeCache(cacheDir);
+    const result = run(['install'], { VIBIUM_CACHE_DIR: cacheDir });
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /already installed/);
+    assert.match(result.stdout, /Installation complete!/);
+  });
+
+  test('add-skill --json wraps the install location', () => {
+    const result = run(['--json', 'add-skill']);
+    assert.strictEqual(result.status, 0);
+    const env = parseEnvelope(result);
+    assert.strictEqual(env.ok, true);
+    assert.strictEqual(env.result.skill, 'browser');
+    assert.ok(env.result.dir.startsWith(tmpHome), 'dir should be inside the sandbox HOME');
+    assert.strictEqual(env.result.files.length, 1);
+  });
+
+  test('config init --json reports the files written', () => {
+    const result = run(['--json', 'config', 'init', 'all']);
+    assert.strictEqual(result.status, 0);
+    const env = parseEnvelope(result);
+    assert.strictEqual(env.ok, true);
+    assert.strictEqual(env.result.mode, '0600');
+    assert.strictEqual(env.result.written.length, 2);
+    for (const file of env.result.written) {
+      assert.ok(fs.existsSync(file), `reported file missing: ${file}`);
+    }
+  });
+
+  test('daemon status --json carries ok beside its existing keys', () => {
+    const result = run(['--json', 'daemon', 'status']);
+    // Not running: exit 1 by design, but the JSON must still say ok.
+    assert.strictEqual(result.status, 1);
+    const env = parseEnvelope(result);
+    assert.strictEqual(env.ok, true);
+    assert.strictEqual(env.running, false);
+  });
+
+  test('daemon stop --json reports stopped:false when nothing runs', () => {
+    const result = run(['--json', 'daemon', 'stop']);
+    assert.strictEqual(result.status, 0);
+    const env = parseEnvelope(result);
+    assert.strictEqual(env.ok, true);
+    assert.deepStrictEqual(env.result, { running: false, stopped: false });
+  });
+
+  test('daemon start/stop --json round-trip on a private session', () => {
+    const started = run(['--json', 'daemon', 'start']);
+    assert.strictEqual(started.status, 0, `daemon start failed:\n${started.stderr}`);
+    const startEnv = parseEnvelope(started);
+    assert.strictEqual(startEnv.ok, true);
+    assert.strictEqual(startEnv.result.started, true);
+    assert.strictEqual(typeof startEnv.result.pid, 'number');
+
+    const status = run(['--json', 'daemon', 'status']);
+    assert.strictEqual(status.status, 0);
+    const statusEnv = parseEnvelope(status);
+    assert.strictEqual(statusEnv.ok, true);
+    assert.strictEqual(statusEnv.running, true);
+
+    const stopped = run(['--json', 'daemon', 'stop']);
+    assert.strictEqual(stopped.status, 0);
+    const stopEnv = parseEnvelope(stopped);
+    assert.strictEqual(stopEnv.ok, true);
+    assert.deepStrictEqual(stopEnv.result, { running: false, stopped: true });
+  });
+});

--- a/tests/daemon/lifecycle.test.js
+++ b/tests/daemon/lifecycle.test.js
@@ -180,8 +180,9 @@ describe('Daemon: status exit code', () => {
       assert.fail('daemon status should exit non-zero when nothing is running');
     } catch (err) {
       // The human-readable line used to be printed alongside the JSON, which
-      // broke any consumer piping this to a parser.
-      assert.deepStrictEqual(JSON.parse(err.stdout.trim()), { running: false });
+      // broke any consumer piping this to a parser. ok arrived with #517:
+      // true because the check ran, beside the old keys, not around them.
+      assert.deepStrictEqual(JSON.parse(err.stdout.trim()), { ok: true, running: false });
     }
   });
 


### PR DESCRIPTION
Fixes VibiumDev/vibium#517.

`--json` was ignored by version, install, add-skill, daemon start, daemon stop and config init, daemon status emitted JSON without `ok`, and is-installed printed nothing at all. Each now puts a single envelope on stdout. Report, all-paths sweep, and a reference patch by @lana-20 in the issue; this lands the same three contract decisions with our own implementation and tests: `ok` means the command ran (so is-installed can answer `installed:false` with `ok:true` and exit 1), `daemon status` keeps its top-level keys and gains `ok` beside them so parsers of `.running` keep working, and paths in JSON are absolute while human output keeps `~`.

install needed a change one layer down: the installer's commentary in internal/browser printed straight to stdout, so a command-level envelope landed after lines of plain text. A late-bound `Progress` writer now carries that commentary and the CLI points it at stderr under --json. It must stay late-bound because pipe and mcp reassign os.Stdout inside their own Run; progress_test.go fails if the lookup goes eager.

Verified:
- tests/cli/json-output.test.js fails 9 of 11 on a main build and passes 11/11 here; the other two pin human output unchanged and pass on both builds by design
- go test ./... in clicker green; no-daemon CLI suites 155/155, ready.test.js 11/11
- Human output does not move: the non-json branches are untouched code paths, and the install/version human cases assert the stock transcript
- No browser launched anywhere in the new tests; install runs against a seeded fake cache