### PR TITLE
Scroll the active document, not the page behind a frame

### DIFF
--- a/clicker/internal/agent/handlers.go
+++ b/clicker/internal/agent/handlers.go
@@ -2004,24 +2004,6 @@ func (h *Handlers) browserScroll(args map[string]interface{}) (*ToolsCallResult,
 		return nil, err
 	}
 
-	// Determine scroll target coordinates
-	x, y := 0, 0
-	if selector, ok := args["selector"].(string); ok && selector != "" {
-		selector = h.resolveSelector(selector)
-		info, err := api.ResolveElement(s, ctx, api.ElementParams{Selector: selector})
-		if err != nil {
-			return nil, err
-		}
-		x = int(info.Box.X + info.Box.Width/2)
-		y = int(info.Box.Y + info.Box.Height/2)
-	} else {
-		var err error
-		x, y, err = api.ViewportCenter(s, ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find viewport center: %w", err)
-		}
-	}
-
 	// Map direction to deltas (120 pixels per scroll "notch")
 	deltaX, deltaY := 0, 0
 	pixels := amount * 120
@@ -2038,8 +2020,29 @@ func (h *Handlers) browserScroll(args map[string]interface{}) (*ToolsCallResult,
 		return nil, fmt.Errorf("invalid direction: %q (use up, down, left, right)", direction)
 	}
 
-	if err := api.ScrollWheel(s, ctx, x, y, deltaX, deltaY); err != nil {
-		return nil, fmt.Errorf("failed to scroll: %w", err)
+	// A selector aims the wheel at that element's center; a bare directional
+	// scroll moves the active document, which DirectionalScroll does with the
+	// mechanism that reaches it even inside a frame or right after a
+	// navigation (#511).
+	if selector, ok := args["selector"].(string); ok && selector != "" {
+		selector = h.resolveSelector(selector)
+		info, err := api.ResolveElement(s, ctx, api.ElementParams{Selector: selector})
+		if err != nil {
+			return nil, err
+		}
+		x := int(info.Box.X + info.Box.Width/2)
+		y := int(info.Box.Y + info.Box.Height/2)
+		if err := api.ScrollWheel(s, ctx, x, y, deltaX, deltaY); err != nil {
+			return nil, fmt.Errorf("failed to scroll: %w", err)
+		}
+	} else {
+		x, y, err := api.ViewportCenter(s, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find viewport center: %w", err)
+		}
+		if err := api.DirectionalScroll(s, ctx, x, y, deltaX, deltaY); err != nil {
+			return nil, fmt.Errorf("failed to scroll: %w", err)
+		}
 	}
 
 	return &ToolsCallResult{

--- a/clicker/internal/api/handlers_input.go
+++ b/clicker/internal/api/handlers_input.go
@@ -316,25 +316,6 @@ func (r *Router) handlePageScroll(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 
-	// Determine scroll target coordinates
-	var x, y int
-	if selector, ok := cmd.Params["selector"].(string); ok && selector != "" {
-		// Scroll at element center
-		info, err := r.resolveElement(session, context, ElementParams{Selector: selector})
-		if err != nil {
-			r.sendError(session, cmd.ID, err)
-			return
-		}
-		x, y = pointerTarget(info)
-	} else {
-		var err error
-		x, y, err = ViewportCenter(NewAPISession(r, session, context), context)
-		if err != nil {
-			r.sendError(session, cmd.ID, err)
-			return
-		}
-	}
-
 	// Map direction to deltas (120 pixels per scroll "notch")
 	deltaX, deltaY := 0, 0
 	pixels := amount * 120
@@ -352,28 +333,33 @@ func (r *Router) handlePageScroll(session *BrowserSession, cmd bidiCommand) {
 		return
 	}
 
-	wheelParams := map[string]interface{}{
-		"context": context,
-		"actions": []map[string]interface{}{
-			{
-				"type": "wheel",
-				"id":   "wheel",
-				"actions": []map[string]interface{}{
-					{
-						"type":   "scroll",
-						"x":      x,
-						"y":      y,
-						"deltaX": deltaX,
-						"deltaY": deltaY,
-					},
-				},
-			},
-		},
-	}
+	apiSession := NewAPISession(r, session, context)
 
-	if _, err := r.sendInternalCommand(session, "input.performActions", wheelParams); err != nil {
-		r.sendError(session, cmd.ID, err)
-		return
+	// A selector aims the wheel at that element's center; a bare directional
+	// scroll moves the active document, which DirectionalScroll does with the
+	// mechanism that reaches it even inside a frame or right after a
+	// navigation (#511).
+	if selector, ok := cmd.Params["selector"].(string); ok && selector != "" {
+		info, err := r.resolveElement(session, context, ElementParams{Selector: selector})
+		if err != nil {
+			r.sendError(session, cmd.ID, err)
+			return
+		}
+		x, y := pointerTarget(info)
+		if err := ScrollWheel(apiSession, context, x, y, deltaX, deltaY); err != nil {
+			r.sendError(session, cmd.ID, err)
+			return
+		}
+	} else {
+		x, y, err := ViewportCenter(apiSession, context)
+		if err != nil {
+			r.sendError(session, cmd.ID, err)
+			return
+		}
+		if err := DirectionalScroll(apiSession, context, x, y, deltaX, deltaY); err != nil {
+			r.sendError(session, cmd.ID, err)
+			return
+		}
 	}
 
 	r.sendSuccess(session, cmd.ID, map[string]interface{}{"scrolled": true})

--- a/clicker/internal/api/handlers_interaction.go
+++ b/clicker/internal/api/handlers_interaction.go
@@ -1070,6 +1070,85 @@ func ScrollWheel(s Session, context string, x, y, deltaX, deltaY int) error {
 	return err
 }
 
+// DirectionalScroll scrolls the active context by the given deltas, picking
+// the mechanism that actually moves the intended document (#511).
+//
+// A synthesized wheel is dispatched in top-level viewport coordinates, so in a
+// subframe the (x, y) taken from the frame's own viewport center lands on the
+// page behind the frame: Chrome scrolls the wrong document, Firefox drops the
+// event, and the frame never moves. Inside a subframe we therefore scroll
+// programmatically in the frame's own context, which is coordinate-free and
+// cannot touch the parent.
+//
+// At the top level the wheel is kept — a page may drive behaviour off real
+// wheel events — but verified rather than assumed: the first wheel after a
+// navigation arrives before the new document can be hit-tested and is dropped,
+// while the command still reports success. When the offset did not move we
+// fall back to a programmatic scroll, so "scrolled" means it scrolled.
+func DirectionalScroll(s Session, context string, x, y, deltaX, deltaY int) error {
+	if inSubframe(s, context) {
+		return scrollContextBy(s, context, deltaX, deltaY)
+	}
+
+	beforeY, beforeX, haveBefore := documentScrollOffset(s, context)
+	if err := ScrollWheel(s, context, x, y, deltaX, deltaY); err != nil {
+		return err
+	}
+	if haveBefore {
+		afterY, afterX, ok := documentScrollOffset(s, context)
+		if ok && afterX == beforeX && afterY == beforeY {
+			return scrollContextBy(s, context, deltaX, deltaY)
+		}
+	}
+	return nil
+}
+
+// inSubframe reports whether the context is a nested browsing context. The
+// reference comparison never touches a cross-origin property, so it does not
+// throw; on any error we assume top-level and keep the wheel path.
+func inSubframe(s Session, context string) bool {
+	resp, err := CallScript(s, context, `() => String(window !== window.top)`, []map[string]interface{}{})
+	if err != nil {
+		return false
+	}
+	val, err := parseScriptResult(resp)
+	return err == nil && val == "true"
+}
+
+// documentScrollOffset returns the active context's scroll offsets (top, left).
+func documentScrollOffset(s Session, context string) (top, left int, ok bool) {
+	resp, err := CallScript(s, context,
+		`() => { const e = document.scrollingElement || document.documentElement;
+			return JSON.stringify({ top: Math.round(e.scrollTop), left: Math.round(e.scrollLeft) }); }`,
+		[]map[string]interface{}{})
+	if err != nil {
+		return 0, 0, false
+	}
+	val, err := parseScriptResult(resp)
+	if err != nil {
+		return 0, 0, false
+	}
+	var off struct {
+		Top  int `json:"top"`
+		Left int `json:"left"`
+	}
+	if err := json.Unmarshal([]byte(val), &off); err != nil {
+		return 0, 0, false
+	}
+	return off.Top, off.Left, true
+}
+
+// scrollContextBy scrolls the active context's own window by the given deltas.
+func scrollContextBy(s Session, context string, deltaX, deltaY int) error {
+	_, err := CallScript(s, context,
+		`(dx, dy) => { window.scrollBy(dx, dy); return 'ok'; }`,
+		[]map[string]interface{}{
+			{"type": "number", "value": deltaX},
+			{"type": "number", "value": deltaY},
+		})
+	return err
+}
+
 // --- Script builders for JS-based interactions ---
 
 // buildIsCheckedScript builds a JS function to check if an element is checked.

--- a/tests/cli/engine/scroll.test.js
+++ b/tests/cli/engine/scroll.test.js
@@ -23,6 +23,18 @@ const html =
   '<div style="height:1000px">tall</div></div>' +
   '</body></html>';
 
+// An outer page with a tall body and a small scrollable iframe far below the
+// fold, so the frame's own viewport center maps to a point over the outer
+// document (#511).
+const innerFile = path.join(os.tmpdir(), `vibium-scroll-inner-${process.pid}.html`);
+const innerHtml =
+  '<html><body><h1>Inner</h1><div style="height:2000px">tall inner</div></body></html>';
+const outerFile = path.join(os.tmpdir(), `vibium-scroll-outer-${process.pid}.html`);
+const outerHtml =
+  '<html><body><h1>Outer</h1><div style="height:2000px">tall</div>' +
+  `<iframe name="inner" src="file://${innerFile}" width="300" height="100"></iframe>` +
+  '</body></html>';
+
 function run(cmd) {
   return execSync(`${VIBIUM} ${cmd}`, { encoding: 'utf-8', timeout: 30000 });
 }
@@ -72,5 +84,43 @@ describe('CLI: scroll targets the viewport center (#443, #444)', () => {
 
   test('cleanup: remove fixture', () => {
     fs.rmSync(tmpFile, { force: true });
+  });
+});
+
+describe('CLI: scroll reaches the active document (#511)', () => {
+  test('setup: write frame fixtures', () => {
+    fs.writeFileSync(innerFile, innerHtml);
+    fs.writeFileSync(outerFile, outerHtml);
+  });
+
+  test('scroll inside a frame moves the frame, not the page behind it', () => {
+    run(`go "file://${outerFile}"`);
+    run('frame inner');
+    // Confirm the frame is scrollable and we are inside it.
+    pollNum('window.top !== window.self ? 1 : 0', (v) => v === 1, 'should be inside the frame');
+
+    run('scroll down');
+    run('scroll down');
+    // The frame scrolled...
+    pollNum('window.scrollY', (v) => v > 0, 'the frame should have scrolled');
+
+    // ...and the outer page did not. Before the fix the wheel landed on the
+    // outer document (Chrome scrolled it, Firefox dropped the event) while the
+    // frame stayed at 0.
+    run('page switch 0');
+    const outerY = evalNum('window.scrollY');
+    assert.strictEqual(outerY, 0, 'the page behind the frame must not have moved');
+  });
+
+  // The other #511 symptom — the first wheel after a navigation being dropped
+  // before the new document can be hit-tested — is a race (reliable on Chrome,
+  // intermittent on Firefox), so it does not make a deterministic fail-on-main
+  // gate. The verify-and-fall-back-to-scrollBy fix covers it and is a safe
+  // no-op when the wheel already moved; measured 3/3 dropped on stock vs 0/5
+  // patched from a cold daemon.
+
+  test('cleanup: remove frame fixtures', () => {
+    fs.rmSync(innerFile, { force: true });
+    fs.rmSync(outerFile, { force: true });
   });
 });


### PR DESCRIPTION
Fixes VibiumDev/vibium#511.

A directional scroll synthesized a wheel event at the active context's viewport center, but BiDi pointer coordinates are relative to the top-level viewport. Inside a frame that center maps to a point over the outer document, so `scroll down` moved the wrong page on Chrome and was dropped on Firefox while the frame stayed at 0 — the command reporting `Scrolled down by 3` either way.

Directional scroll now goes through one shared `api.DirectionalScroll`, called by both the CLI/MCP path (`browser_scroll`) and the client path (`page.scroll`), so the CLI, MCP and all three language clients get the fix from one place. Inside a subframe it scrolls programmatically in the frame's own context — coordinate-free, and it cannot touch the parent. At the top level it keeps the wheel, since a page may drive behaviour off real wheel events, but verifies it: when the offset did not move it falls back to a programmatic scroll, which also covers the first-wheel-after-navigation being dropped before the new document can be hit-tested. Selector-targeted scroll is unchanged.

Reported with a reference patch by @lana-20. Her patch verified the scroll afterward and fell back to scrollBy, but on Chrome the wheel had already moved the outer page 720 before the fallback fixed the frame — the damage she flagged as unsolved. Not firing the wheel in a frame at all removes it.

Verified:
- New frame regression test in tests/cli/engine/scroll.test.js fails on a main build and passes here: the frame moves 720 and the outer page stays 0, versus stock where the outer page moves 720 and the frame stays 0
- The existing #443/#444 scroll tests still pass, so selector and viewport-center behaviour is unchanged
- The nav-race symptom is a race (reliable on Chrome, intermittent on Firefox), so it is not a deterministic fail-on-main gate; the verify-and-fall-back fix is a safe no-op when the wheel already moved, measured 3/3 dropped on stock vs 0/5 patched from a cold daemon
- go test ./... green