### PR TITLE
Leave a frame on navigation instead of navigating inside it

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -51,6 +51,10 @@ type Handlers struct {
 	downloadDir    string
 	lastElementBox *api.BoxInfo // stashed by AgentSession.SetLastElementBox via callback
 	activeContext  string       // last page context switched to or created
+	// activeFrameParent is the page context that activeContext's frame
+	// belongs to, or "" when activeContext is a page rather than a frame.
+	// It lets navigation leave a frame it was never asked to stay in (#510).
+	activeFrameParent string
 	// pageOverride pins the current call to one browsing context: callers
 	// multiplexed over a single connection (concurrent MCP subagents) pass a
 	// page id so their commands stop landing on whatever page is globally
@@ -120,6 +124,27 @@ func NewHandlers(screenshotDir string, engine string, headless bool, connectURL 
 		connectURL:     connectURL,
 		connectHeaders: connectHeaders,
 		connectCaps:    connectCaps,
+	}
+}
+
+// leaveActiveFrame returns the ambient context to the page a frame belongs
+// to, if the active context is currently a frame. Navigation calls this so a
+// frame entered by browser_frame does not trap every later command inside it
+// (#510). A no-op when the active context is already a page.
+func (h *Handlers) leaveActiveFrame() {
+	if h.activeFrameParent != "" {
+		h.activeContext = h.activeFrameParent
+		h.activeFrameParent = ""
+	}
+}
+
+// clearFrameIfContextClosed drops the frame state when the closed context is
+// the frame's page (the frame dies with it) — keeping either would leave
+// later commands pointed at a dead frame (#510).
+func (h *Handlers) clearFrameIfContextClosed(closed string) {
+	if h.activeFrameParent == closed {
+		h.activeContext = ""
+		h.activeFrameParent = ""
 	}
 }
 
@@ -746,6 +771,7 @@ func (h *Handlers) Close() {
 	h.ownsRemote = false
 	h.ownedUserContexts = nil
 	h.activeContext = ""
+	h.activeFrameParent = ""
 	h.refMaps = nil
 	h.lastMaps = nil
 	recorder := h.recorder
@@ -1021,6 +1047,15 @@ func (h *Handlers) browserNavigate(args map[string]interface{}) (*ToolsCallResul
 	url, ok := args["url"].(string)
 	if !ok || url == "" {
 		return nil, fmt.Errorf("url is required")
+	}
+
+	// Navigating leaves a frame. Without this the frame context set by
+	// browser_frame is still current, so `go` replaces the iframe's document
+	// and every later command stays trapped inside it (#510). A pinned call
+	// targets its own page and leaves the ambient frame state alone.
+	if h.activeFrameParent != "" && h.pageOverride == "" {
+		h.activeContext = h.activeFrameParent
+		h.activeFrameParent = ""
 	}
 
 	s := h.newSession()
@@ -1660,6 +1695,7 @@ func (h *Handlers) browserNewPage(args map[string]interface{}) (*ToolsCallResult
 		return nil, fmt.Errorf("failed to activate new page: %w", err)
 	}
 	h.activeContext = contextID
+	h.activeFrameParent = ""
 
 	// The id lets a caller pin later calls to this page (#383).
 	kind := "page"
@@ -1751,6 +1787,7 @@ func (h *Handlers) browserSwitchPage(args map[string]interface{}) (*ToolsCallRes
 		return nil, err
 	}
 	h.activeContext = contextID
+	h.activeFrameParent = ""
 
 	return &ToolsCallResult{
 		Content: []Content{{
@@ -1811,7 +1848,10 @@ func (h *Handlers) browserClosePage(args map[string]interface{}) (*ToolsCallResu
 	}
 	if h.activeContext == closedContext {
 		h.activeContext = ""
+		h.activeFrameParent = ""
 	}
+	// Closing the page a frame lives in kills the frame with it.
+	h.clearFrameIfContextClosed(closedContext)
 
 	// Closing the last page of an isolated context removes the context too,
 	// so its storage partition does not outlive its pages.
@@ -3042,6 +3082,7 @@ func (h *Handlers) discardSession() {
 	h.refMaps = nil
 	h.lastMaps = nil
 	h.activeContext = ""
+	h.activeFrameParent = ""
 	h.ownedUserContexts = nil
 }
 
@@ -4123,6 +4164,12 @@ func (h *Handlers) browserFrame(args map[string]interface{}) (*ToolsCallResult, 
 
 	// The daemon is the only thing that survives between CLI invocations, so
 	// without this the frame is forgotten before the next command runs.
+	// Remember the page it belongs to as well, so a later navigation can
+	// leave the frame instead of navigating inside it (#510). On nested
+	// frame calls ctx is itself a frame, so keep the first recorded page.
+	if h.activeFrameParent == "" {
+		h.activeFrameParent = ctx
+	}
 	h.activeContext = frame.Context
 
 	result, _ := json.Marshal(frame)

--- a/clicker/internal/agent/handlers_frame_context_test.go
+++ b/clicker/internal/agent/handlers_frame_context_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import "testing"
+
+// After browser_frame the ambient context is the frame and activeFrameParent
+// records the page it lives in. Navigation must return to that page instead
+// of replacing the iframe's document and trapping every later command inside
+// it (#510).
+func TestLeaveActiveFrameReturnsToParentPage(t *testing.T) {
+	h := &Handlers{activeContext: "frame-ctx", activeFrameParent: "page-ctx"}
+
+	h.leaveActiveFrame()
+
+	if h.activeContext != "page-ctx" {
+		t.Errorf("activeContext = %q, want the parent page-ctx", h.activeContext)
+	}
+	if h.activeFrameParent != "" {
+		t.Errorf("activeFrameParent = %q, want cleared", h.activeFrameParent)
+	}
+}
+
+// On a plain page — the common case — leaving is a no-op, so ordinary
+// navigation is untouched.
+func TestLeaveActiveFrameNoopOnPage(t *testing.T) {
+	h := &Handlers{activeContext: "page-ctx"}
+
+	h.leaveActiveFrame()
+
+	if h.activeContext != "page-ctx" {
+		t.Errorf("activeContext = %q, want unchanged page-ctx", h.activeContext)
+	}
+	if h.activeFrameParent != "" {
+		t.Errorf("activeFrameParent = %q, want still empty", h.activeFrameParent)
+	}
+}
+
+// Closing the page a frame belongs to kills the frame with it: both the
+// active context and the parent record must clear, or later commands target
+// a dead frame (#510). This is the "trap survives closing the page" case in
+// the report.
+func TestClearFrameIfContextClosedDropsDeadFrame(t *testing.T) {
+	h := &Handlers{activeContext: "frame-ctx", activeFrameParent: "page-ctx"}
+
+	h.clearFrameIfContextClosed("page-ctx")
+
+	if h.activeContext != "" || h.activeFrameParent != "" {
+		t.Errorf("after closing the frame's page: activeContext=%q activeFrameParent=%q, want both empty",
+			h.activeContext, h.activeFrameParent)
+	}
+}
+
+// Closing an unrelated page leaves the frame state alone.
+func TestClearFrameIfContextClosedIgnoresOtherPages(t *testing.T) {
+	h := &Handlers{activeContext: "frame-ctx", activeFrameParent: "page-ctx"}
+
+	h.clearFrameIfContextClosed("some-other-page")
+
+	if h.activeContext != "frame-ctx" || h.activeFrameParent != "page-ctx" {
+		t.Errorf("unrelated close changed frame state: activeContext=%q activeFrameParent=%q",
+			h.activeContext, h.activeFrameParent)
+	}
+}

--- a/tests/cli/engine/page-context.test.js
+++ b/tests/cli/engine/page-context.test.js
@@ -176,4 +176,49 @@ describe('CLI: active context reaches script-backed commands', () => {
     }).trim();
     assert.strictEqual(inner, 'inner', 'eval should run inside the switched frame');
   });
+
+  test('go leaves the frame instead of navigating inside it (#510)', () => {
+    execSync(`${VIBIUM} go ${baseURL}/frames`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} frame myframe`, { encoding: 'utf-8', timeout: 30000 });
+
+    // The #205 contract still holds: we are inside the frame now.
+    const inFrame = execSync(`${VIBIUM} eval "window.top !== window.self"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(inFrame, 'true', 'setup: frame switch should stick (#205)');
+
+    // Navigating must return to the top-level document. Before the fix this
+    // loaded the page into the iframe, so window.top !== window.self stayed
+    // true and every later command was trapped in the frame's geometry.
+    execSync(`${VIBIUM} go ${baseURL}/frames`, { encoding: 'utf-8', timeout: 30000 });
+    const afterGo = execSync(`${VIBIUM} eval "window.top !== window.self"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(afterGo, 'false', 'go should leave the frame, not navigate inside it');
+
+    const outerId = execSync(`${VIBIUM} eval "document.querySelector('h1').id"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(outerId, 'outer', 'after go the top-level document is active again');
+  });
+
+  test('closing the page a frame lives in does not trap the next command (#510)', () => {
+    execSync(`${VIBIUM} go ${baseURL}/`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} page new ${baseURL}/frames`, { encoding: 'utf-8', timeout: 30000 });
+    execSync(`${VIBIUM} frame myframe`, { encoding: 'utf-8', timeout: 30000 });
+
+    // Close the framed page by index, without switching away first — a switch
+    // would clear the frame state on its own. The frame dies with its page,
+    // and the surviving page 0 must not inherit the dead frame's context.
+    execSync(`${VIBIUM} page close 1`, { encoding: 'utf-8', timeout: 30000 });
+
+    const trapped = execSync(`${VIBIUM} eval "window.top !== window.self"`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    }).trim();
+    assert.strictEqual(trapped, 'false', 'closing the framed page should clear the frame context');
+  });
 });


### PR DESCRIPTION
Fixes VibiumDev/vibium#510.

After `vibium frame <name>`, the frame context set by browser_frame stays current, so `go` loads the URL into the iframe and the page appears nested inside itself. The usual checks hide it: location.href and document.title report what you asked for while `window.top !== window.self` stays true and every command targets the iframe's box.

#205 asked for the opposite — the frame context must survive to the next CLI command, since the daemon is the only thing that persists between invocations. That persistence is kept; what was missing is the exit. browser_frame now records the page a frame belongs to, navigation returns the ambient context to that page, and closing the framed page clears the frame with it. The JavaScript, Python and Java clients already return a frame-scoped Page handle and never touch shared state; this makes the CLI/MCP path agree on the one operation that leaks — navigation. A pinned call (page override) targets its own page and leaves the ambient frame state alone.

Reported with a reference patch by @lana-20; this implementation is verified independently, credit to the report.

Verified:
- Two new cases in tests/cli/engine/page-context.test.js — `go` leaves the frame, and closing the framed page does not trap the next command — fail on a main build and pass here
- The #205 case (frame switch persists to the next `eval`) still passes on both builds, so the behavior that issue asked for is unchanged
- Hermetic unit tests cover the leaveActiveFrame and clearFrameIfContextClosed state transitions
- go test ./... green