### PR TITLE
Honor a per-call Chrome channel in browser_start

### DIFF
--- a/clicker/cmd/clicker/daemon_client.go
+++ b/clicker/cmd/clicker/daemon_client.go
@@ -66,6 +66,9 @@ func requestedLaunchOptions() map[string]interface{} {
 		channel := engineChannel
 		if channel == "" {
 			channel = paths.FirefoxChannel()
+			if engineName != "firefox" {
+				channel = paths.ChromeChannel()
+			}
 		}
 		args["channel"] = channel
 	}

--- a/clicker/cmd/clicker/main.go
+++ b/clicker/cmd/clicker/main.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -116,16 +115,11 @@ func applyGlobalFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("unsupported engine %q (supported: chrome, firefox)", engineName)
 	}
 	// Channels differ per engine: Mozilla's are release/beta, Chrome
-	// for Testing's are stable/beta/dev/canary.
-	if engineChannel != "" {
-		valid := map[string][]string{
-			"firefox": {"release", "beta"},
-			"chrome":  {"stable", "beta", "dev", "canary"},
-		}[engineName]
-		if !slices.Contains(valid, engineChannel) {
-			return fmt.Errorf("unsupported channel %q for %s (supported: %s)",
-				engineChannel, engineName, strings.Join(valid, ", "))
-		}
+	// for Testing's are stable/beta/dev/canary. The table is shared with
+	// the MCP schema and the daemon's per-call validation (#525).
+	if !paths.ValidChannel(engineName, engineChannel) {
+		return fmt.Errorf("unsupported channel %q for %s (supported: %s)",
+			engineChannel, engineName, strings.Join(paths.EngineChannels[engineName], ", "))
 	}
 	// VIBIUM_ENGINE_PATH is an engine-neutral name but only Firefox
 	// implements it. Say so rather than accepting the setting and

--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -34,6 +34,7 @@ type Handlers struct {
 	screenshotDir  string
 	engine         string // "chrome" (default) or "firefox"
 	firefoxChannel string // daemon/session default; captured at construction
+	chromeChannel  string // daemon/session default; captured at construction
 	headless       bool
 	connectURL     string                       // remote BiDi WebSocket URL (empty = local browser)
 	connectHeaders http.Header                  // headers for remote WebSocket connection
@@ -77,8 +78,8 @@ type Handlers struct {
 	// launched with, same caveat as launchedHeadless.
 	launchedEngine string
 
-	// launchedChannel distinguishes separately installed Firefox channels.
-	// It is empty for Chrome and remote sessions.
+	// launchedChannel distinguishes separately installed release channels of
+	// either engine. It is empty for remote sessions.
 	launchedChannel string
 
 	// launchNotify, when set, is called once at the moment a tool call
@@ -114,6 +115,7 @@ func NewHandlers(screenshotDir string, engine string, headless bool, connectURL 
 		screenshotDir:  screenshotDir,
 		engine:         engine,
 		firefoxChannel: paths.FirefoxChannel(),
+		chromeChannel:  paths.ChromeChannel(),
 		headless:       headless,
 		connectURL:     connectURL,
 		connectHeaders: connectHeaders,
@@ -816,10 +818,10 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 				"%s is already running; requested %s. Run `vibium stop` first, or drop the flag to use the running browser",
 				h.launchedEngine, want)
 		}
-		if want, ok := args["channel"].(string); ok && want != "" && h.launchedEngine == "firefox" && want != h.launchedChannel {
+		if want, ok := args["channel"].(string); ok && want != "" && h.launchedChannel != "" && want != h.launchedChannel {
 			return nil, fmt.Errorf(
-				"Firefox %s is already running; requested %s. Run `vibium stop` first, or use another --session",
-				h.launchedChannel, want)
+				"%s %s is already running; requested %s. Run `vibium stop` first, or use another --session",
+				engineTitle(h.launchedEngine), h.launchedChannel, want)
 		}
 		return &ToolsCallResult{
 			Content: []Content{{
@@ -880,15 +882,20 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 	if useEngine == "" {
 		useEngine = "chrome"
 	}
-	useChannel := ""
+	// The default channel is the daemon's, captured at construction; a
+	// per-call channel overrides it for either engine. Chrome used to read
+	// this argument only in the Firefox branch, silently launching stable
+	// no matter what the caller asked for (#525).
+	useChannel := h.chromeChannel
 	if useEngine == "firefox" {
 		useChannel = h.firefoxChannel
-		if val, ok := args["channel"].(string); ok && val != "" {
-			if val != "release" && val != "beta" {
-				return nil, fmt.Errorf("unknown Firefox channel %q (supported: release, beta)", val)
-			}
-			useChannel = val
+	}
+	if val, ok := args["channel"].(string); ok && val != "" {
+		if !paths.ValidChannel(useEngine, val) {
+			return nil, fmt.Errorf("unknown %s channel %q (supported: %s)",
+				engineTitle(useEngine), val, strings.Join(paths.EngineChannels[useEngine], ", "))
 		}
+		useChannel = val
 	}
 
 	// Install the engine if this machine has never had one. The client
@@ -907,7 +914,7 @@ func (h *Handlers) browserLaunch(args map[string]interface{}) (*ToolsCallResult,
 
 	// Launch browser
 	launchResult, err := browser.Launch(browser.LaunchOptions{
-		Engine: useEngine, FirefoxChannel: useChannel, Headless: useHeadless,
+		Engine: useEngine, Channel: useChannel, Headless: useHeadless,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to launch browser: %w", err)
@@ -949,6 +956,16 @@ func modeName(headless bool) string {
 		return "headless"
 	}
 	return "headed"
+}
+
+// engineTitle renders an engine name for error messages.
+func engineTitle(engine string) string {
+	switch engine {
+	case "firefox":
+		return "Firefox"
+	default:
+		return "Chrome"
+	}
 }
 
 // startPromptTracking subscribes to user-prompt events and keeps h.prompts in

--- a/clicker/internal/agent/handlers_browser_launch_test.go
+++ b/clicker/internal/agent/handlers_browser_launch_test.go
@@ -55,3 +55,36 @@ func TestHandlersCaptureFirefoxChannelDefault(t *testing.T) {
 		t.Fatalf("firefoxChannel = %q, want captured default release", h.firefoxChannel)
 	}
 }
+
+func TestBrowserLaunchRejectsChromeChannelMismatch(t *testing.T) {
+	// The guard used to be gated on firefox, so a Chrome channel mismatch
+	// answered "already running" as a success (#525).
+	h := &Handlers{
+		client:          &bidi.Client{},
+		launchedEngine:  "chrome",
+		launchedChannel: "stable",
+	}
+	_, err := h.browserLaunch(map[string]interface{}{"engine": "chrome", "channel": "beta"})
+	if err == nil || !strings.Contains(err.Error(), "Chrome stable is already running; requested beta") {
+		t.Fatalf("browserLaunch() error = %v", err)
+	}
+}
+
+func TestBrowserLaunchValidatesChannelPerEngine(t *testing.T) {
+	// Validation happens before any install or launch, so no browser and no
+	// network is touched. Chrome used to skip it entirely and silently
+	// launch stable (#525).
+	cases := []struct {
+		engine, channel, want string
+	}{
+		{"chrome", "release", `unknown Chrome channel "release" (supported: stable, beta, dev, canary)`},
+		{"firefox", "canary", `unknown Firefox channel "canary" (supported: release, beta)`},
+	}
+	for _, c := range cases {
+		h := NewHandlers("", c.engine, true, "", nil, nil)
+		_, err := h.browserLaunch(map[string]interface{}{"engine": c.engine, "channel": c.channel})
+		if err == nil || !strings.Contains(err.Error(), c.want) {
+			t.Errorf("browserLaunch(%s, %s) error = %v, want %q", c.engine, c.channel, err, c.want)
+		}
+	}
+}

--- a/clicker/internal/agent/schema.go
+++ b/clicker/internal/agent/schema.go
@@ -1,5 +1,11 @@
 package agent
 
+import (
+	"sort"
+
+	"github.com/vibium/clicker/internal/paths"
+)
+
 // noPageParam lists the tools that are not scoped to a page: session
 // lifecycle, page management, recording control, and plain waits. Every
 // other tool accepts an optional page argument (added in GetToolSchemas)
@@ -29,6 +35,26 @@ const (
 	ScrollAmountDesc   = "Number of scroll increments"
 )
 
+// channelEnum is browser_start's channel enum: every channel of every
+// engine, from the same table the CLI and the launch handler validate
+// against. The schema cannot express per-engine enums, so the handler does
+// that half; what matters here is that a real channel is never refused at
+// the schema and a removed one never lingers (#525).
+func channelEnum() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, channels := range paths.EngineChannels {
+		for _, c := range channels {
+			if !seen[c] {
+				seen[c] = true
+				out = append(out, c)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // GetToolSchemas returns the list of available MCP tools with their schemas.
 func GetToolSchemas() []Tool {
 	tools := []Tool{
@@ -53,8 +79,8 @@ func GetToolSchemas() []Tool {
 					},
 					"channel": map[string]interface{}{
 						"type":        "string",
-						"description": "Firefox release channel",
-						"enum":        []string{"release", "beta"},
+						"description": "Release channel of the selected engine; chrome: stable (default), beta, dev, canary; firefox: release (default), beta",
+						"enum":        channelEnum(),
 					},
 				},
 				"additionalProperties": false,

--- a/clicker/internal/agent/schema_channel_test.go
+++ b/clicker/internal/agent/schema_channel_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vibium/clicker/internal/paths"
+)
+
+// browser_start's channel enum must stay the union of the shared per-engine
+// table. It was last hand-written before Chrome channels existed and spent a
+// year advertising a Firefox-only world (#525).
+func TestBrowserStartChannelEnumMatchesTable(t *testing.T) {
+	var got []string
+	for _, tool := range GetToolSchemas() {
+		if tool.Name != "browser_start" {
+			continue
+		}
+		props := tool.InputSchema["properties"].(map[string]interface{})
+		channel := props["channel"].(map[string]interface{})
+		got = channel["enum"].([]string)
+	}
+	if got == nil {
+		t.Fatal("browser_start has no channel enum")
+	}
+
+	seen := map[string]bool{}
+	for _, channels := range paths.EngineChannels {
+		for _, c := range channels {
+			seen[c] = true
+		}
+	}
+	if len(got) != len(seen) {
+		t.Fatalf("channel enum = %v, want exactly the union of paths.EngineChannels %v", got, seen)
+	}
+	for _, c := range got {
+		if !seen[c] {
+			t.Errorf("channel enum lists %q, which no engine in paths.EngineChannels has", c)
+		}
+	}
+	if !reflect.DeepEqual(got, channelEnum()) {
+		t.Errorf("channel enum = %v, want channelEnum() = %v", got, channelEnum())
+	}
+}

--- a/clicker/internal/browser/ensure.go
+++ b/clicker/internal/browser/ensure.go
@@ -20,14 +20,13 @@ func EngineInstalled(engine string) bool {
 }
 
 // EngineInstalledForChannel reports whether the engine is installed for a
-// specific Firefox channel. An empty channel means the VIBIUM_ENGINE_CHANNEL
-// default. Chrome resolves its own channel from the environment and ignores
-// the argument.
+// specific channel. An empty channel means the VIBIUM_ENGINE_CHANNEL
+// default.
 func EngineInstalledForChannel(engine, channel string) bool {
 	if engine == "firefox" {
 		return IsFirefoxInstalledForChannel(channel)
 	}
-	return IsInstalled()
+	return IsInstalledForChannel(channel)
 }
 
 // EnsureInstalled installs the selected engine if it is not already present.
@@ -37,10 +36,10 @@ func EnsureInstalled(engine string) error {
 	return EnsureInstalledForChannel(engine, "")
 }
 
-// EnsureInstalledForChannel installs the engine for a specific Firefox
-// channel. The daemon resolves a per-call --channel that need not match the
-// environment, so installing the environment's channel there would download
-// a Firefox the launch then fails to find.
+// EnsureInstalledForChannel installs the engine for a specific channel. The
+// daemon resolves a per-call --channel that need not match the environment,
+// so installing the environment's channel there would download a browser the
+// launch then fails to find.
 func EnsureInstalledForChannel(engine, channel string) error {
 	if SkipBrowserDownload() || EngineInstalledForChannel(engine, channel) {
 		return nil
@@ -49,6 +48,6 @@ func EnsureInstalledForChannel(engine, channel string) error {
 		_, err := InstallFirefoxForChannel(channel)
 		return err
 	}
-	_, err := Install()
+	_, err := InstallForChannel(channel)
 	return err
 }

--- a/clicker/internal/browser/installer.go
+++ b/clicker/internal/browser/installer.go
@@ -55,17 +55,28 @@ type InstallResult struct {
 // Install downloads and installs Chrome for Testing and chromedriver.
 // Returns paths to the installed binaries. Skips download if already installed.
 func Install() (*InstallResult, error) {
+	return InstallForChannel("")
+}
+
+// InstallForChannel installs a specific Chrome release channel. An empty
+// channel means the VIBIUM_ENGINE_CHANNEL default. The daemon resolves a
+// per-call channel that need not match the environment (#525), so every
+// lookup below takes the channel explicitly instead of reading the env.
+func InstallForChannel(channel string) (*InstallResult, error) {
 	// Check for skip environment variable
 	if os.Getenv("VIBIUM_SKIP_BROWSER_DOWNLOAD") == "1" {
 		return nil, fmt.Errorf("browser download skipped (VIBIUM_SKIP_BROWSER_DOWNLOAD=1)")
 	}
+	if channel == "" {
+		channel = paths.ChromeChannel()
+	}
 
 	// Check if already installed
-	if IsInstalled() {
-		chromePath, _ := paths.GetChromeExecutable()
-		chromedriverPath, _ := paths.GetChromedriverPath()
+	if IsInstalledForChannel(channel) {
+		chromePath, _ := paths.GetChromeExecutableForChannel(channel)
+		chromedriverPath, _ := paths.GetChromedriverPathForChannel(channel)
 		// Extract version from path (e.g., .../chrome-for-testing/143.0.7499.192/...)
-		version := extractVersionFromPath(chromePath)
+		version := extractVersionFromPath(chromePath, channel)
 		progressf("Chrome for Testing v%s already installed.\n", version)
 		return &InstallResult{
 			ChromePath:       chromePath,
@@ -76,12 +87,11 @@ func Install() (*InstallResult, error) {
 
 	platform := paths.GetPlatformString()
 
-	versionInfo, err := resolveChromeVersionInfo()
+	versionInfo, err := resolveChromeVersionInfo(channel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch version info: %w", err)
 	}
 
-	channel := paths.ChromeChannel()
 	if channel == "stable" {
 		progressf("Installing Chrome for Testing v%s...\n", versionInfo.Version)
 	} else {
@@ -89,7 +99,7 @@ func Install() (*InstallResult, error) {
 	}
 
 	// Create version directory
-	cftDir, err := paths.GetChromeChannelDir()
+	cftDir, err := paths.GetChromeChannelDirForChannel(channel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cache dir: %w", err)
 	}
@@ -122,12 +132,12 @@ func Install() (*InstallResult, error) {
 	}
 
 	// Get paths to installed binaries
-	chromePath, err := paths.GetChromeExecutable()
+	chromePath, err := paths.GetChromeExecutableForChannel(channel)
 	if err != nil {
 		return nil, fmt.Errorf("Chrome installed but not found: %w", err)
 	}
 
-	chromedriverPath, err := paths.GetChromedriverPath()
+	chromedriverPath, err := paths.GetChromedriverPathForChannel(channel)
 	if err != nil {
 		return nil, fmt.Errorf("chromedriver installed but not found: %w", err)
 	}
@@ -166,22 +176,22 @@ var chromeChannelKeys = map[string]string{
 // there is no offline path even for a pinned version: Chrome for Testing
 // download URLs come from its versions JSON, not a constructible pattern.
 // But a pinned lookup can never resolve to an untested new release.
-func resolveChromeVersionInfo() (*VersionInfo, error) {
-	if v := chromeInstallVersion(); v != "" {
+func resolveChromeVersionInfo(channel string) (*VersionInfo, error) {
+	if v := chromeInstallVersion(channel); v != "" {
 		return fetchVersionInfoFor(v)
 	}
-	return fetchChannelVersion(paths.ChromeChannel())
+	return fetchChannelVersion(channel)
 }
 
 // chromeInstallVersion returns the exact version to install, or "" when the
 // channel's current version should be fetched instead. Beta, dev, and
 // canary track their moving edge on purpose: beta-watch needs the current
 // beta, and pinning a canary would defeat it entirely.
-func chromeInstallVersion() string {
+func chromeInstallVersion(channel string) string {
 	if v := os.Getenv("VIBIUM_ENGINE_VERSION"); v != "" {
 		return v
 	}
-	if paths.ChromeChannel() == "stable" {
+	if channel == "stable" {
 		return pinnedChromeVersion
 	}
 	return ""
@@ -389,7 +399,13 @@ func extractZip(zipPath, destDir string) error {
 
 // IsInstalled checks if Chrome for Testing and chromedriver are both installed.
 func IsInstalled() bool {
-	chromePath, err := paths.GetChromeExecutable()
+	return IsInstalledForChannel("")
+}
+
+// IsInstalledForChannel checks a specific Chrome release channel. An empty
+// channel means the VIBIUM_ENGINE_CHANNEL default.
+func IsInstalledForChannel(channel string) bool {
+	chromePath, err := paths.GetChromeExecutableForChannel(channel)
 	if err != nil {
 		return false
 	}
@@ -397,7 +413,7 @@ func IsInstalled() bool {
 		return false
 	}
 
-	chromedriverPath, err := paths.GetChromedriverPath()
+	chromedriverPath, err := paths.GetChromedriverPathForChannel(channel)
 	if err != nil {
 		return false
 	}
@@ -407,12 +423,15 @@ func IsInstalled() bool {
 
 // extractVersionFromPath extracts the version number from a Chrome path.
 // e.g., ".../chrome-for-testing/143.0.7499.192/..." -> "143.0.7499.192"
-func extractVersionFromPath(path string) string {
+func extractVersionFromPath(path, channel string) string {
+	if channel == "" {
+		channel = paths.ChromeChannel()
+	}
 	parts := strings.Split(path, string(os.PathSeparator))
 	for i, part := range parts {
 		if part == "chrome-for-testing" && i+1 < len(parts) {
 			// Non-stable channels nest their version dirs one level deeper.
-			if ch := paths.ChromeChannel(); ch != "stable" && parts[i+1] == ch && i+2 < len(parts) {
+			if channel != "stable" && parts[i+1] == channel && i+2 < len(parts) {
 				return parts[i+2]
 			}
 			return parts[i+1]

--- a/clicker/internal/browser/installer_chrome_pin_test.go
+++ b/clicker/internal/browser/installer_chrome_pin_test.go
@@ -12,14 +12,14 @@ import (
 func TestChromeStableChannelResolvesToBakedPin(t *testing.T) {
 	t.Setenv("VIBIUM_ENGINE_VERSION", "")
 	t.Setenv("VIBIUM_ENGINE_CHANNEL", "")
-	if got := chromeInstallVersion(); got != pinnedChromeVersion {
+	if got := chromeInstallVersion("stable"); got != pinnedChromeVersion {
 		t.Errorf("chromeInstallVersion() = %q, want the baked %q", got, pinnedChromeVersion)
 	}
 }
 
 func TestChromeVersionOverrideBeatsBakedPin(t *testing.T) {
 	t.Setenv("VIBIUM_ENGINE_VERSION", "140.0.7000.10")
-	if got := chromeInstallVersion(); got != "140.0.7000.10" {
+	if got := chromeInstallVersion("stable"); got != "140.0.7000.10" {
 		t.Errorf("chromeInstallVersion() = %q, want the override 140.0.7000.10", got)
 	}
 }
@@ -29,7 +29,7 @@ func TestChromeVersionOverrideBeatsBakedPin(t *testing.T) {
 func TestChromeBetaChannelSkipsBakedPin(t *testing.T) {
 	t.Setenv("VIBIUM_ENGINE_VERSION", "")
 	t.Setenv("VIBIUM_ENGINE_CHANNEL", "beta")
-	if got := chromeInstallVersion(); got != "" {
+	if got := chromeInstallVersion("beta"); got != "" {
 		t.Errorf("chromeInstallVersion() = %q, want \"\" so beta fetches its current version", got)
 	}
 }

--- a/clicker/internal/browser/launcher.go
+++ b/clicker/internal/browser/launcher.go
@@ -67,11 +67,11 @@ func (pw *prefixWriter) Write(p []byte) (n int, err error) {
 
 // LaunchOptions contains options for launching the browser.
 type LaunchOptions struct {
-	Engine         string // "chrome" (default) or "firefox"
-	FirefoxChannel string // "release" (default) or "beta"
-	Headless       bool
-	Port           int  // Chromedriver port, 0 = auto-select
-	Verbose        bool // Show browser/driver output
+	Engine   string // "chrome" (default) or "firefox"
+	Channel  string // engine release channel; "" means the VIBIUM_ENGINE_CHANNEL default
+	Headless bool
+	Port     int  // Chromedriver port, 0 = auto-select
+	Verbose  bool // Show browser/driver output
 }
 
 // LaunchResult contains the result of launching the browser via chromedriver.
@@ -134,7 +134,7 @@ func Launch(opts LaunchOptions) (*LaunchResult, error) {
 		return nil, err
 	}
 
-	chromedriverPath, err := paths.GetChromedriverPath()
+	chromedriverPath, err := paths.GetChromedriverPathForChannel(opts.Channel)
 	if err != nil {
 		return nil, fmt.Errorf("chromedriver not found")
 	}
@@ -146,7 +146,7 @@ func Launch(opts LaunchOptions) (*LaunchResult, error) {
 		process.ReapOrphans(cacheDir)
 	}
 
-	chromePath, err := paths.GetChromeExecutable()
+	chromePath, err := paths.GetChromeExecutableForChannel(opts.Channel)
 	if err != nil {
 		return nil, fmt.Errorf("Chrome not found")
 	}

--- a/clicker/internal/browser/launcher_firefox.go
+++ b/clicker/internal/browser/launcher_firefox.go
@@ -51,7 +51,7 @@ var firefoxPrefs = map[string]interface{}{
 func launchFirefox(opts LaunchOptions) (*LaunchResult, error) {
 	log.Debug("launching firefox", "headless", opts.Headless)
 
-	channel := opts.FirefoxChannel
+	channel := opts.Channel
 	if channel == "" {
 		channel = paths.FirefoxChannel()
 	}

--- a/clicker/internal/paths/paths.go
+++ b/clicker/internal/paths/paths.go
@@ -92,6 +92,29 @@ func GetChromeForTestingDir() (string, error) {
 	return filepath.Join(cacheDir, "chrome-for-testing"), nil
 }
 
+// EngineChannels is the canonical list of valid release channels per engine,
+// first entry the default. The CLI flag validation, the MCP browser_start
+// schema and the daemon's per-call validation all build from this table, so
+// the three surfaces cannot drift apart again (#525).
+var EngineChannels = map[string][]string{
+	"chrome":  {"stable", "beta", "dev", "canary"},
+	"firefox": {"release", "beta"},
+}
+
+// ValidChannel reports whether channel is valid for engine. An empty channel
+// means the engine's default and is always valid.
+func ValidChannel(engine, channel string) bool {
+	if channel == "" {
+		return true
+	}
+	for _, c := range EngineChannels[engine] {
+		if c == channel {
+			return true
+		}
+	}
+	return false
+}
+
 // ChromeChannel returns the Chrome release channel to install and run.
 // Defaults to "stable"; override with VIBIUM_ENGINE_CHANNEL (e.g. "beta").
 // The same variable steers the Firefox channel, so an engine-agnostic
@@ -103,18 +126,28 @@ func ChromeChannel() string {
 	return "stable"
 }
 
-// GetChromeChannelDir returns the directory holding the channel's version
-// dirs. Stable keeps the historical chrome-for-testing root so existing
-// caches stay valid; other channels nest one level deeper, which also keeps
-// a beta's higher version number from shadowing stable under the
-// newest-first resolution below.
+// GetChromeChannelDir returns the directory holding the version dirs of the
+// environment's channel.
 func GetChromeChannelDir() (string, error) {
+	return GetChromeChannelDirForChannel(ChromeChannel())
+}
+
+// GetChromeChannelDirForChannel returns the directory holding the channel's
+// version dirs. An empty channel means the VIBIUM_ENGINE_CHANNEL default.
+// Stable keeps the historical chrome-for-testing root so existing caches
+// stay valid; other channels nest one level deeper, which also keeps a
+// beta's higher version number from shadowing stable under the newest-first
+// resolution below.
+func GetChromeChannelDirForChannel(channel string) (string, error) {
+	if channel == "" {
+		channel = ChromeChannel()
+	}
 	cftDir, err := GetChromeForTestingDir()
 	if err != nil {
 		return "", err
 	}
-	if ch := ChromeChannel(); ch != "stable" {
-		return filepath.Join(cftDir, ch), nil
+	if channel != "stable" {
+		return filepath.Join(cftDir, channel), nil
 	}
 	return cftDir, nil
 }
@@ -132,8 +165,8 @@ func GetChromeChannelDir() (string, error) {
 // VIBIUM_ENGINE_VERSION pins the choice: the pinned version must also be
 // what launches, or newest-cached would silently run a different Chrome
 // than the pin installed.
-func resolveVersionDir() (string, error) {
-	cftDir, err := GetChromeChannelDir()
+func resolveVersionDir(channel string) (string, error) {
+	cftDir, err := GetChromeChannelDirForChannel(channel)
 	if err != nil {
 		return "", err
 	}
@@ -203,7 +236,13 @@ func compareVersions(a, b string) int {
 // GetChromeExecutable returns the path to Chrome for Testing executable.
 // Only checks Vibium cache - does not fall back to system Chrome.
 func GetChromeExecutable() (string, error) {
-	dir, err := resolveVersionDir()
+	return GetChromeExecutableForChannel("")
+}
+
+// GetChromeExecutableForChannel resolves the executable of a specific
+// channel. An empty channel means the VIBIUM_ENGINE_CHANNEL default.
+func GetChromeExecutableForChannel(channel string) (string, error) {
+	dir, err := resolveVersionDir(channel)
 	if err != nil {
 		return "", err
 	}
@@ -214,7 +253,13 @@ func GetChromeExecutable() (string, error) {
 // from the same version directory as GetChromeExecutable, so the two always
 // match.
 func GetChromedriverPath() (string, error) {
-	dir, err := resolveVersionDir()
+	return GetChromedriverPathForChannel("")
+}
+
+// GetChromedriverPathForChannel resolves the chromedriver of a specific
+// channel, from the same version directory as the executable.
+func GetChromedriverPathForChannel(channel string) (string, error) {
+	dir, err := resolveVersionDir(channel)
 	if err != nil {
 		return "", err
 	}

--- a/clicker/internal/paths/paths_chrome_channel_test.go
+++ b/clicker/internal/paths/paths_chrome_channel_test.go
@@ -32,7 +32,7 @@ func TestResolveVersionDirHonorsPin(t *testing.T) {
 	installFakeChrome(t, cache, "141.0.7100.20")
 
 	// Unpinned picks the newest complete version.
-	dir, err := resolveVersionDir()
+	dir, err := resolveVersionDir("")
 	if err != nil {
 		t.Fatalf("resolveVersionDir() error = %v", err)
 	}
@@ -42,7 +42,7 @@ func TestResolveVersionDirHonorsPin(t *testing.T) {
 
 	// A pin selects that version even with a newer one cached.
 	t.Setenv("VIBIUM_ENGINE_VERSION", "140.0.7000.10")
-	dir, err = resolveVersionDir()
+	dir, err = resolveVersionDir("")
 	if err != nil {
 		t.Fatalf("pinned resolveVersionDir() error = %v", err)
 	}
@@ -53,7 +53,7 @@ func TestResolveVersionDirHonorsPin(t *testing.T) {
 	// A pin on a version that is not cached fails instead of silently
 	// falling back to whatever is newest.
 	t.Setenv("VIBIUM_ENGINE_VERSION", "139.0.6900.1")
-	if _, err := resolveVersionDir(); err == nil {
+	if _, err := resolveVersionDir(""); err == nil {
 		t.Error("resolveVersionDir() with missing pinned version: want error, got nil")
 	}
 }
@@ -70,7 +70,7 @@ func TestChromeChannelDirsAreSeparate(t *testing.T) {
 	installFakeChrome(t, cache, "beta", "142.0.7200.5")
 
 	// Stable resolution must not pick up the beta despite its higher version.
-	dir, err := resolveVersionDir()
+	dir, err := resolveVersionDir("")
 	if err != nil {
 		t.Fatalf("stable resolveVersionDir() error = %v", err)
 	}
@@ -80,7 +80,7 @@ func TestChromeChannelDirsAreSeparate(t *testing.T) {
 
 	// Beta resolution sees only the beta subdirectory.
 	t.Setenv("VIBIUM_ENGINE_CHANNEL", "beta")
-	dir, err = resolveVersionDir()
+	dir, err = resolveVersionDir("")
 	if err != nil {
 		t.Fatalf("beta resolveVersionDir() error = %v", err)
 	}
@@ -100,5 +100,54 @@ func TestChromeChannelDefaultsToStable(t *testing.T) {
 	t.Setenv("VIBIUM_ENGINE_CHANNEL", "beta")
 	if got := ChromeChannel(); got != "beta" {
 		t.Errorf("ChromeChannel() = %q, want beta", got)
+	}
+}
+
+// A per-call channel must override the environment's channel: the daemon
+// resolves browser_start's channel argument explicitly, and an env lookup
+// underneath it would launch a different Chrome than it validated (#525).
+func TestResolveVersionDirExplicitChannelBeatsEnv(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("VIBIUM_CACHE_DIR", cache)
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "")
+	installFakeChrome(t, cache, "141.0.7100.20")
+	installFakeChrome(t, cache, "beta", "142.0.7200.5")
+
+	dir, err := resolveVersionDir("beta")
+	if err != nil {
+		t.Fatalf(`resolveVersionDir("beta") error = %v`, err)
+	}
+	if got := filepath.Base(dir); got != "142.0.7200.5" {
+		t.Errorf(`resolveVersionDir("beta") = %s, want 142.0.7200.5`, got)
+	}
+
+	// And the reverse: an explicit stable ignores an env beta.
+	t.Setenv("VIBIUM_ENGINE_CHANNEL", "beta")
+	dir, err = resolveVersionDir("stable")
+	if err != nil {
+		t.Fatalf(`resolveVersionDir("stable") error = %v`, err)
+	}
+	if got := filepath.Base(dir); got != "141.0.7100.20" {
+		t.Errorf(`resolveVersionDir("stable") = %s, want 141.0.7100.20`, got)
+	}
+}
+
+func TestValidChannel(t *testing.T) {
+	cases := []struct {
+		engine, channel string
+		want            bool
+	}{
+		{"chrome", "", true},
+		{"chrome", "stable", true},
+		{"chrome", "canary", true},
+		{"chrome", "release", false},
+		{"firefox", "release", true},
+		{"firefox", "canary", false},
+		{"firefox", "", true},
+	}
+	for _, c := range cases {
+		if got := ValidChannel(c.engine, c.channel); got != c.want {
+			t.Errorf("ValidChannel(%q, %q) = %v, want %v", c.engine, c.channel, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
Fixes VibiumDev/vibium#525.

browser_start's channel parameter predated Chrome channels and stayed Firefox-only at every layer: the schema described a Firefox enum, the launch handler read the argument only in its firefox branch and silently launched stable Chrome no matter what the caller asked for, and the already-running channel guard skipped Chrome too.

The valid channels per engine now live in one table, paths.EngineChannels, and the CLI flag validation, the schema enum and the handler validation all build from it. The Chrome resolution chain gains the ForChannel variants Firefox already had (executable, chromedriver, channel dir, install, is-installed), so a per-call channel overrides the environment instead of being resolved out from under the launch. LaunchOptions' FirefoxChannel becomes Channel and applies to both engines, launchedChannel is recorded for Chrome, and the mismatch guard covers it. The CLI daemon client also stops defaulting an empty --channel to the Firefox default when the engine is Chrome.

Verified:
- The Chrome mismatch guard test fails on a main build, measured: browserLaunch returns a nil error there, answering "already running" as a success
- The schema test pins browser_start's channel enum to the union of paths.EngineChannels; on main the enum is a hand-written Firefox pair and the shared source it checks against does not exist
- The Chrome validation test cannot fail cleanly on main because that is the bug: the call proceeds toward a stable-Chrome install/launch instead of returning an error
- New paths tests cover explicit-channel-beats-env resolution in both directions
- Full go test ./... green; CLI flag suites green (global-flags, json-contract, help-flags, json-output, is-installed); the CLI error message for a bad --channel is byte-identical, so existing tests and scripts keep matching