### PR TITLE
Make lateParse the only way to disable flag parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,3 +38,4 @@ Power users can override defaults (headless mode, custom paths, etc.) when neede
 - Always fix flaky tests immediately when they show up — never dismiss them as "pre-existing"
 - The browser under test is a parameter, never a literal in a test. Suites read `ENGINE` from tests/helpers.js (`VIBIUM_ENGINE`, threaded through the Makefile as `ENGINE=`), and CI runs each suite once per engine job. Naming an engine inside a case in the default suite runs it in the chrome job, which installs no other browser. Adding an engine should be a new job, not a new branch in a test.
 - When adding new command line options to the vibium binary, add a simple example and sample output (or short description)
+- A CLI command whose positional values can be negative or numeric (coordinates, offsets, durations) must be built with `lateParse` (cmd/clicker/helpers.go). Never set `DisableFlagParsing` by hand; the flag drift test rejects it.

--- a/clicker/cmd/clicker/fill.go
+++ b/clicker/cmd/clicker/fill.go
@@ -20,14 +20,7 @@ func newFillCmd() *cobra.Command {
 
   vibium fill "#search" "vibium" --timeout 5s
   # Custom timeout (5s, or 5000 for milliseconds)`,
-		DisableFlagParsing: true,
-		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			args, perr := parseFlagsAllowNegative(cmd, args)
-			if perr != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", perr)
-				os.Exit(1)
-			}
 			if len(args) != 2 {
 				fmt.Fprintf(os.Stderr, "Error: accepts 2 arg(s), received %d\n", len(args))
 				os.Exit(1)
@@ -47,8 +40,6 @@ func newFillCmd() *cobra.Command {
 		},
 	}
 	addTimeoutFlag(cmd, &timeout)
-	// fill now carries a --timeout flag, so it can't disable flag parsing the way
-	// #179 did for the flagless case. SetInterspersed(false) instead keeps negative
-	// positional values (e.g. fill "#x" "-2") from being parsed as shorthand flags.
-	return cmd
+	// Values like fill "#x" "-2" must not be parsed as shorthand flags (#179).
+	return lateParse(cmd)
 }

--- a/clicker/cmd/clicker/flagdrift_test.go
+++ b/clicker/cmd/clicker/flagdrift_test.go
@@ -53,8 +53,8 @@ func TestNoLocalFlagShadowsRootPersistent(t *testing.T) {
 // The commands that disable cobra flag parsing re-run the global-flag bridge
 // themselves (parseFlagsAllowNegative), and get --help/--session/--channel
 // coverage from tests/cli/help-flags.test.js and global-flags.test.js. A new
-// member joins that contract deliberately: add it here and to those suites,
-// or it ships with #422/#423/#482 all over again.
+// member joins that contract deliberately: build it with lateParse, add it
+// here and to those suites, or it ships with #422/#423/#482 all over again.
 func TestDisableFlagParsingSetIsExact(t *testing.T) {
 	root, _ := newRootCmd("vibium")
 
@@ -63,6 +63,9 @@ func TestDisableFlagParsingSetIsExact(t *testing.T) {
 	walkCommands(root, func(path string, c *cobra.Command) {
 		if c.DisableFlagParsing {
 			got = append(got, path)
+			if !lateParseCommands[c.Name()] {
+				t.Errorf("%q sets DisableFlagParsing without lateParse, so it parses flags without the --help interception and the global-flag re-apply (#422/#482)", path)
+			}
 		}
 	})
 	sort.Strings(got)

--- a/clicker/cmd/clicker/geolocation.go
+++ b/clicker/cmd/clicker/geolocation.go
@@ -17,14 +17,7 @@ func newGeolocationCmd() *cobra.Command {
 
   vibium geolocation 51.5074 -0.1278 --accuracy 10
   # Set location to London with 10m accuracy`,
-		DisableFlagParsing: true,
-		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			args, perr := parseFlagsAllowNegative(cmd, args)
-			if perr != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", perr)
-				os.Exit(1)
-			}
 			if len(args) != 2 {
 				fmt.Fprintf(os.Stderr, "Error: accepts 2 arg(s), received %d\n", len(args))
 				os.Exit(1)
@@ -58,5 +51,6 @@ func newGeolocationCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Float64("accuracy", 0, "Accuracy in meters (default: 1)")
-	return cmd
+	// Western longitudes are negative: `geolocation 37.8 -122.4` (#179).
+	return lateParse(cmd)
 }

--- a/clicker/cmd/clicker/helpers.go
+++ b/clicker/cmd/clicker/helpers.go
@@ -18,6 +18,35 @@ func printCheck(name string, passed bool) {
 	}
 }
 
+// lateParseCommands records every command built with lateParse. The flag
+// drift test compares it against the commands that disable flag parsing, so
+// setting DisableFlagParsing by hand, without the parse and global-flag
+// re-apply that must come with it (#482), fails the build.
+var lateParseCommands = map[string]bool{}
+
+// lateParse converts a command to late flag parsing, for positionals that can
+// be negative numbers (`sleep -5`, `geolocation 37.8 -122.4`), which pflag
+// would otherwise read as unknown flags. The command's Run receives the
+// parsed positionals and still checks its own arity; everything else, flag
+// parsing, --help interception, and the global-flag re-apply, happens here.
+//
+// This is the only supported way to disable flag parsing on a command.
+func lateParse(cmd *cobra.Command) *cobra.Command {
+	inner := cmd.Run
+	cmd.DisableFlagParsing = true
+	cmd.Args = cobra.ArbitraryArgs
+	cmd.Run = func(c *cobra.Command, raw []string) {
+		args, err := parseFlagsAllowNegative(c, raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		inner(c, args)
+	}
+	lateParseCommands[cmd.Name()] = true
+	return cmd
+}
+
 // parseFlagsAllowNegative splits raw args into flags and positionals, treating a
 // token that starts with '-' as a positional when it parses as a number.
 //
@@ -27,8 +56,8 @@ func printCheck(name string, passed bool) {
 // breaking trailing flags, so `sleep 1 --json` printed plain text and
 // `fill '#x' y --timeout 5s` failed on arity (#241).
 //
-// Commands using this set DisableFlagParsing and cobra.ArbitraryArgs, then check
-// their own arity on the returned positionals.
+// Commands reach this through lateParse, which owns the DisableFlagParsing
+// and ArbitraryArgs settings it depends on.
 func parseFlagsAllowNegative(cmd *cobra.Command, raw []string) ([]string, error) {
 	// Touching InheritedFlags merges the parents' persistent flags (--json,
 	// --headless, --verbose) into cmd.Flags(). cmd.ParseFlags is not usable

--- a/clicker/cmd/clicker/sleep_cmd.go
+++ b/clicker/cmd/clicker/sleep_cmd.go
@@ -17,14 +17,7 @@ func newSleepCmd() *cobra.Command {
 
   vibium sleep 500
   # Wait 500ms`,
-		DisableFlagParsing: true,
-		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			args, perr := parseFlagsAllowNegative(cmd, args)
-			if perr != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", perr)
-				os.Exit(1)
-			}
 			if len(args) != 1 {
 				fmt.Fprintf(os.Stderr, "Error: accepts 1 arg(s), received %d\n", len(args))
 				os.Exit(1)
@@ -43,5 +36,6 @@ func newSleepCmd() *cobra.Command {
 			printResult(result)
 		},
 	}
-	return cmd
+	// `sleep -5` is a negative value, not a flag (#179).
+	return lateParse(cmd)
 }

--- a/clicker/cmd/clicker/type_cmd.go
+++ b/clicker/cmd/clicker/type_cmd.go
@@ -21,14 +21,7 @@ func newTypeCmd() *cobra.Command {
 
   vibium type https://the-internet.herokuapp.com/inputs "input" "12345" --timeout 5s
   # Custom timeout (5s, or 5000 for milliseconds)`,
-		DisableFlagParsing: true,
-		Args:               cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			args, perr := parseFlagsAllowNegative(cmd, args)
-			if perr != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", perr)
-				os.Exit(1)
-			}
 			if len(args) < 2 || len(args) > 3 {
 				fmt.Fprintf(os.Stderr, "Error: accepts between 2 and 3 arg(s), received %d\n", len(args))
 				os.Exit(1)
@@ -63,5 +56,6 @@ func newTypeCmd() *cobra.Command {
 		},
 	}
 	addTimeoutFlag(cmd, &timeout)
-	return cmd
+	// Values like type "#x" "-2" must not be parsed as shorthand flags (#179).
+	return lateParse(cmd)
 }


### PR DESCRIPTION
Follow-up to VibiumDev/vibium#523, closing the last structural hole in the VibiumDev/vibium#179 lineage.

The negative-positional commands (fill, type, geolocation, sleep) each hand-assembled the same recipe: DisableFlagParsing, ArbitraryArgs, and a parseFlagsAllowNegative call at the top of Run. Copying the first line without the last is exactly how --session and --channel went silently ignored (#482), and nothing but review stood between a fifth command and the same mistake.

lateParse now owns the recipe and records its users, and the flag drift test rejects any command that sets DisableFlagParsing without it, so the mismatch is a build failure instead of a field report. Command Run bodies keep only their arity checks. CLAUDE.md documents the rule for the next command with numeric positionals.

Verified:
- Hand-setting DisableFlagParsing on a command without lateParse fails TestDisableFlagParsingSetIsExact naming the command and the bugs it would repeat
- Behavior unchanged: help-flags, global-flags and json-contract suites pass against the refactored build (124/124), and spot checks confirm `geolocation 37.8 -122.4 --channel bogus` still reaches channel validation and `sleep -5 --help` still shows help
- go test ./... in clicker green