### PR TITLE
Name a11y-tree nodes from their text content

### DIFF
--- a/clicker/internal/api/handlers_a11y.go
+++ b/clicker/internal/api/handlers_a11y.go
@@ -216,8 +216,20 @@ func A11yTreeScript() string {
 			return fn ? fn(el) : 'generic';
 		}
 
-		function getName(el) {
-			if (typeof el.computedName === 'string') return el.computedName;
+		// Roles that take their accessible name from descendant text when no
+		// explicit label is present ("name from content" in the accname spec).
+		// Restricted to these roles so wrapper divs full of prose stay nameless.
+		const NAME_FROM_CONTENT = new Set([
+			'button', 'link', 'heading', 'option', 'menuitem', 'menuitemcheckbox',
+			'menuitemradio', 'tab', 'treeitem', 'cell', 'columnheader', 'rowheader',
+			'gridcell', 'checkbox', 'radio', 'switch', 'listitem', 'term',
+			'definition', 'caption', 'tooltip', 'legend'
+		]);
+
+		function getName(el, role) {
+			// An empty computedName means "not computed", not "no name" —
+			// returning it would skip every fallback below.
+			if (typeof el.computedName === 'string' && el.computedName !== '') return el.computedName;
 			const ariaLabel = el.getAttribute('aria-label');
 			if (ariaLabel) return ariaLabel;
 			const labelledBy = el.getAttribute('aria-labelledby');
@@ -238,6 +250,10 @@ func A11yTreeScript() string {
 			if (alt) return alt;
 			const title = el.getAttribute('title');
 			if (title) return title;
+			if (NAME_FROM_CONTENT.has(role)) {
+				const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+				if (text) return text;
+			}
 			return '';
 		}
 
@@ -261,7 +277,7 @@ func A11yTreeScript() string {
 
 		function buildNode(el) {
 			const role = getRole(el);
-			const name = getName(el);
+			const name = getName(el, role);
 
 			// Collect children first
 			const childNodes = [];

--- a/tests/js/async/engine/a11y.test.js
+++ b/tests/js/async/engine/a11y.test.js
@@ -230,6 +230,55 @@ describe('Page Accessibility: a11yTree()', () => {
     assert.ok(levels.includes(3), 'should have h3 level=3');
   });
 
+  test('names buttons, links and headings from their text content', async () => {
+    await vibe.setContent(`
+      <button>Save</button>
+      <button aria-label="Close">X</button>
+      <a href="#x">Documentation</a>
+      <h2>Section Heading</h2>
+    `);
+    const tree = await vibe.a11yTree();
+
+    function findAll(node, role) {
+      const found = [];
+      if (node.role === role) found.push(node);
+      if (node.children) {
+        for (const child of node.children) {
+          found.push(...findAll(child, role));
+        }
+      }
+      return found;
+    }
+
+    const buttonNames = findAll(tree, 'button').map(n => n.name);
+    assert.ok(buttonNames.includes('Save'), `button should be named from its text, got: ${buttonNames.join(', ')}`);
+    assert.ok(buttonNames.includes('Close'), `aria-label should still win over text, got: ${buttonNames.join(', ')}`);
+    assert.strictEqual(findAll(tree, 'link')[0].name, 'Documentation');
+    assert.strictEqual(findAll(tree, 'heading')[0].name, 'Section Heading');
+  });
+
+  test('does not name plain divs from their text content', async () => {
+    await vibe.setContent('<div role="region" aria-label="wrap"><div>Just some prose in a wrapper.</div><button>Go</button></div>');
+    const tree = await vibe.a11yTree({ everything: true });
+
+    function findAll(node, role) {
+      const found = [];
+      if (node.role === role) found.push(node);
+      if (node.children) {
+        for (const child of node.children) {
+          found.push(...findAll(child, role));
+        }
+      }
+      return found;
+    }
+
+    const generics = findAll(tree, 'generic');
+    assert.ok(generics.length > 0, 'everything:true should surface the plain div');
+    for (const g of generics) {
+      assert.ok(!g.name, `plain div should stay nameless, got: "${g.name}"`);
+    }
+  });
+
   test('root option scopes tree to a subtree', async () => {
     await vibe.setContent(`
       <div>


### PR DESCRIPTION
Fixes VibiumDev/vibium#512

a11y-tree returned a plain `<button>Save</button>` as `{"role":"button"}` with no name, while `find role button --name "Save"` and `element.label` resolved the same name on the same page load. The tree's `getName` chain stopped at the `title` attribute with no text-content step, and it also returned `computedName` even when empty, which skipped every fallback.

The fix adds a text-content fallback restricted to the standard name-from-content roles (button, link, heading, option, menuitem, tab, cell, and the rest of the accname set), so the labels agents need survive while wrapper divs full of prose stay nameless. Empty `computedName` is now treated as not computed. The diagnosis and the role-restricted approach come from the issue report; the role list is the reporter's open question, so flag if you want it narrower or wider.

Verified:
- New test "names buttons, links and headings from their text content" fails on main (button has no name) and passes with the fix
- New test confirms plain divs stay nameless with `everything: true`
- Full a11y suite 19/19 on Chrome, `go test ./internal/api/` green
- The issue's CLI repro now returns all four names: Save, Close, Documentation, Search; aria-label still wins over text
