### PR TITLE
Add a flag drift checker for the CLI output and flag contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ test-go:
 # Process tests run separately with --test-concurrency=1 to avoid interference
 test-cli: build-go
 	@echo "--- CLI Tests (no daemon) ---"
-	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/help-flags.test.js tests/cli/ready.test.js tests/cli/is-installed.test.js tests/cli/json-output.test.js tests/cli/packaging.test.js tests/cli/release-versioning.test.js tests/cli/wrapper.test.js
+	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/help-flags.test.js tests/cli/ready.test.js tests/cli/is-installed.test.js tests/cli/json-output.test.js tests/cli/json-contract.test.js tests/cli/packaging.test.js tests/cli/release-versioning.test.js tests/cli/wrapper.test.js
 	@"$(MAKE)" test-cli-shared ENGINE=$(ENGINE)
 	@echo "--- CLI Process Tests (sequential) ---"
 	$(TIMEOUT_CMD) node --test $(TEST_FLAGS) --test-concurrency=1 tests/cli/process.test.js tests/cli/dead-browser.test.js tests/cli/start-json.test.js

--- a/clicker/cmd/clicker/flagdrift_test.go
+++ b/clicker/cmd/clicker/flagdrift_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// walkCommands visits every descendant of root, depth first, with its full
+// space-joined path.
+func walkCommands(root *cobra.Command, fn func(path string, c *cobra.Command)) {
+	var walk func(c *cobra.Command, prefix string)
+	walk = func(c *cobra.Command, prefix string) {
+		for _, sub := range c.Commands() {
+			path := strings.TrimSpace(prefix + " " + sub.Name())
+			fn(path, sub)
+			walk(sub, path)
+		}
+	}
+	walk(root, "")
+}
+
+// A subcommand that redeclares a root persistent flag shadows it: cobra drops
+// the root's flag from Global Flags and the local wording and behavior win.
+// That is how `mcp --headless` diverged from every other command (#452). The
+// allowlist is empty on purpose; a legitimate exception should be argued into
+// this test, not slipped past it.
+func TestNoLocalFlagShadowsRootPersistent(t *testing.T) {
+	root, _ := newRootCmd("vibium")
+
+	global := map[string]bool{}
+	root.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		global[f.Name] = true
+	})
+	if len(global) == 0 {
+		t.Fatal("no root persistent flags found; the walk below would pass vacuously")
+	}
+
+	walkCommands(root, func(path string, c *cobra.Command) {
+		check := func(f *pflag.Flag) {
+			if global[f.Name] {
+				t.Errorf("%q declares local flag --%s, shadowing the root persistent flag of the same name", path, f.Name)
+			}
+		}
+		c.Flags().VisitAll(check)
+		c.PersistentFlags().VisitAll(check)
+	})
+}
+
+// The commands that disable cobra flag parsing re-run the global-flag bridge
+// themselves (parseFlagsAllowNegative), and get --help/--session/--channel
+// coverage from tests/cli/help-flags.test.js and global-flags.test.js. A new
+// member joins that contract deliberately: add it here and to those suites,
+// or it ships with #422/#423/#482 all over again.
+func TestDisableFlagParsingSetIsExact(t *testing.T) {
+	root, _ := newRootCmd("vibium")
+
+	want := []string{"fill", "geolocation", "sleep", "type"}
+	var got []string
+	walkCommands(root, func(path string, c *cobra.Command) {
+		if c.DisableFlagParsing {
+			got = append(got, path)
+		}
+	})
+	sort.Strings(got)
+
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("DisableFlagParsing commands = %v, want %v\n"+
+			"If you added one on purpose, extend tests/cli/help-flags.test.js and tests/cli/global-flags.test.js to cover it, then update this list.", got, want)
+	}
+}

--- a/clicker/cmd/clicker/main.go
+++ b/clicker/cmd/clicker/main.go
@@ -146,8 +146,20 @@ func applyGlobalFlags(cmd *cobra.Command) error {
 }
 
 func main() {
-	progName := filepath.Base(os.Args[0])
+	rootCmd, runCmd := newRootCmd(filepath.Base(os.Args[0]))
 
+	rootCmd.SetArgs(promptArgs(rootCmd, runCmd, os.Args[1:]))
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// newRootCmd builds the full command tree. Factored out of main so tests can
+// walk the real tree in-process (flagdrift_test.go) instead of parsing help
+// text from the binary.
+func newRootCmd(progName string) (root, run *cobra.Command) {
 	rootCmd := &cobra.Command{
 		Use: progName + " [command | \"<prompt>\"]",
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -265,10 +277,5 @@ func main() {
 	rootCmd.Version = version
 	rootCmd.SetVersionTemplate(progName + " v{{.Version}}\n")
 
-	rootCmd.SetArgs(promptArgs(rootCmd, runCmd, os.Args[1:]))
-
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	return rootCmd, runCmd
 }

--- a/clicker/cmd/clicker/scroll.go
+++ b/clicker/cmd/clicker/scroll.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/vibium/clicker/internal/agent"
 )
 
 func newScrollCmd() *cobra.Command {
@@ -47,8 +48,8 @@ func newScrollCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	cmd.Flags().Int("amount", 3, "Number of scroll increments")
-	cmd.Flags().String("selector", "", "CSS selector for the element to scroll within")
+	cmd.Flags().Int("amount", 3, agent.ScrollAmountDesc)
+	cmd.Flags().String("selector", "", agent.ScrollSelectorDesc)
 
 	var intoViewTimeout time.Duration
 	intoViewCmd := &cobra.Command{

--- a/clicker/internal/agent/schema.go
+++ b/clicker/internal/agent/schema.go
@@ -20,6 +20,15 @@ var noPageParam = map[string]bool{
 	"browser_download_set_dir":   true,
 }
 
+// Descriptions shared between a cobra flag's help text and the MCP tool
+// schema live here, so the two surfaces cannot contradict each other again
+// the way scroll's --selector did (#445). Surface-specific detail is
+// appended at the use site, never restated.
+const (
+	ScrollSelectorDesc = "CSS selector for the element to scroll within"
+	ScrollAmountDesc   = "Number of scroll increments"
+)
+
 // GetToolSchemas returns the list of available MCP tools with their schemas.
 func GetToolSchemas() []Tool {
 	tools := []Tool{
@@ -393,12 +402,12 @@ func GetToolSchemas() []Tool {
 					},
 					"amount": map[string]interface{}{
 						"type":        "number",
-						"description": "Number of scroll increments (default: 3)",
+						"description": ScrollAmountDesc + " (default: 3)",
 						"default":     3,
 					},
 					"selector": map[string]interface{}{
 						"type":        "string",
-						"description": "CSS selector for the element to scroll within (optional; without it the page scrolls at the viewport center)",
+						"description": ScrollSelectorDesc + " (optional; without it the page scrolls at the viewport center)",
 					},
 				},
 				"additionalProperties": false,

--- a/tests/cli/json-contract.test.js
+++ b/tests/cli/json-contract.test.js
@@ -1,0 +1,251 @@
+/**
+ * CLI Tests: the --json output contract, swept over every command path
+ *
+ * `--json` kept regressing one command at a time (#241, #392, #451, #517)
+ * because each fix covered only the commands named in the report. This suite
+ * closes the class: every path `vibium commands` lists is declared in the
+ * table below, and a tripwire fails the moment a new command ships without
+ * declaring its class. Declaring it is also joining it, because the declared
+ * class is asserted by running the command.
+ *
+ * Classes:
+ *   envelope     stdout is exactly one JSON object with a boolean "ok".
+ *                Holds on failure too: a browser command that cannot launch
+ *                must answer {"ok":false,...}, not plain text. Exit codes
+ *                are the command's own business (is-installed says no with
+ *                ok:true and exit 1), so they are not asserted here.
+ *   usage-error  called with no arguments the command refuses: stdout stays
+ *                empty, the complaint goes to stderr, exit is non-zero. A
+ *                usage error is conventionally plain text, so this class is
+ *                about keeping stdout clean for parsers.
+ *   exempt       never run, reason documented inline.
+ *
+ * Everything runs in a sandbox: temp HOME and config dir, an empty cache
+ * with downloads disabled so browser launches fail fast instead of
+ * downloading Chrome, and a private session so an auto-started daemon never
+ * touches a real one. No browser is ever launched; `install` runs against a
+ * seeded fake cache and takes its already-installed path.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { VIBIUM } = require('../helpers');
+
+// Short session and cache names: the daemon socket path must stay under the
+// 103-byte macOS unix-socket limit.
+const SESSION = `jc${process.pid}`;
+
+const CLASSES = {
+  'a11y-tree': 'envelope',
+  'add-skill': 'envelope',
+  'attr': 'usage-error',
+  'back': 'envelope',
+  'bidi-test': 'exempt', // five-step diagnostic transcript, not a result
+  'check': 'usage-error',
+  'click': 'usage-error',
+  'config init': 'envelope',
+  'content': 'usage-error',
+  'cookies': 'envelope',
+  'cookies clear': 'envelope',
+  'count': 'usage-error',
+  'daemon start': 'envelope',
+  'daemon status': 'envelope',
+  'daemon stop': 'envelope',
+  'dblclick': 'usage-error',
+  'dialog accept': 'envelope',
+  'dialog dismiss': 'envelope',
+  'diff map': 'envelope',
+  'download dir': 'usage-error',
+  'drag': 'usage-error',
+  'eval': 'usage-error',
+  'fill': 'usage-error',
+  'find': 'usage-error',
+  'find alt': 'usage-error',
+  'find label': 'usage-error',
+  'find placeholder': 'usage-error',
+  'find role': 'usage-error',
+  'find testid': 'usage-error',
+  'find text': 'usage-error',
+  'find title': 'usage-error',
+  'find xpath': 'usage-error',
+  'focus': 'usage-error',
+  'forward': 'envelope',
+  'frame': 'usage-error',
+  'frames': 'envelope',
+  'geolocation': 'usage-error',
+  'go': 'usage-error',
+  'highlight': 'usage-error',
+  'hover': 'usage-error',
+  'html': 'envelope',
+  'install': 'envelope',
+  'is actionable': 'usage-error',
+  'is enabled': 'usage-error',
+  'is set': 'usage-error',
+  'is visible': 'usage-error',
+  'is-installed': 'envelope',
+  'keys': 'usage-error',
+  'launch-test': 'exempt', // runs until Ctrl+C
+  'map': 'envelope',
+  'mcp': 'exempt', // server: banner on stderr, exits when stdin closes
+  'media': 'usage-error',
+  'mouse click': 'envelope',
+  'mouse down': 'envelope',
+  'mouse move': 'usage-error',
+  'mouse up': 'envelope',
+  'page close': 'envelope',
+  'page new': 'envelope',
+  'page switch': 'usage-error',
+  'pages': 'envelope',
+  'paths': 'envelope',
+  'pdf': 'envelope',
+  'pipe': 'exempt', // stdout carries the BiDi protocol stream by design
+  'press': 'usage-error',
+  'ready': 'envelope',
+  'ready ai': 'envelope',
+  'ready browser': 'envelope',
+  'record chunk start': 'envelope',
+  'record chunk stop': 'envelope',
+  'record group start': 'usage-error',
+  'record group stop': 'envelope',
+  'record start': 'envelope',
+  'record stop': 'envelope',
+  'reload': 'envelope',
+  'run': 'usage-error',
+  'screenshot': 'envelope',
+  'scroll': 'envelope',
+  'scroll into-view': 'usage-error',
+  'select': 'usage-error',
+  'serve': 'exempt', // runs until interrupted
+  'set': 'usage-error',
+  'sleep': 'usage-error',
+  'start': 'envelope',
+  'stop': 'envelope',
+  'storage': 'envelope',
+  'storage restore': 'usage-error',
+  'text': 'envelope',
+  'title': 'envelope',
+  'type': 'usage-error',
+  'unset': 'usage-error',
+  'upload': 'usage-error',
+  'url': 'envelope',
+  'value': 'usage-error',
+  'version': 'envelope',
+  'viewport': 'envelope',
+  'wait': 'usage-error',
+  'wait fn': 'usage-error',
+  'wait load': 'envelope',
+  'wait text': 'usage-error',
+  'wait url': 'usage-error',
+  'window': 'envelope',
+  'ws-test': 'usage-error',
+};
+
+let tmpHome;
+let emptyCache;
+let fakeCache;
+
+function run(args, extraEnv = {}) {
+  const result = spawnSync(VIBIUM, args, {
+    encoding: 'utf-8',
+    timeout: 30000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      VIBIUM_CONFIG_DIR: path.join(tmpHome, 'config'),
+      VIBIUM_CACHE_DIR: emptyCache,
+      VIBIUM_SESSION: SESSION,
+      VIBIUM_ENGINE_CHANNEL: '',
+      VIBIUM_SKIP_BROWSER_DOWNLOAD: '1',
+      ...extraEnv,
+    },
+  });
+  assert.strictEqual(result.error, undefined, `spawn failed: ${result.error}`);
+  return result;
+}
+
+// install is envelope-class via its already-installed path; give it a seeded
+// cache and let it "install" (Install() checks the download switch before
+// the cache, so the switch must be off).
+const ENV_OVERRIDES = {
+  'install': () => ({ VIBIUM_CACHE_DIR: fakeCache, VIBIUM_SKIP_BROWSER_DOWNLOAD: '' }),
+};
+
+function seedFakeChromeCache(cacheDir) {
+  const versionDir = path.join(cacheDir, 'chrome-for-testing', '999.0.0.0');
+  let chromePath;
+  if (process.platform === 'darwin') {
+    chromePath = path.join(versionDir, 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing');
+  } else if (process.platform === 'win32') {
+    chromePath = path.join(versionDir, 'chrome.exe');
+  } else {
+    chromePath = path.join(versionDir, 'chrome');
+  }
+  fs.mkdirSync(path.dirname(chromePath), { recursive: true });
+  fs.writeFileSync(chromePath, 'fake', { mode: 0o755 });
+  const driverName = process.platform === 'win32' ? 'chromedriver.exe' : 'chromedriver';
+  fs.writeFileSync(path.join(versionDir, driverName), 'fake', { mode: 0o755 });
+}
+
+describe('CLI: --json output contract on every command path', () => {
+  before(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'vibium-jc-home-'));
+    emptyCache = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-'));
+    fakeCache = fs.mkdtempSync(path.join(os.tmpdir(), 'jcf-'));
+    seedFakeChromeCache(fakeCache);
+  });
+
+  after(() => {
+    // Some envelope commands auto-start a daemon on the private session.
+    run(['daemon', 'stop']);
+    for (const dir of [tmpHome, emptyCache, fakeCache]) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('every command path declares its class (tripwire)', () => {
+    const result = run(['commands']);
+    assert.strictEqual(result.status, 0, `vibium commands failed:\n${result.stderr}`);
+    const listed = JSON.parse(result.stdout)[''];
+    const declared = Object.keys(CLASSES);
+
+    const missing = listed.filter((p) => !(p in CLASSES));
+    const stale = declared.filter((p) => !listed.includes(p));
+    assert.deepStrictEqual(missing, [],
+      'new command paths must declare a --json class in this table (envelope, usage-error, or exempt with a reason)');
+    assert.deepStrictEqual(stale, [],
+      'table entries for command paths that no longer exist');
+  });
+
+  for (const [cmd, cls] of Object.entries(CLASSES)) {
+    if (cls === 'exempt') continue;
+
+    test(`${cmd} [${cls}]`, () => {
+      const extraEnv = ENV_OVERRIDES[cmd] ? ENV_OVERRIDES[cmd]() : {};
+      const result = run(['--json', ...cmd.split(' ')], extraEnv);
+
+      if (cls === 'usage-error') {
+        assert.notStrictEqual(result.status, 0,
+          `expected a non-zero exit with no arguments\nstdout: ${result.stdout}`);
+        assert.strictEqual(result.stdout, '',
+          `a usage error must leave stdout empty for parsers\nstdout: ${result.stdout}`);
+        assert.notStrictEqual(result.stderr.trim(), '',
+          'the usage error itself went missing from stderr');
+        return;
+      }
+
+      const lines = result.stdout.trim().split('\n');
+      assert.strictEqual(lines.length, 1,
+        `expected a single JSON line on stdout\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+      let parsed;
+      assert.doesNotThrow(() => { parsed = JSON.parse(lines[0]); },
+        `stdout is not JSON\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+      assert.strictEqual(typeof parsed.ok, 'boolean',
+        `envelope has no boolean ok\nstdout: ${result.stdout}`);
+    });
+  }
+});


### PR DESCRIPTION
Fixes VibiumDev/vibium#521.

Stacked on #104 (the VibiumDev/vibium#517 fix); merge after it. Without that fix this suite is red, failing on exactly the eight commands named there.

The --json contract regressed one command at a time (VibiumDev/vibium#241, #392, #451, #517) because each fix covered only the commands named in the report. This closes the class the way apidrift closes it for the API surface: a contract, checked against the real command tree, on every PR.

- tests/cli/json-contract.test.js sweeps all 102 paths from `vibium commands` against a checked-in class table (envelope / usage-error / exempt with reasons: pipe, bidi-test, serve, launch-test, mcp). A tripwire fails the moment a new command ships without declaring its class. The sandbox disables downloads so browser launches fail fast into `{"ok":false,...}` envelopes; the whole sweep is hermetic and runs in about a second.
- cmd/clicker/flagdrift_test.go walks the cobra tree in-process (via newRootCmd, factored out of main): no subcommand may shadow a root persistent flag (the VibiumDev/vibium#452 class, empty allowlist), and the DisableFlagParsing set is pinned to {fill, geolocation, sleep, type} so a new member must join the #422/#423/#482 behavioral coverage deliberately.
- scroll's --selector and --amount descriptions, duplicated between the cobra flag and the MCP schema (the #445 class), now share constants in internal/agent; surface-specific detail is appended at the use site. Resulting schema strings are byte-identical.

Verified:
- json-contract suite: 98/98 on this branch; against a main build it fails on exactly the eight #517 commands and nothing else, matching the tally measured in that issue
- flagdrift tests pass; the shadowing check has a vacuity guard (fails if it finds no root persistent flags)
- go test ./... in clicker green; no-daemon CLI suites 155/155

Note: gofmt flags pre-existing comment alignment in internal/agent/handlers.go and server.go (untouched here). Left out of this PR on purpose.